### PR TITLE
fix: Resolve next page navigation from index pages

### DIFF
--- a/docs/.vitepress/config/sidebar.config.ts
+++ b/docs/.vitepress/config/sidebar.config.ts
@@ -1811,7 +1811,7 @@ function createI18nSideBarConfig(t) {
                 "items": [
                     {
                         "text": t['sqldelight.overview'],
-                        "link": "index"
+                        "link": "index.md"
                     },
                     {
                         "text": t['sqldelight.upgrading-2.0'],


### PR DESCRIPTION
When on a page rendered from an `index.md` file, such as `/sqldelight/`, the 'Next Page' link in the footer failed to navigate to the next page defined in the sidebar. It would incorrectly reload the current index page instead.