### PR TITLE
[codex] Restore Kotlin language proposals docs

### DIFF
--- a/docs/ja/kotlin/kotlin-language-features-and-proposals.md
+++ b/docs/ja/kotlin/kotlin-language-features-and-proposals.md
@@ -1,4 +1,440 @@
-の扱いの改善**
+[//]: # (title: Kotlin 言語の機能と提案)
+
+<web-summary>Kotlin の機能のライフサイクルについて学びましょう。このページには、Kotlin 言語の機能と設計提案の全リストが含まれています。</web-summary>
+
+JetBrains は、実用的な設計に基づいた [Kotlin 言語進化の原則](kotlin-evolution-principles.md)に従って、Kotlin 言語を進化させています。
+
+> 言語機能の提案は Kotlin 1.7.0 以降のものがリストされています。
+>
+> 言語機能のステータスの説明については、
+> [Kotlin 進化の原則ドキュメント](kotlin-evolution-principles.md#pre-stable-features)を参照してください。
+>
+{style="note"}
+
+<tabs>
+<tab id="all-proposals" title="すべて">
+
+<!-- <include element-id="all-proposals" from="all-proposals.topic"/> -->
+
+<snippet id="source">
+<table style="header-column">
+
+<!-- the first td element should have the width="200" attribute -->
+
+<!-- EXPLORATION AND DESIGN BLOCK -->
+
+<tr filter="exploration-and-design">
+<td width="200">
+
+**検討および設計**
+
+</td>
+<td>
+
+**不変性のサポート (Support immutability)**
+
+* KEEP ノート: [immutability](https://github.com/Kotlin/KEEP/blob/master/notes/value-classes.md#immutability-and-value-classes)
+* YouTrack イシュー: [KT-77734](https://youtrack.jetbrains.com/issue/KT-77734)
+
+</td>
+</tr>
+
+<!-- END OF EXPLORATION AND DESIGN BLOCK -->
+
+<!-- KEEP DISCUSSION BLOCK -->
+
+<tr filter="keep">
+<td width="200">
+
+**KEEP の議論**
+
+</td>
+<td>
+
+**コンパイル時定数の改善**
+
+* KEEP 提案: [improve-compile-time-constants.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0444-improve-compile-time-constants.md)
+* YouTrack イシュー: [KT-22505](https://youtrack.jetbrains.com/issue/KT-22505)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP の議論**
+
+</td>
+<td>
+
+**コンテキストパラメータとしての `CoroutineContext`**
+
+* KEEP 提案: [CoroutineContext-context-parameter.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0443-suspend-CoroutineContext-context-parameter.md)
+* YouTrack イシュー: [KT-15555](https://youtrack.jetbrains.com/issue/KT-15555)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP の議論**
+
+</td>
+<td>
+
+**Rich Errors: 動機と根拠**
+
+* KEEP 提案: [rich-errors-motivation.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0441-rich-errors-motivation.md)
+* YouTrack イシュー: [KT-68296](https://youtrack.jetbrains.com/issue/KT-68296)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP の議論**
+
+</td>
+<td>
+
+**Kotlin の static および static 拡張**
+
+* KEEP 提案: [statics.md](https://github.com/Kotlin/KEEP/blob/static-scope/proposals/static-member-type-extension.md)
+* YouTrack イシュー: [KT-11968](https://youtrack.jetbrains.com/issue/KT-11968)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP の議論**
+
+</td>
+<td>
+
+**コレクションリテラル (Collection literals)**
+
+* KEEP 提案: [collection-literals.md](https://github.com/Kotlin/KEEP/blob/bobko/collection-literals/proposals/collection-literals.md)
+* YouTrack イシュー: [KT-43871](https://youtrack.jetbrains.com/issue/KT-43871)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP の議論**
+
+</td>
+<td>
+
+**バージョンオーバーロード (Version overloading)**
+
+* KEEP 提案: [version-overloading.md](https://github.com/Kotlin/KEEP/blob/version-overloading-proposal/proposals/version-overloading.md)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP の議論**
+
+</td>
+<td>
+
+**KDoc の曖昧なリンクの合理化**
+
+* KEEP 提案: [streamline-KDoc-ambiguity-references.md](https://github.com/Kotlin/KEEP/blob/kdoc/Streamline-KDoc-ambiguity-references/proposals/kdoc/streamline-KDoc-ambiguity-references.md)
+* GitHub イシュー: [dokka/#3451](https://github.com/Kotlin/dokka/issues/3451), [dokka/#3179](https://github.com/Kotlin/dokka/issues/3179), [dokka/#3334](https://github.com/Kotlin/dokka/issues/3334)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP の議論**
+
+</td>
+<td>
+
+**KDoc における拡張へのリンクの解決**
+
+* KEEP 提案: [links-to-extensions.md](https://github.com/Kotlin/KEEP/blob/kdoc/extension-links/proposals/kdoc/links-to-extensions.md)
+* GitHub イシュー: [dokka/#3555](https://github.com/Kotlin/dokka/issues/3555)
+
+</td>
+</tr>
+
+<!-- END OF KEEP DISCUSSION BLOCK -->
+
+<!-- IN PREVIEW BLOCK -->
+
+<tr filter="in-preview">
+<td width="200">
+
+**プレビュー中**
+
+</td>
+<td>
+
+**名前ベースの分割代入 (Name-based destructuring)**
+
+* KEEP 提案: [name-based-destructuring.md](https://github.com/Kotlin/KEEP/blob/name-based-destructuring/proposals/name-based-destructuring.md)
+* YouTrack イシュー: [KT-19627](https://youtrack.jetbrains.com/issue/KT-19627)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.3.20
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td width="200">
+
+**プレビュー中**
+
+</td>
+<td>
+
+**明示的なバッキングフィールド (Explicit backing fields)**
+
+* KEEP 提案: [explicit-backing-fields.md](https://github.com/Kotlin/KEEP/blob/explicit-backing-fields/proposals/explicit-backing-fields.md)
+* YouTrack イシュー: [KT-14663](https://youtrack.jetbrains.com/issue/KT-14663)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
+**コンテキストパラメータ: コンテキストに依存した宣言のサポート**
+
+* KEEP 提案: [context-parameters.md](https://github.com/Kotlin/KEEP/blob/context-parameters/proposals/context-parameters.md)
+* YouTrack イシュー: [KT-10468](https://youtrack.jetbrains.com/issue/KT-10468)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
+**未使用の戻り値チェッカー (Unused return value checker)**
+
+* KEEP 提案: [unused-return-value-checker.md](https://github.com/Kotlin/KEEP/blob/underscore-for-unused-local/proposals/unused-return-value-checker.md)
+* YouTrack イシュー: [KT-12719](https://youtrack.jetbrains.com/issue/KT-12719)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
+**プロパティにおけるアノテーションの使用場所ターゲット (use-site targets) の改善**
+
+* KEEP 提案: [Improvements to annotation use-site targets on properties](https://github.com/Kotlin/KEEP/blob/master/proposals/annotation-target-in-properties.md)
+* YouTrack イシュー: [KT-73255](https://youtrack.jetbrains.com/issue/KT-73255)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
+**コンテキストに依存した解決 (Context-sensitive resolution)**
+
+* KEEP 提案: [context-sensitive-resolution.md](https://github.com/Kotlin/KEEP/blob/improved-resolution-expected-type/proposals/context-sensitive-resolution.md)
+* YouTrack イシュー: [KT-16768](https://youtrack.jetbrains.com/issue/KT-16768)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
+**JVM でのボックス化されたインライン値クラスの公開**
+
+* KEEP 提案: [jvm-expose-boxed.md](https://github.com/Kotlin/KEEP/blob/jvm-expose-boxed/proposals/jvm-expose-boxed.md)
+* YouTrack イシュー: [KT-28135](https://youtrack.jetbrains.com/issue/KT-28135)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
+**Uuid**
+
+* KEEP 提案: [uuid.md](https://github.com/Kotlin/KEEP/blob/uuid/proposals/stdlib/uuid.md)
+* YouTrack イシュー: [KT-31880](https://youtrack.jetbrains.com/issue/KT-31880)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.0.20
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
+**共通の Atomic および Atomic 配列 (Common Atomics and Atomic Arrays)**
+
+* KEEP 提案: [Common atomics](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/common-atomics.md)
+* YouTrack イシュー: [KT-62423](https://youtrack.jetbrains.com/issue/KT-62423)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
+**KMP Kotlin から Java への直接的な actual 実装 (direct actualization)**
+
+* KEEP 提案: [kmp-kotlin-to-java-direct-actualization.md](https://github.com/Kotlin/KEEP/blob/kotlin-to-java-direct-actualization/proposals/kmp-kotlin-to-java-direct-actualization.md)
+* YouTrack イシュー: [KT-67202](https://youtrack.jetbrains.com/issue/KT-67202)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.1.0
+
+</td>
+</tr>
+
+<!-- END OF IN PREVIEW BLOCK -->
+
+<!-- STABLE BLOCK -->
+
+<tr filter="stable">
+<td width="200">
+
+**安定版**
+
+</td>
+<td>
+
+**データフローに基づく網羅性チェック (Data flow-based exhaustiveness checking)**
+
+* KEEP 提案: [dfa-exhaustiveness.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0442-dfa-exhaustiveness.md)
+* YouTrack イシュー: [KT-8781](https://youtrack.jetbrains.com/issue/KT-8781)
+* 利用可能バージョン: 2.2.20, 2.3.0 以降で安定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**安定版**
+
+</td>
+<td>
+
+**ネストされた（キャプチャしない）型エイリアス**
+
+* KEEP 提案: [Nested (non-capturing) type aliases](https://github.com/Kotlin/KEEP/blob/master/proposals/nested-typealias.md)
+* YouTrack イシュー: [KT-45285](https://youtrack.jetbrains.com/issue/KT-45285)
+* 利用可能バージョン: 2.2.0, 2.3.0 以降で安定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**安定版**
+
+</td>
+<td>
+
+**kotlin.time.Instant**
+
+* KEEP 提案: [Instant and Clock](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/instant.md)
+* YouTrack イシュー: [KT-80778](https://youtrack.jetbrains.com/issue/KT-80778)
+* 利用可能バージョン: 2.1.0, 2.3.0 以降で安定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**安定版**
+
+</td>
+<td>
+
+**引数付き when におけるガード条件 (Guard conditions in when-with-subject)**
+
+* KEEP 提案: [guards.md](https://github.com/Kotlin/KEEP/blob/guards/proposals/guards.md)
+* YouTrack イシュー: [KT-13626](https://youtrack.jetbrains.com/issue/KT-13626)
+* 利用可能バージョン: 2.2.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**安定版**
+
+</td>
+<td>
+
+**マルチダラー補間: 文字列リテラル内での `$` の扱いの改善**
 
 * KEEP 提案: [dollar-escape.md](https://github.com/Kotlin/KEEP/blob/master/proposals/dollar-escape.md)
 * YouTrack イシュー: [KT-2425](https://youtrack.jetbrains.com/issue/KT-2425)
@@ -108,13 +544,11 @@
 
 </td>
 </tr>
-</table>
 
-</tab>
+<!-- END OF STABLE BLOCK -->
 
-<tab id="revoked" title="取り消し済み">
+<!-- REVOKED BLOCK -->
 
-<table>
 <tr filter="revoked">
 <td width="200">
 
@@ -147,7 +581,11 @@
 
 </td>
 </tr>
+
 </table>
+</snippet>
+
+<!-- END OF REVOKED BLOCK -->
 
 </tab>
 
@@ -178,6 +616,22 @@
 <table>
 <tr filter="keep">
 <td width="200">
+
+**KEEP の議論**
+
+</td>
+<td>
+
+**コンパイル時定数の改善**
+
+* KEEP 提案: [improve-compile-time-constants.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0444-improve-compile-time-constants.md)
+* YouTrack イシュー: [KT-22505](https://youtrack.jetbrains.com/issue/KT-22505)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
 
 **KEEP の議論**
 
@@ -220,6 +674,22 @@
 
 * KEEP 提案: [statics.md](https://github.com/Kotlin/KEEP/blob/static-scope/proposals/static-member-type-extension.md)
 * YouTrack イシュー: [KT-11968](https://youtrack.jetbrains.com/issue/KT-11968)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP の議論**
+
+</td>
+<td>
+
+**コレクションリテラル (Collection literals)**
+
+* KEEP 提案: [collection-literals.md](https://github.com/Kotlin/KEEP/blob/bobko/collection-literals/proposals/collection-literals.md)
+* YouTrack イシュー: [KT-43871](https://youtrack.jetbrains.com/issue/KT-43871)
 
 </td>
 </tr>
@@ -285,48 +755,48 @@
 </td>
 <td>
 
-**コレクションリテラル (Collection literals)**
-
-* KEEP 提案: [collection-literals.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0416-collection-literals.md)
-* YouTrack イシュー: [KT-43871](https://youtrack.jetbrains.com/issue/KT-43871)
-* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
-* 利用可能バージョン: 2.4.0
-
-</td>
-</tr>
-
-<tr filter="in-preview">
-<td width="200">
-
-**プレビュー中**
-
-</td>
-<td>
-
-**コンパイル時定数の改善**
-
-* KEEP 提案: [improve-compile-time-constants.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0444-improve-compile-time-constants.md)
-* YouTrack イシュー: [KT-22505](https://youtrack.jetbrains.com/issue/KT-22505)
-* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
-* 利用可能バージョン: 2.4.0
-
-</td>
-</tr>
-
-<tr filter="in-preview">
-<td width="200">
-
-**プレビュー中**
-
-</td>
-<td>
-
 **名前ベースの分割代入 (Name-based destructuring)**
 
 * KEEP 提案: [name-based-destructuring.md](https://github.com/Kotlin/KEEP/blob/name-based-destructuring/proposals/name-based-destructuring.md)
 * YouTrack イシュー: [KT-19627](https://youtrack.jetbrains.com/issue/KT-19627)
 * 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
 * 利用可能バージョン: 2.3.20
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td width="200">
+
+**プレビュー中**
+
+</td>
+<td>
+
+**明示的なバッキングフィールド (Explicit backing fields)**
+
+* KEEP 提案: [explicit-backing-fields.md](https://github.com/Kotlin/KEEP/blob/explicit-backing-fields/proposals/explicit-backing-fields.md)
+* YouTrack イシュー: [KT-14663](https://youtrack.jetbrains.com/issue/KT-14663)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
+**コンテキストパラメータ: コンテキストに依存した宣言のサポート**
+
+* KEEP 提案: [context-parameters.md](https://github.com/Kotlin/KEEP/blob/context-parameters/proposals/context-parameters.md)
+* YouTrack イシュー: [KT-10468](https://youtrack.jetbrains.com/issue/KT-10468)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.2.0
 
 </td>
 </tr>
@@ -345,6 +815,24 @@
 * YouTrack イシュー: [KT-12719](https://youtrack.jetbrains.com/issue/KT-12719)
 * 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
 * 利用可能バージョン: 2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
+**プロパティにおけるアノテーションの使用場所ターゲット (use-site targets) の改善**
+
+* KEEP 提案: [Improvements to annotation use-site targets on properties](https://github.com/Kotlin/KEEP/blob/master/proposals/annotation-target-in-properties.md)
+* YouTrack イシュー: [KT-73255](https://youtrack.jetbrains.com/issue/KT-73255)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.2.0
 
 </td>
 </tr>
@@ -393,9 +881,27 @@
 </td>
 <td>
 
+**Uuid**
+
+* KEEP 提案: [uuid.md](https://github.com/Kotlin/KEEP/blob/uuid/proposals/stdlib/uuid.md)
+* YouTrack イシュー: [KT-31880](https://youtrack.jetbrains.com/issue/KT-31880)
+* 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
+* 利用可能バージョン: 2.0.20
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**プレビュー中**
+
+</td>
+<td>
+
 **共通の Atomic および Atomic 配列 (Common Atomics and Atomic Arrays)**
 
-* KEEP 提案: [Common atomics](https://github.com/Kotlin/KEEP/blob/main/proposals/stdlib/KEEP-0398-common-atomics.md)
+* KEEP 提案: [Common atomics](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/common-atomics.md)
 * YouTrack イシュー: [KT-62423](https://youtrack.jetbrains.com/issue/KT-62423)
 * 安定性レベル: [試験的 (Experimental)](components-stability.md#stability-levels-explained)
 * 利用可能バージョン: 2.2.0
@@ -427,74 +933,6 @@
 <tab id="stable" title="安定版">
 
 <table>
-<tr filter="stable">
-<td width="200">
-
-**安定版**
-
-</td>
-<td>
-
-**コンテキストパラメータ: コンテキストに依存した宣言のサポート**
-
-* KEEP 提案: [context-parameters.md](https://github.com/Kotlin/KEEP/blob/context-parameters/proposals/context-parameters.md)
-* YouTrack イシュー: [KT-10468](https://youtrack.jetbrains.com/issue/KT-10468)
-* 利用可能バージョン: 2.2.0, 2.4.0 以降で安定
-
-</td>
-</tr>
-
-<tr filter="stable">
-<td>
-
-**安定版**
-
-</td>
-<td>
-
-**プロパティにおけるアノテーションの使用場所ターゲット (use-site targets) の改善**
-
-* KEEP 提案: [Improvements to annotation use-site targets on properties](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0402-annotation-target-in-properties.md)
-* YouTrack イシュー: [KT-73255](https://youtrack.jetbrains.com/issue/KT-73255)
-* 利用可能バージョン: 2.2.0, 2.4.0 以降で安定
-
-</td>
-</tr>
-
-<tr filter="stable">
-<td width="200">
-
-**安定版**
-
-</td>
-<td>
-
-**明示的なバッキングフィールド (Explicit backing fields)**
-
-* KEEP 提案: [explicit-backing-fields.md](https://github.com/Kotlin/KEEP/blob/explicit-backing-fields/proposals/explicit-backing-fields.md)
-* YouTrack イシュー: [KT-14663](https://youtrack.jetbrains.com/issue/KT-14663)
-* 利用可能バージョン: 2.3.0, 2.4.0 以降で安定
-
-</td>
-</tr>
-
-<tr filter="stable">
-<td>
-
-**安定版**
-
-</td>
-<td>
-
-**Uuid**
-
-* KEEP 提案: [uuid.md](https://github.com/Kotlin/KEEP/blob/uuid/proposals/stdlib/uuid.md)
-* YouTrack イシュー: [KT-31880](https://youtrack.jetbrains.com/issue/KT-31880)
-* 利用可能バージョン: 2.0.20, 2.4.0 以降で安定
-
-</td>
-</tr>
-
 <tr filter="stable">
 <td width="200">
 
@@ -571,7 +1009,7 @@
 </td>
 <td>
 
-**マルチダラー補間: 文字列リテラル内での $ の扱いの改善**
+**マルチダラー補間: 文字列リテラル内での `$` の扱いの改善**
 
 * KEEP 提案: [dollar-escape.md](https://github.com/Kotlin/KEEP/blob/master/proposals/dollar-escape.md)
 * YouTrack イシュー: [KT-2425](https://youtrack.jetbrains.com/issue/KT-2425)

--- a/docs/kotlin/kotlin-language-features-and-proposals.md
+++ b/docs/kotlin/kotlin-language-features-and-proposals.md
@@ -1,4 +1,437 @@
-中 $ 的处理**
+[//]: # (title: Kotlin 语言功能与提案)
+
+<web-summary>了解 Kotlin 功能的生命周期。本页包含 Kotlin 语言功能和设计提案的完整列表。</web-summary>
+
+JetBrains 根据 [Kotlin 语言演进原则](kotlin-evolution-principles.md)，在务实设计的指导下演进 Kotlin 语言。
+
+> 语言功能提案自 Kotlin 1.7.0 起列出。
+>
+> 参阅 [Kotlin 演进原则文档](kotlin-evolution-principles.md#pre-stable-features)中关于语言功能状态的说明。
+>
+{style="note"}
+
+<tabs>
+<tab id="all-proposals" title="全部">
+
+<!-- <include element-id="all-proposals" from="all-proposals.topic"/> -->
+
+<snippet id="source">
+<table style="header-column">
+
+<!-- the first td element should have the width="200" attribute -->
+
+<!-- EXPLORATION AND DESIGN BLOCK -->
+
+<tr filter="exploration-and-design">
+<td width="200">
+
+**探索与设计**
+
+</td>
+<td>
+
+**基于名称的析构**
+
+* KEEP 提案：[name-based-destructuring.md](https://github.com/Kotlin/KEEP/blob/name-based-destructuring/proposals/name-based-destructuring.md)
+* YouTrack 问题：[KT-19627](https://youtrack.jetbrains.com/issue/KT-19627)
+
+</td>
+</tr>
+
+<tr filter="exploration-and-design">
+<td>
+
+**探索与设计**
+
+</td>
+<td>
+
+**支持不可变性**
+
+* KEEP 笔记：[immutability](https://github.com/Kotlin/KEEP/blob/master/notes/value-classes.md#immutability-and-value-classes)
+* YouTrack 问题：[KT-77734](https://youtrack.jetbrains.com/issue/KT-77734)
+
+</td>
+</tr>
+
+<!-- END OF EXPLORATION AND DESIGN BLOCK -->
+
+<!-- KEEP DISCUSSION BLOCK -->
+
+<tr filter="keep">
+<td width="200">
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**改进编译时常量**
+
+* KEEP 提案：[improve-compile-time-constants.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0444-improve-compile-time-constants.md)
+* YouTrack 问题：[KT-22505](https://youtrack.jetbrains.com/issue/KT-22505)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**`CoroutineContext` 作为上下文参数**
+
+* KEEP 提案：[CoroutineContext-context-parameter.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0443-suspend-CoroutineContext-context-parameter.md)
+* YouTrack 问题：[KT-15555](https://youtrack.jetbrains.com/issue/KT-15555)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**富错误 (Rich Errors)：动机与原理**
+
+* KEEP 提案：[rich-errors-motivation.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0441-rich-errors-motivation.md)
+* YouTrack 问题：[KT-68296](https://youtrack.jetbrains.com/issue/KT-68296)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**Kotlin 静态成员与静态扩展**
+
+* KEEP 提案：[statics.md](https://github.com/Kotlin/KEEP/blob/static-scope/proposals/static-member-type-extension.md)
+* YouTrack 问题：[KT-11968](https://youtrack.jetbrains.com/issue/KT-11968)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**集合字面量**
+
+* KEEP 提案：[collection-literals.md](https://github.com/Kotlin/KEEP/blob/bobko/collection-literals/proposals/collection-literals.md)
+* YouTrack 问题：[KT-43871](https://youtrack.jetbrains.com/issue/KT-43871)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**版本重载**
+
+* KEEP 提案：[version-overloading.md](https://github.com/Kotlin/KEEP/blob/version-overloading-proposal/proposals/version-overloading.md)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**精简 KDoc 歧义链接**
+
+* KEEP 提案：[streamline-KDoc-ambiguity-references.md](https://github.com/Kotlin/KEEP/blob/kdoc/Streamline-KDoc-ambiguity-references/proposals/kdoc/streamline-KDoc-ambiguity-references.md)
+* GitHub 问题：[dokka/#3451](https://github.com/Kotlin/dokka/issues/3451), [dokka/#3179](https://github.com/Kotlin/dokka/issues/3179), [dokka/#3334](https://github.com/Kotlin/dokka/issues/3334)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**KDoc 中扩展链接的解析**
+
+* KEEP 提案：[links-to-extensions.md](https://github.com/Kotlin/KEEP/blob/kdoc/extension-links/proposals/kdoc/links-to-extensions.md)
+* GitHub 问题：[dokka/#3555](https://github.com/Kotlin/dokka/issues/3555)
+
+</td>
+</tr>
+
+<!-- END OF KEEP DISCUSSION BLOCK -->
+
+<!-- IN PREVIEW BLOCK -->
+
+<tr filter="in-preview">
+<td width="200">
+
+**预览中**
+
+</td>
+<td>
+
+**显式支持字段**
+
+* KEEP 提案：[explicit-backing-fields.md](https://github.com/Kotlin/KEEP/blob/explicit-backing-fields/proposals/explicit-backing-fields.md)
+* YouTrack 问题：[KT-14663](https://youtrack.jetbrains.com/issue/KT-14663)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**上下文参数：支持上下文相关的声明**
+
+* KEEP 提案：[context-parameters.md](https://github.com/Kotlin/KEEP/blob/context-parameters/proposals/context-parameters.md)
+* YouTrack 问题：[KT-10468](https://youtrack.jetbrains.com/issue/KT-10468)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**未使用返回值检查器**
+
+* KEEP 提案：[unused-return-value-checker.md](https://github.com/Kotlin/KEEP/blob/underscore-for-unused-local/proposals/unused-return-value-checker.md)
+* YouTrack 问题：[KT-12719](https://youtrack.jetbrains.com/issue/KT-12719)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**属性上注解使用处目标的改进**
+
+* KEEP 提案：[Improvements to annotation use-site targets on properties](https://github.com/Kotlin/KEEP/blob/master/proposals/annotation-target-in-properties.md)
+* YouTrack 问题：[KT-73255](https://youtrack.jetbrains.com/issue/KT-73255)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**上下文相关解析**
+
+* KEEP 提案：[context-sensitive-resolution.md](https://github.com/Kotlin/KEEP/blob/improved-resolution-expected-type/proposals/context-sensitive-resolution.md)
+* YouTrack 问题：[KT-16768](https://youtrack.jetbrains.com/issue/KT-16768)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**在 JVM 中公开装箱的内联值类**
+
+* KEEP 提案：[jvm-expose-boxed.md](https://github.com/Kotlin/KEEP/blob/jvm-expose-boxed/proposals/jvm-expose-boxed.md)
+* YouTrack 问题：[KT-28135](https://youtrack.jetbrains.com/issue/KT-28135)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**Uuid**
+
+* KEEP 提案：[uuid.md](https://github.com/Kotlin/KEEP/blob/uuid/proposals/stdlib/uuid.md)
+* YouTrack 问题：[KT-31880](https://youtrack.jetbrains.com/issue/KT-31880)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.0.20
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**通用原子类与原子数组**
+
+* KEEP 提案：[Common atomics](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/common-atomics.md)
+* YouTrack 问题：[KT-62423](https://youtrack.jetbrains.com/issue/KT-62423)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**KMP Kotlin 到 Java 直接实际化**
+
+* KEEP 提案：[kmp-kotlin-to-java-direct-actualization.md](https://github.com/Kotlin/KEEP/blob/kotlin-to-java-direct-actualization/proposals/kmp-kotlin-to-java-direct-actualization.md)
+* YouTrack 问题：[KT-67202](https://youtrack.jetbrains.com/issue/KT-67202)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.1.0
+
+</td>
+</tr>
+
+<!-- END OF IN PREVIEW BLOCK -->
+
+<!-- STABLE BLOCK -->
+
+<tr filter="stable">
+<td width="200">
+
+**稳定版**
+
+</td>
+<td>
+
+**基于数据流的穷举性检查**
+
+* KEEP 提案：[dfa-exhaustiveness.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0442-dfa-exhaustiveness.md)
+* YouTrack 问题：[KT-8781](https://youtrack.jetbrains.com/issue/KT-8781)
+* 自 2.2.20 起可用，自 2.3.0 起稳定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**嵌套（非捕获）类型别名**
+
+* KEEP 提案：[Nested (non-capturing) type aliases](https://github.com/Kotlin/KEEP/blob/master/proposals/nested-typealias.md)
+* YouTrack 问题：[KT-45285](https://youtrack.jetbrains.com/issue/KT-45285)
+* 自 2.2.0 起可用，自 2.3.0 起稳定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**kotlin.time.Instant**
+
+* KEEP 提案：[Instant and Clock](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/instant.md)
+* YouTrack 问题：[KT-80778](https://youtrack.jetbrains.com/issue/KT-80778)
+* 自 2.1.0 起可用，自 2.3.0 起稳定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**带主语 when 中的守护条件**
+
+* KEEP 提案：[guards.md](https://github.com/Kotlin/KEEP/blob/guards/proposals/guards.md)
+* YouTrack 问题：[KT-13626](https://youtrack.jetbrains.com/issue/KT-13626)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**多美元插值：改进字符串文字中 $ 的处理**
 
 * KEEP 提案：[dollar-escape.md](https://github.com/Kotlin/KEEP/blob/master/proposals/dollar-escape.md)
 * YouTrack 问题：[KT-2425](https://youtrack.jetbrains.com/issue/KT-2425)
@@ -150,6 +583,538 @@
 </snippet>
 
 <!-- END OF REVOKED BLOCK -->
+
+</tab>
+
+<tab id="exploration-and-design" title="探索与设计">
+
+<table>
+<tr filter="exploration-and-design">
+<td width="200">
+
+**探索与设计**
+
+</td>
+<td>
+
+**基于名称的析构**
+
+* KEEP 提案：[name-based-destructuring.md](https://github.com/Kotlin/KEEP/blob/name-based-destructuring/proposals/name-based-destructuring.md)
+* YouTrack 问题：[KT-19627](https://youtrack.jetbrains.com/issue/KT-19627)
+
+</td>
+</tr>
+
+<tr filter="exploration-and-design">
+<td>
+
+**探索与设计**
+
+</td>
+<td>
+
+**支持不可变性**
+
+* KEEP 笔记：[immutability](https://github.com/Kotlin/KEEP/blob/master/notes/value-classes.md#immutability-and-value-classes)
+* YouTrack 问题：[KT-77734](https://youtrack.jetbrains.com/issue/KT-77734)
+
+</td>
+</tr>
+</table>
+
+</tab>
+
+<tab id="keep-preparation" title="KEEP 讨论">
+
+<table>
+<tr filter="keep">
+<td width="200">
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**改进编译时常量**
+
+* KEEP 提案：[improve-compile-time-constants.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0444-improve-compile-time-constants.md)
+* YouTrack 问题：[KT-22505](https://youtrack.jetbrains.com/issue/KT-22505)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**`CoroutineContext` 作为上下文参数**
+
+* KEEP 提案：[CoroutineContext-context-parameter.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0443-suspend-CoroutineContext-context-parameter.md)
+* YouTrack 问题：[KT-15555](https://youtrack.jetbrains.com/issue/KT-15555)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**富错误 (Rich Errors)：动机与原理**
+
+* KEEP 提案：[rich-errors-motivation.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0441-rich-errors-motivation.md)
+* YouTrack 问题：[KT-68296](https://youtrack.jetbrains.com/issue/KT-68296)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**Kotlin 静态成员与静态扩展**
+
+* KEEP 提案：[statics.md](https://github.com/Kotlin/KEEP/blob/static-scope/proposals/static-member-type-extension.md)
+* YouTrack 问题：[KT-11968](https://youtrack.jetbrains.com/issue/KT-11968)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**集合字面量**
+
+* KEEP 提案：[collection-literals.md](https://github.com/Kotlin/KEEP/blob/bobko/collection-literals/proposals/collection-literals.md)
+* YouTrack 问题：[KT-43871](https://youtrack.jetbrains.com/issue/KT-43871)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**版本重载**
+
+* KEEP 提案：[version-overloading.md](https://github.com/Kotlin/KEEP/blob/version-overloading-proposal/proposals/version-overloading.md)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**精简 KDoc 歧义链接**
+
+* KEEP 提案：[streamline-KDoc-ambiguity-references.md](https://github.com/Kotlin/KEEP/blob/kdoc/Streamline-KDoc-ambiguity-references/proposals/kdoc/streamline-KDoc-ambiguity-references.md)
+* GitHub 问题：[dokka/#3451](https://github.com/Kotlin/dokka/issues/3451), [dokka/#3179](https://github.com/Kotlin/dokka/issues/3179), [dokka/#3334](https://github.com/Kotlin/dokka/issues/3334)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 讨论**
+
+</td>
+<td>
+
+**KDoc 中扩展链接的解析**
+
+* KEEP 提案：[links-to-extensions.md](https://github.com/Kotlin/KEEP/blob/kdoc/extension-links/proposals/kdoc/links-to-extensions.md)
+* GitHub 问题：[dokka/#3555](https://github.com/Kotlin/dokka/issues/3555)
+
+</td>
+</tr>
+</table>
+
+</tab>
+
+<tab id="in-preview" title="预览中">
+
+<table>
+<tr filter="in-preview">
+<td width="200">
+
+**预览中**
+
+</td>
+<td>
+
+**显式支持字段**
+
+* KEEP 提案：[explicit-backing-fields.md](https://github.com/Kotlin/KEEP/blob/explicit-backing-fields/proposals/explicit-backing-fields.md)
+* YouTrack 问题：[KT-14663](https://youtrack.jetbrains.com/issue/KT-14663)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**上下文参数：支持上下文相关的声明**
+
+* KEEP 提案：[context-parameters.md](https://github.com/Kotlin/KEEP/blob/context-parameters/proposals/context-parameters.md)
+* YouTrack 问题：[KT-10468](https://youtrack.jetbrains.com/issue/KT-10468)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**未使用返回值检查器**
+
+* KEEP 提案：[unused-return-value-checker.md](https://github.com/Kotlin/KEEP/blob/underscore-for-unused-local/proposals/unused-return-value-checker.md)
+* YouTrack 问题：[KT-12719](https://youtrack.jetbrains.com/issue/KT-12719)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**属性上注解使用处目标的改进**
+
+* KEEP 提案：[Improvements to annotation use-site targets on properties](https://github.com/Kotlin/KEEP/blob/master/proposals/annotation-target-in-properties.md)
+* YouTrack 问题：[KT-73255](https://youtrack.jetbrains.com/issue/KT-73255)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**上下文相关解析**
+
+* KEEP 提案：[context-sensitive-resolution.md](https://github.com/Kotlin/KEEP/blob/improved-resolution-expected-type/proposals/context-sensitive-resolution.md)
+* YouTrack 问题：[KT-16768](https://youtrack.jetbrains.com/issue/KT-16768)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**在 JVM 中公开装箱的内联值类**
+
+* KEEP 提案：[jvm-expose-boxed.md](https://github.com/Kotlin/KEEP/blob/jvm-expose-boxed/proposals/jvm-expose-boxed.md)
+* YouTrack 问题：[KT-28135](https://youtrack.jetbrains.com/issue/KT-28135)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**Uuid**
+
+* KEEP 提案：[uuid.md](https://github.com/Kotlin/KEEP/blob/uuid/proposals/stdlib/uuid.md)
+* YouTrack 问题：[KT-31880](https://youtrack.jetbrains.com/issue/KT-31880)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.0.20
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**通用原子类与原子数组**
+
+* KEEP 提案：[Common atomics](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/common-atomics.md)
+* YouTrack 问题：[KT-62423](https://youtrack.jetbrains.com/issue/KT-62423)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**预览中**
+
+</td>
+<td>
+
+**KMP Kotlin 到 Java 直接实际化**
+
+* KEEP 提案：[kmp-kotlin-to-java-direct-actualization.md](https://github.com/Kotlin/KEEP/blob/kotlin-to-java-direct-actualization/proposals/kmp-kotlin-to-java-direct-actualization.md)
+* YouTrack 问题：[KT-67202](https://youtrack.jetbrains.com/issue/KT-67202)
+* 稳定性级别：[实验性](components-stability.md#stability-levels-explained)
+* 自以下版本起可用：2.1.0
+
+</td>
+</tr>
+</table>
+
+</tab>
+
+<tab id="stable" title="稳定版">
+
+<table>
+<tr filter="stable">
+<td width="200">
+
+**稳定版**
+
+</td>
+<td>
+
+**基于数据流的穷举性检查**
+
+* KEEP 提案：[dfa-exhaustiveness.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0442-dfa-exhaustiveness.md)
+* YouTrack 问题：[KT-8781](https://youtrack.jetbrains.com/issue/KT-8781)
+* 自 2.2.20 起可用，自 2.3.0 起稳定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**嵌套（非捕获）类型别名**
+
+* KEEP 提案：[Nested (non-capturing) type aliases](https://github.com/Kotlin/KEEP/blob/master/proposals/nested-typealias.md)
+* YouTrack 问题：[KT-45285](https://youtrack.jetbrains.com/issue/KT-45285)
+* 自 2.2.0 起可用，自 2.3.0 起稳定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**kotlin.time.Instant**
+
+* KEEP 提案：[Instant and Clock](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/instant.md)
+* YouTrack 问题：[KT-80778](https://youtrack.jetbrains.com/issue/KT-80778)
+* 自 2.1.0 起可用，自 2.3.0 起稳定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**带主语 when 中的守护条件**
+
+* KEEP 提案：[guards.md](https://github.com/Kotlin/KEEP/blob/guards/proposals/guards.md)
+* YouTrack 问题：[KT-13626](https://youtrack.jetbrains.com/issue/KT-13626)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**多美元插值：改进字符串文字中 $ 的处理**
+
+* KEEP 提案：[dollar-escape.md](https://github.com/Kotlin/KEEP/blob/master/proposals/dollar-escape.md)
+* YouTrack 问题：[KT-2425](https://youtrack.jetbrains.com/issue/KT-2425)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**非局部 `break` 与 `continue`**
+
+* KEEP 提案：[break-continue-in-inline-lambdas.md](https://github.com/Kotlin/KEEP/blob/master/proposals/break-continue-in-inline-lambdas.md)
+* YouTrack 问题：[KT-1436](https://youtrack.jetbrains.com/issue/KT-1436)
+* 自以下版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**稳定版 `@SubclassOptInRequired`**
+
+* KEEP 提案：[subclass-opt-in-required.md](https://github.com/Kotlin/KEEP/blob/master/proposals/subclass-opt-in-required.md)
+* YouTrack 问题：[KT-54617](https://youtrack.jetbrains.com/issue/KT-54617)
+* 自以下版本起可用：2.1.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td width="200">
+
+**稳定版**
+
+</td>
+<td>
+
+**`Enum.entries`：`Enum.values()` 的高性能替代方案**
+
+* KEEP 提案：[enum-entries.md](https://github.com/Kotlin/KEEP/blob/master/proposals/enum-entries.md)
+* YouTrack 问题：[KT-48872](https://youtrack.jetbrains.com/issue/KT-48872)
+* 自以下版本起可用：2.0.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**数据对象**
+
+* KEEP 提案：[data-objects.md](https://github.com/Kotlin/KEEP/blob/master/proposals/data-objects.md)
+* YouTrack 问题：[KT-4107](https://youtrack.jetbrains.com/issue/KT-4107)
+* 自以下版本起可用：1.9.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**RangeUntil 运算符 `..<`**
+
+* KEEP 提案：[open-ended-ranges.md](https://github.com/kotlin/KEEP/blob/open-ended-ranges/proposals/open-ended-ranges.md)
+* YouTrack 问题：[KT-15613](https://youtrack.jetbrains.com/issue/KT-15613)
+* 自以下版本起可用：1.7.20
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**稳定版**
+
+</td>
+<td>
+
+**绝对不可为空类型**
+
+* KEEP 提案：[definitely-non-nullable-types.md](https://github.com/Kotlin/KEEP/blob/master/proposals/definitely-non-nullable-types.md)
+* YouTrack 问题：[KT-26245](https://youtrack.jetbrains.com/issue/KT-26245)
+* 自以下版本起可用：1.7.0
+
+</td>
+</tr>
+</table>
 
 </tab>
 

--- a/docs/zh-Hant/kotlin/kotlin-language-features-and-proposals.md
+++ b/docs/zh-Hant/kotlin/kotlin-language-features-and-proposals.md
@@ -1,4 +1,1014 @@
-：改進字串常值中 $ 的處理**
+[//]: # (title: Kotlin 語言特性與提案)
+
+<web-summary>了解 Kotlin 特性的生命週期。此頁面包含 Kotlin 語言特性與設計提案的完整清單。</web-summary>
+
+JetBrains 根據 [Kotlin 語言演進原則](kotlin-evolution-principles.md)，以實務設計為導向來發展 Kotlin 語言。
+
+> 自 Kotlin 1.7.0 起列出語言特性提案。
+>
+> 請參閱 [Kotlin 演進原則文件](kotlin-evolution-principles.md#pre-stable-features) 中關於語言特性狀態的說明。
+>
+{style="note"}
+
+<tabs>
+<tab id="all-proposals" title="全部">
+
+<!-- <include element-id="all-proposals" from="all-proposals.topic"/> -->
+
+<snippet id="source">
+<table style="header-column">
+
+<!-- the first td element should have the width="200" attribute -->
+
+<!-- EXPLORATION AND DESIGN BLOCK -->
+
+<tr filter="exploration-and-design">
+<td width="200">
+
+**探索與設計**
+
+</td>
+<td>
+
+**支援不可變性 (Support immutability)**
+
+* KEEP 筆記：[immutability](https://github.com/Kotlin/KEEP/blob/master/notes/value-classes.md#immutability-and-value-classes)
+* YouTrack 問題：[KT-77734](https://youtrack.jetbrains.com/issue/KT-77734)
+
+</td>
+</tr>
+
+<!-- END OF EXPLORATION AND DESIGN BLOCK -->
+
+<!-- KEEP DISCUSSION BLOCK -->
+
+<tr filter="keep">
+<td width="200">
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**改進編譯期常數**
+
+* KEEP 提案：[improve-compile-time-constants.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0444-improve-compile-time-constants.md)
+* YouTrack 問題：[KT-22505](https://youtrack.jetbrains.com/issue/KT-22505)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**`CoroutineContext` 作為上下文參數**
+
+* KEEP 提案：[CoroutineContext-context-parameter.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0443-suspend-CoroutineContext-context-parameter.md)
+* YouTrack 問題：[KT-15555](https://youtrack.jetbrains.com/issue/KT-15555)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**豐富錯誤 (Rich Errors)：動機與原理**
+
+* KEEP 提案：[rich-errors-motivation.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0441-rich-errors-motivation.md)
+* YouTrack 問題：[KT-68296](https://youtrack.jetbrains.com/issue/KT-68296)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**Kotlin static 與 static 擴充**
+
+* KEEP 提案：[statics.md](https://github.com/Kotlin/KEEP/blob/static-scope/proposals/static-member-type-extension.md)
+* YouTrack 問題：[KT-11968](https://youtrack.jetbrains.com/issue/KT-11968)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**集合常值 (Collection literals)**
+
+* KEEP 提案：[collection-literals.md](https://github.com/Kotlin/KEEP/blob/bobko/collection-literals/proposals/collection-literals.md)
+* YouTrack 問題：[KT-43871](https://youtrack.jetbrains.com/issue/KT-43871)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**版本多載 (Version overloading)**
+
+* KEEP 提案：[version-overloading.md](https://github.com/Kotlin/KEEP/blob/version-overloading-proposal/proposals/version-overloading.md)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**精簡 KDoc 歧義連結**
+
+* KEEP 提案：[streamline-KDoc-ambiguity-references.md](https://github.com/Kotlin/KEEP/blob/kdoc/Streamline-KDoc-ambiguity-references/proposals/kdoc/streamline-KDoc-ambiguity-references.md)
+* GitHub 問題：[dokka/#3451](https://github.com/Kotlin/dokka/issues/3451), [dokka/#3179](https://github.com/Kotlin/dokka/issues/3179), [dokka/#3334](https://github.com/Kotlin/dokka/issues/3334)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**KDoc 中擴充連結的解析**
+
+* KEEP 提案：[links-to-extensions.md](https://github.com/Kotlin/KEEP/blob/kdoc/extension-links/proposals/kdoc/links-to-extensions.md)
+* GitHub 問題：[dokka/#3555](https://github.com/Kotlin/dokka/issues/3555)
+
+</td>
+</tr>
+
+<!-- END OF KEEP DISCUSSION BLOCK -->
+
+<!-- IN PREVIEW BLOCK -->
+
+<tr filter="in-preview">
+<td width="200">
+
+**預覽中**
+
+</td>
+<td>
+
+**基於名稱的解構 (Name-based destructuring)**
+
+* KEEP 提案：[name-based-destructuring.md](https://github.com/Kotlin/KEEP/blob/name-based-destructuring/proposals/name-based-destructuring.md)
+* YouTrack 問題：[KT-19627](https://youtrack.jetbrains.com/issue/KT-19627)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.3.20
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td width="200">
+
+**預覽中**
+
+</td>
+<td>
+
+**明確支援欄位 (Explicit backing fields)**
+
+* KEEP 提案：[explicit-backing-fields.md](https://github.com/Kotlin/KEEP/blob/explicit-backing-fields/proposals/explicit-backing-fields.md)
+* YouTrack 問題：[KT-14663](https://youtrack.jetbrains.com/issue/KT-14663)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**上下文參數 (Context parameters)：支援上下文相關宣告**
+
+* KEEP 提案：[context-parameters.md](https://github.com/Kotlin/KEEP/blob/context-parameters/proposals/context-parameters.md)
+* YouTrack 問題：[KT-10468](https://youtrack.jetbrains.com/issue/KT-10468)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**未使用的傳回值檢查器**
+
+* KEEP 提案：[unused-return-value-checker.md](https://github.com/Kotlin/KEEP/blob/underscore-for-unused-local/proposals/unused-return-value-checker.md)
+* YouTrack 問題：[KT-12719](https://youtrack.jetbrains.com/issue/KT-12719)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**屬性上註解使用處目標 (use-site targets) 的改進**
+
+* KEEP 提案：[Improvements to annotation use-site targets on properties](https://github.com/Kotlin/KEEP/blob/master/proposals/annotation-target-in-properties.md)
+* YouTrack 問題：[KT-73255](https://youtrack.jetbrains.com/issue/KT-73255)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**上下文相關解析 (Context-sensitive resolution)**
+
+* KEEP 提案：[context-sensitive-resolution.md](https://github.com/Kotlin/KEEP/blob/improved-resolution-expected-type/proposals/context-sensitive-resolution.md)
+* YouTrack 問題：[KT-16768](https://youtrack.jetbrains.com/issue/KT-16768)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**在 JVM 中公開裝箱的行內值類別**
+
+* KEEP 提案：[jvm-expose-boxed.md](https://github.com/Kotlin/KEEP/blob/jvm-expose-boxed/proposals/jvm-expose-boxed.md)
+* YouTrack 問題：[KT-28135](https://youtrack.jetbrains.com/issue/KT-28135)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**Uuid**
+
+* KEEP 提案：[uuid.md](https://github.com/Kotlin/KEEP/blob/uuid/proposals/stdlib/uuid.md)
+* YouTrack 問題：[KT-31880](https://youtrack.jetbrains.com/issue/KT-31880)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.0.20
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**通用不可分割量 (Common Atomics) 與不可分割陣列 (Atomic Arrays)**
+
+* KEEP 提案：[Common atomics](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/common-atomics.md)
+* YouTrack 問題：[KT-62423](https://youtrack.jetbrains.com/issue/KT-62423)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**KMP Kotlin-to-Java 直接實例化 (direct actualization)**
+
+* KEEP 提案：[kmp-kotlin-to-java-direct-actualization.md](https://github.com/Kotlin/KEEP/blob/kotlin-to-java-direct-actualization/proposals/kmp-kotlin-to-java-direct-actualization.md)
+* YouTrack 問題：[KT-67202](https://youtrack.jetbrains.com/issue/KT-67202)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.1.0
+
+</td>
+</tr>
+
+<!-- END OF IN PREVIEW BLOCK -->
+
+<!-- STABLE BLOCK -->
+
+<tr filter="stable">
+<td width="200">
+
+**穩定**
+
+</td>
+<td>
+
+**基於資料流的窮舉性檢查 (Data flow-based exhaustiveness checking)**
+
+* KEEP 提案：[dfa-exhaustiveness.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0442-dfa-exhaustiveness.md)
+* YouTrack 問題：[KT-8781](https://youtrack.jetbrains.com/issue/KT-8781)
+* 自該版本起可用：2.2.20，自 2.3.0 起穩定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**巢狀（非擷取）型別別名 (Nested (non-capturing) type aliases)**
+
+* KEEP 提案：[Nested (non-capturing) type aliases](https://github.com/Kotlin/KEEP/blob/master/proposals/nested-typealias.md)
+* YouTrack 問題：[KT-45285](https://youtrack.jetbrains.com/issue/KT-45285)
+* 自該版本起可用：2.2.0，自 2.3.0 起穩定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**kotlin.time.Instant**
+
+* KEEP 提案：[Instant and Clock](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/instant.md)
+* YouTrack 問題：[KT-80778](https://youtrack.jetbrains.com/issue/KT-80778)
+* 自該版本起可用：2.1.0，自 2.3.0 起穩定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**when-with-subject 中的防護條件 (Guard conditions)**
+
+* KEEP 提案：[guards.md](https://github.com/Kotlin/KEEP/blob/guards/proposals/guards.md)
+* YouTrack 問題：[KT-13626](https://youtrack.jetbrains.com/issue/KT-13626)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**多錢符號插值：改進字串常值中 $ 的處理**
+
+* KEEP 提案：[dollar-escape.md](https://github.com/Kotlin/KEEP/blob/master/proposals/dollar-escape.md)
+* YouTrack 問題：[KT-2425](https://youtrack.jetbrains.com/issue/KT-2425)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**非區域 (Non-local) `break` 與 `continue`**
+
+* KEEP 提案：[break-continue-in-inline-lambdas.md](https://github.com/Kotlin/KEEP/blob/master/proposals/break-continue-in-inline-lambdas.md)
+* YouTrack 問題：[KT-1436](https://youtrack.jetbrains.com/issue/KT-1436)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**穩定的 `@SubclassOptInRequired`**
+
+* KEEP 提案：[subclass-opt-in-required.md](https://github.com/Kotlin/KEEP/blob/master/proposals/subclass-opt-in-required.md)
+* YouTrack 問題：[KT-54617](https://youtrack.jetbrains.com/issue/KT-54617)
+* 自該版本起可用：2.1.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td width="200">
+
+**穩定**
+
+</td>
+<td>
+
+**`Enum.entries`：`Enum.values()` 的高效能替代方案**
+
+* KEEP 提案：[enum-entries.md](https://github.com/Kotlin/KEEP/blob/master/proposals/enum-entries.md)
+* YouTrack 問題：[KT-48872](https://youtrack.jetbrains.com/issue/KT-48872)
+* 自該版本起可用：2.0.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**資料物件 (Data objects)**
+
+* KEEP 提案：[data-objects.md](https://github.com/Kotlin/KEEP/blob/master/proposals/data-objects.md)
+* YouTrack 問題：[KT-4107](https://youtrack.jetbrains.com/issue/KT-4107)
+* 自該版本起可用：1.9.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**RangeUntil 運算子 `..<`**
+
+* KEEP 提案：[open-ended-ranges.md](https://github.com/kotlin/KEEP/blob/open-ended-ranges/proposals/open-ended-ranges.md)
+* YouTrack 問題：[KT-15613](https://youtrack.jetbrains.com/issue/KT-15613)
+* 自該版本起可用：1.7.20
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**絕對不可為 null 型別 (Definitely non-nullable types)**
+
+* KEEP 提案：[definitely-non-nullable-types.md](https://github.com/Kotlin/KEEP/blob/master/proposals/definitely-non-nullable-types.md)
+* YouTrack 問題：[KT-26245](https://youtrack.jetbrains.com/issue/KT-26245)
+* 自該版本起可用：1.7.0
+
+</td>
+</tr>
+
+<!-- END OF STABLE BLOCK -->
+
+<!-- REVOKED BLOCK -->
+
+<tr filter="revoked">
+<td width="200">
+
+**已撤銷**
+
+</td>
+<td>
+
+**上下文接收器 (Context receivers)**
+
+* KEEP 提案：[context-receivers.md](https://github.com/Kotlin/KEEP/blob/master/proposals/context-receivers.md)
+* YouTrack 問題：[KT-10468](https://youtrack.jetbrains.com/issue/KT-10468)
+* 替換為 [context-parameters.md](https://github.com/Kotlin/KEEP/blob/context-parameters/proposals/context-parameters.md)
+
+</td>
+</tr>
+
+<tr filter="revoked">
+<td>
+
+**已撤銷**
+
+</td>
+<td>
+
+**Java 合成屬性參照 (Java synthetic property references)**
+
+* KEEP 提案：[references-to-java-synthetic-properties.md](https://github.com/Kotlin/KEEP/blob/master/proposals/references-to-java-synthetic-properties.md)
+* YouTrack 問題：[KT-8575](https://youtrack.jetbrains.com/issue/KT-8575)
+
+</td>
+</tr>
+
+</table>
+</snippet>
+
+<!-- END OF REVOKED BLOCK -->
+
+</tab>
+
+<tab id="exploration-and-design" title="探索與設計">
+
+<table>
+<tr filter="exploration-and-design">
+<td width="200">
+
+**探索與設計**
+
+</td>
+<td>
+
+**支援不可變性 (Support immutability)**
+
+* KEEP 筆記：[immutability](https://github.com/Kotlin/KEEP/blob/master/notes/value-classes.md#immutability-and-value-classes)
+* YouTrack 問題：[KT-77734](https://youtrack.jetbrains.com/issue/KT-77734)
+
+</td>
+</tr>
+</table>
+
+</tab>
+
+<tab id="keep-preparation" title="KEEP 討論">
+
+<table>
+<tr filter="keep">
+<td width="200">
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**改進編譯期常數**
+
+* KEEP 提案：[improve-compile-time-constants.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0444-improve-compile-time-constants.md)
+* YouTrack 問題：[KT-22505](https://youtrack.jetbrains.com/issue/KT-22505)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**`CoroutineContext` 作為上下文參數**
+
+* KEEP 提案：[CoroutineContext-context-parameter.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0443-suspend-CoroutineContext-context-parameter.md)
+* YouTrack 問題：[KT-15555](https://youtrack.jetbrains.com/issue/KT-15555)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**豐富錯誤 (Rich Errors)：動機與原理**
+
+* KEEP 提案：[rich-errors-motivation.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0441-rich-errors-motivation.md)
+* YouTrack 問題：[KT-68296](https://youtrack.jetbrains.com/issue/KT-68296)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**Kotlin static 與 static 擴充**
+
+* KEEP 提案：[statics.md](https://github.com/Kotlin/KEEP/blob/static-scope/proposals/static-member-type-extension.md)
+* YouTrack 問題：[KT-11968](https://youtrack.jetbrains.com/issue/KT-11968)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**集合常值 (Collection literals)**
+
+* KEEP 提案：[collection-literals.md](https://github.com/Kotlin/KEEP/blob/bobko/collection-literals/proposals/collection-literals.md)
+* YouTrack 問題：[KT-43871](https://youtrack.jetbrains.com/issue/KT-43871)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**版本多載 (Version overloading)**
+
+* KEEP 提案：[version-overloading.md](https://github.com/Kotlin/KEEP/blob/version-overloading-proposal/proposals/version-overloading.md)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**精簡 KDoc 歧義連結**
+
+* KEEP 提案：[streamline-KDoc-ambiguity-references.md](https://github.com/Kotlin/KEEP/blob/kdoc/Streamline-KDoc-ambiguity-references/proposals/kdoc/streamline-KDoc-ambiguity-references.md)
+* GitHub 問題：[dokka/#3451](https://github.com/Kotlin/dokka/issues/3451), [dokka/#3179](https://github.com/Kotlin/dokka/issues/3179), [dokka/#3334](https://github.com/Kotlin/dokka/issues/3334)
+
+</td>
+</tr>
+
+<tr filter="keep">
+<td>
+
+**KEEP 討論**
+
+</td>
+<td>
+
+**KDoc 中擴充連結的解析**
+
+* KEEP 提案：[links-to-extensions.md](https://github.com/Kotlin/KEEP/blob/kdoc/extension-links/proposals/kdoc/links-to-extensions.md)
+* GitHub 問題：[dokka/#3555](https://github.com/Kotlin/dokka/issues/3555)
+
+</td>
+</tr>
+</table>
+
+</tab>
+
+<tab id="in-preview" title="預覽中">
+
+<table>
+<tr filter="in-preview">
+<td width="200">
+
+**預覽中**
+
+</td>
+<td>
+
+**基於名稱的解構 (Name-based destructuring)**
+
+* KEEP 提案：[name-based-destructuring.md](https://github.com/Kotlin/KEEP/blob/name-based-destructuring/proposals/name-based-destructuring.md)
+* YouTrack 問題：[KT-19627](https://youtrack.jetbrains.com/issue/KT-19627)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.3.20
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td width="200">
+
+**預覽中**
+
+</td>
+<td>
+
+**明確支援欄位 (Explicit backing fields)**
+
+* KEEP 提案：[explicit-backing-fields.md](https://github.com/Kotlin/KEEP/blob/explicit-backing-fields/proposals/explicit-backing-fields.md)
+* YouTrack 問題：[KT-14663](https://youtrack.jetbrains.com/issue/KT-14663)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**上下文參數 (Context parameters)：支援上下文相關宣告**
+
+* KEEP 提案：[context-parameters.md](https://github.com/Kotlin/KEEP/blob/context-parameters/proposals/context-parameters.md)
+* YouTrack 問題：[KT-10468](https://youtrack.jetbrains.com/issue/KT-10468)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**未使用的傳回值檢查器**
+
+* KEEP 提案：[unused-return-value-checker.md](https://github.com/Kotlin/KEEP/blob/underscore-for-unused-local/proposals/unused-return-value-checker.md)
+* YouTrack 問題：[KT-12719](https://youtrack.jetbrains.com/issue/KT-12719)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.3.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**屬性上註解使用處目標 (use-site targets) 的改進**
+
+* KEEP 提案：[Improvements to annotation use-site targets on properties](https://github.com/Kotlin/KEEP/blob/master/proposals/annotation-target-in-properties.md)
+* YouTrack 問題：[KT-73255](https://youtrack.jetbrains.com/issue/KT-73255)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**上下文相關解析 (Context-sensitive resolution)**
+
+* KEEP 提案：[context-sensitive-resolution.md](https://github.com/Kotlin/KEEP/blob/improved-resolution-expected-type/proposals/context-sensitive-resolution.md)
+* YouTrack 問題：[KT-16768](https://youtrack.jetbrains.com/issue/KT-16768)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**在 JVM 中公開裝箱的行內值類別**
+
+* KEEP 提案：[jvm-expose-boxed.md](https://github.com/Kotlin/KEEP/blob/jvm-expose-boxed/proposals/jvm-expose-boxed.md)
+* YouTrack 問題：[KT-28135](https://youtrack.jetbrains.com/issue/KT-28135)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**Uuid**
+
+* KEEP 提案：[uuid.md](https://github.com/Kotlin/KEEP/blob/uuid/proposals/stdlib/uuid.md)
+* YouTrack 問題：[KT-31880](https://youtrack.jetbrains.com/issue/KT-31880)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.0.20
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**通用不可分割量 (Common Atomics) 與不可分割陣列 (Atomic Arrays)**
+
+* KEEP 提案：[Common atomics](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/common-atomics.md)
+* YouTrack 問題：[KT-62423](https://youtrack.jetbrains.com/issue/KT-62423)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="in-preview">
+<td>
+
+**預覽中**
+
+</td>
+<td>
+
+**KMP Kotlin-to-Java 直接實例化 (direct actualization)**
+
+* KEEP 提案：[kmp-kotlin-to-java-direct-actualization.md](https://github.com/Kotlin/KEEP/blob/kotlin-to-java-direct-actualization/proposals/kmp-kotlin-to-java-direct-actualization.md)
+* YouTrack 問題：[KT-67202](https://youtrack.jetbrains.com/issue/KT-67202)
+* 穩定性級別：[實驗性](components-stability.md#stability-levels-explained)
+* 自該版本起可用：2.1.0
+
+</td>
+</tr>
+</table>
+
+</tab>
+
+<tab id="stable" title="穩定">
+
+<table>
+<tr filter="stable">
+<td width="200">
+
+**穩定**
+
+</td>
+<td>
+
+**基於資料流的窮舉性檢查 (Data flow-based exhaustiveness checking)**
+
+* KEEP 提案：[dfa-exhaustiveness.md](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0442-dfa-exhaustiveness.md)
+* YouTrack 問題：[KT-8781](https://youtrack.jetbrains.com/issue/KT-8781)
+* 自該版本起可用：2.2.20，自 2.3.0 起穩定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**巢狀（非擷取）型別別名 (Nested (non-capturing) type aliases)**
+
+* KEEP 提案：[Nested (non-capturing) type aliases](https://github.com/Kotlin/KEEP/blob/master/proposals/nested-typealias.md)
+* YouTrack 問題：[KT-45285](https://youtrack.jetbrains.com/issue/KT-45285)
+* 自該版本起可用：2.2.0，自 2.3.0 起穩定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**kotlin.time.Instant**
+
+* KEEP 提案：[Instant and Clock](https://github.com/Kotlin/KEEP/blob/master/proposals/stdlib/instant.md)
+* YouTrack 問題：[KT-80778](https://youtrack.jetbrains.com/issue/KT-80778)
+* 自該版本起可用：2.1.0，自 2.3.0 起穩定
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**when-with-subject 中的防護條件 (Guard conditions)**
+
+* KEEP 提案：[guards.md](https://github.com/Kotlin/KEEP/blob/guards/proposals/guards.md)
+* YouTrack 問題：[KT-13626](https://youtrack.jetbrains.com/issue/KT-13626)
+* 自該版本起可用：2.2.0
+
+</td>
+</tr>
+
+<tr filter="stable">
+<td>
+
+**穩定**
+
+</td>
+<td>
+
+**多錢符號插值：改進字串常值中 $ 的處理**
 
 * KEEP 提案：[dollar-escape.md](https://github.com/Kotlin/KEEP/blob/master/proposals/dollar-escape.md)
 * YouTrack 問題：[KT-2425](https://youtrack.jetbrains.com/issue/KT-2425)


### PR DESCRIPTION
## Summary
- Restore the truncated `kotlin-language-features-and-proposals.md` files for Simplified Chinese, Traditional Chinese, and Japanese.
- This fixes the Cloudflare Pages failure where Vite/Vue saw orphaned table/tab closing tags and reported `Invalid end tag`.

## Root Cause
The current `main` branch has truncated versions of these docs. The Simplified Chinese file starts in the middle of a table cell (`中 $ 的处理**`), so Kotlin CN content preparation copies that broken file into `sites/kotlin-cn/docs/language/`, and VitePress fails while compiling it as Vue.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run kotlin-cn:build`
- `pnpm docs:build`
- `git diff --check`

## Notes
Warnings about Shiki language fallback and chunk size still appear, but both builds complete successfully.