### PR TITLE
[codex] Update Kotlin CN homepage metadata

### DIFF
--- a/sites/kotlin-cn/.vitepress/config.mts
+++ b/sites/kotlin-cn/.vitepress/config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitepress'
 import { resolve, dirname, posix } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { readFileSync, existsSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
 import matter from 'gray-matter'
 
 import {
@@ -17,6 +18,7 @@ const sourceDocsRoot = resolve(repoRoot, 'docs')
 const sidebarRoot = resolve(sourceDocsRoot, '.vitepress/sidebar')
 const localePath = resolve(sourceDocsRoot, '.vitepress/locales/zh-Hans.json')
 const locale = JSON.parse(readFileSync(localePath, 'utf-8')) as Record<string, string>
+const kotlinVariablesPath = resolve(sourceDocsRoot, '.vitepress/variables/kotlin.v.list')
 const mkDiffGrammarPath = resolve(sourceDocsRoot, '.vitepress/plugins/shiki/shiki-mk-diff.json')
 const mkDiffGrammar = JSON.parse(readFileSync(mkDiffGrammarPath, 'utf-8'))
 
@@ -36,6 +38,10 @@ type CommunityDoc = {
   home: string
   sourceType: string
   sidebar: SidebarNode[]
+}
+
+type HomeMeta = {
+  updateText: string
 }
 
 const docsConfig = [
@@ -135,6 +141,79 @@ function getTitleFromMarkdown(rootDir: string, filePath: string): string | null 
   return markdownHeaderMatch?.[1] || null
 }
 
+function readWritersideVar(filePath: string, name: string): string | null {
+  if (!existsSync(filePath)) return null
+  const content = readFileSync(filePath, 'utf-8')
+  const match = content.match(new RegExp(`<var\\s+name="${name}"\\s+value="([^"]+)"`))
+  return match?.[1] || null
+}
+
+function buildHomeMeta(): HomeMeta {
+  const lastUpdated = readDocsUpdateDate() || new Date()
+  const nextUpdated = getNextScheduledDocsUpdate(lastUpdated)
+
+  return {
+    updateText: `本次更新时间：${formatGmtDate(lastUpdated)}；下次更新时间：${formatGmtDate(nextUpdated)}`
+  }
+}
+
+function readDocsUpdateDate(): Date | null {
+  const fromDocsSyncCommit = readGitDate([
+    'log',
+    '-1',
+    '--grep=^docs: .*Sync and translate upstream documentation',
+    '--format=%cI'
+  ])
+  if (fromDocsSyncCommit) return fromDocsSyncCommit
+
+  return readGitDate([
+    'log',
+    '-1',
+    '--format=%cI',
+    '--',
+    'docs/kotlin',
+    'docs/kmp',
+    'docs/koog',
+    'docs/.vitepress/sidebar/kotlin.sidebar.json',
+    'docs/.vitepress/sidebar/kmp.sidebar.json',
+    'docs/.vitepress/sidebar/koog.sidebar.json',
+    'docs/.vitepress/variables/kotlin.v.list',
+    'docs/.vitepress/variables/kmp.v.list'
+  ]) || readGitDate(['show', '-s', '--format=%cI', 'HEAD'])
+}
+
+function readGitDate(args: string[]): Date | null {
+  try {
+    const output = execFileSync('git', args, { cwd: repoRoot, encoding: 'utf-8' }).trim()
+    if (!output) return null
+    const date = new Date(output.split('\n')[0])
+    return Number.isNaN(date.getTime()) ? null : date
+  } catch {
+    return null
+  }
+}
+
+function getNextScheduledDocsUpdate(from: Date): Date {
+  const next = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate(), 0, 0, 0, 0))
+  const daysUntilSunday = (7 - next.getUTCDay()) % 7
+  next.setUTCDate(next.getUTCDate() + daysUntilSunday)
+  if (next <= from) next.setUTCDate(next.getUTCDate() + 7)
+  return next
+}
+
+function formatGmtDate(date: Date): string {
+  const year = date.getUTCFullYear()
+  const month = padDatePart(date.getUTCMonth() + 1)
+  const day = padDatePart(date.getUTCDate())
+  const hour = padDatePart(date.getUTCHours())
+  const minute = padDatePart(date.getUTCMinutes())
+  return `${year}-${month}-${day} ${hour}:${minute} GMT+0`
+}
+
+function padDatePart(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
 function installKotlinCnMarkdownEnvAlias(md: any) {
   const originalParse = md.parse
   const originalRender = md.render
@@ -209,6 +288,8 @@ export default defineConfig({
     plugins: [liquidIncludePlugin()]
   },
   themeConfig: {
+    kotlinVersion: readWritersideVar(kotlinVariablesPath, 'kotlinVersion'),
+    homeMeta: buildHomeMeta(),
     communityDocs: buildCommunityDocs()
   },
   markdown: {

--- a/sites/kotlin-cn/.vitepress/config.mts
+++ b/sites/kotlin-cn/.vitepress/config.mts
@@ -41,7 +41,8 @@ type CommunityDoc = {
 }
 
 type HomeMeta = {
-  updateText: string
+  updatedAt: string
+  nextUpdateAt: string
 }
 
 const docsConfig = [
@@ -153,7 +154,8 @@ function buildHomeMeta(): HomeMeta {
   const nextUpdated = getNextScheduledDocsUpdate(lastUpdated)
 
   return {
-    updateText: `本次更新时间：${formatGmtDate(lastUpdated)}；下次更新时间：${formatGmtDate(nextUpdated)}`
+    updatedAt: formatGmtDate(lastUpdated),
+    nextUpdateAt: formatGmtDate(nextUpdated)
   }
 }
 
@@ -207,7 +209,7 @@ function formatGmtDate(date: Date): string {
   const day = padDatePart(date.getUTCDate())
   const hour = padDatePart(date.getUTCHours())
   const minute = padDatePart(date.getUTCMinutes())
-  return `${year}-${month}-${day} ${hour}:${minute} GMT+0`
+  return `${year}-${month}-${day} ${hour}:${minute}`
 }
 
 function padDatePart(value: number): string {

--- a/sites/kotlin-cn/.vitepress/config.mts
+++ b/sites/kotlin-cn/.vitepress/config.mts
@@ -207,9 +207,7 @@ function formatGmtDate(date: Date): string {
   const year = date.getUTCFullYear()
   const month = padDatePart(date.getUTCMonth() + 1)
   const day = padDatePart(date.getUTCDate())
-  const hour = padDatePart(date.getUTCHours())
-  const minute = padDatePart(date.getUTCMinutes())
-  return `${year}-${month}-${day} ${hour}:${minute}`
+  return `${year}-${month}-${day}`
 }
 
 function padDatePart(value: number): string {

--- a/sites/kotlin-cn/.vitepress/theme/KotlinHome.vue
+++ b/sites/kotlin-cn/.vitepress/theme/KotlinHome.vue
@@ -5,6 +5,12 @@ import KotlinHeader from './components/KotlinHeader.vue'
 
 const { theme } = useData()
 const homeMeta = computed(() => theme.value.homeMeta || {})
+const updatedAtShort = computed(() => compactGmtDate(homeMeta.value.updatedAt))
+const nextUpdateAtShort = computed(() => compactGmtDate(homeMeta.value.nextUpdateAt))
+
+function compactGmtDate(value?: string) {
+  return value?.replace(/^\d{4}-/, '') || ''
+}
 </script>
 
 <template>
@@ -33,8 +39,23 @@ const homeMeta = computed(() => theme.value.homeMeta || {})
         </div>
       </section>
       <footer class="kt-home-footer" aria-label="站点信息">
-        <p v-if="homeMeta.updateText">{{ homeMeta.updateText }}</p>
-        <p>By Kotlin 中文开发者社区</p>
+        <div class="kt-home-footer-inner">
+          <p v-if="homeMeta.updatedAt && homeMeta.nextUpdateAt" class="kt-home-sync">
+            <em>GMT+0</em>
+            <span>
+              <strong>同步</strong>
+              <b class="kt-date-full">{{ homeMeta.updatedAt }}</b>
+              <b class="kt-date-short">{{ updatedAtShort }}</b>
+            </span>
+            <i aria-hidden="true"></i>
+            <span>
+              <strong>下次</strong>
+              <b class="kt-date-full">{{ homeMeta.nextUpdateAt }}</b>
+              <b class="kt-date-short">{{ nextUpdateAtShort }}</b>
+            </span>
+          </p>
+          <p class="kt-home-community">由 Kotlin 中文开发者社区维护</p>
+        </div>
       </footer>
     </main>
   </div>

--- a/sites/kotlin-cn/.vitepress/theme/KotlinHome.vue
+++ b/sites/kotlin-cn/.vitepress/theme/KotlinHome.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
+import { useData } from 'vitepress'
+import { computed } from 'vue'
 import KotlinHeader from './components/KotlinHeader.vue'
+
+const { theme } = useData()
+const homeMeta = computed(() => theme.value.homeMeta || {})
 </script>
 
 <template>
@@ -10,7 +15,7 @@ import KotlinHeader from './components/KotlinHeader.vue'
       <section class="kt-home-hero">
         <div class="kt-home-copy">
           <h1>Kotlin</h1>
-          <p>Concise. Multiplatform. Fun.</p>
+          <p>简洁。多平台。有趣。</p>
           <a class="kt-primary-button" href="/docs/language/home">Get started</a>
           <div class="kt-developed">
             <span>Developed by</span>
@@ -27,7 +32,10 @@ import KotlinHeader from './components/KotlinHeader.vue'
           />
         </div>
       </section>
+      <footer class="kt-home-footer" aria-label="站点信息">
+        <p v-if="homeMeta.updateText">{{ homeMeta.updateText }}</p>
+        <p>By Kotlin 中文开发者社区</p>
+      </footer>
     </main>
   </div>
 </template>
-

--- a/sites/kotlin-cn/.vitepress/theme/KotlinHome.vue
+++ b/sites/kotlin-cn/.vitepress/theme/KotlinHome.vue
@@ -5,12 +5,6 @@ import KotlinHeader from './components/KotlinHeader.vue'
 
 const { theme } = useData()
 const homeMeta = computed(() => theme.value.homeMeta || {})
-const updatedAtShort = computed(() => compactGmtDate(homeMeta.value.updatedAt))
-const nextUpdateAtShort = computed(() => compactGmtDate(homeMeta.value.nextUpdateAt))
-
-function compactGmtDate(value?: string) {
-  return value?.replace(/^\d{4}-/, '') || ''
-}
 </script>
 
 <template>
@@ -41,17 +35,14 @@ function compactGmtDate(value?: string) {
       <footer class="kt-home-footer" aria-label="站点信息">
         <div class="kt-home-footer-inner">
           <p v-if="homeMeta.updatedAt && homeMeta.nextUpdateAt" class="kt-home-sync">
-            <em>GMT+0</em>
             <span>
               <strong>同步</strong>
-              <b class="kt-date-full">{{ homeMeta.updatedAt }}</b>
-              <b class="kt-date-short">{{ updatedAtShort }}</b>
+              <b>{{ homeMeta.updatedAt }}</b>
             </span>
             <i aria-hidden="true"></i>
             <span>
               <strong>下次</strong>
-              <b class="kt-date-full">{{ homeMeta.nextUpdateAt }}</b>
-              <b class="kt-date-short">{{ nextUpdateAtShort }}</b>
+              <b>{{ homeMeta.nextUpdateAt }}</b>
             </span>
           </p>
           <p class="kt-home-community">由 Kotlin 中文开发者社区维护</p>

--- a/sites/kotlin-cn/.vitepress/theme/components/KotlinHeader.vue
+++ b/sites/kotlin-cn/.vitepress/theme/components/KotlinHeader.vue
@@ -9,6 +9,7 @@ defineProps<{
 const { theme } = useData()
 const route = useRoute()
 const docs = computed(() => theme.value.communityDocs || [])
+const kotlinVersion = computed(() => theme.value.kotlinVersion || '')
 
 function isActive(home: string) {
   if (home.startsWith('/docs/language/')) return route.path.startsWith('/docs/language/')
@@ -22,7 +23,7 @@ function isActive(home: string) {
   <header class="kt-header" :class="{ 'is-docs': docsMode }">
     <a class="kt-brand" href="/" aria-label="Kotlin 中文社区首页">
       <img src="/assets/kotlin-logo-white.svg" alt="Kotlin" />
-      <span>v2.4.0</span>
+      <span v-if="kotlinVersion">v{{ kotlinVersion }}</span>
     </a>
     <nav class="kt-top-docs" aria-label="Documentation">
       <span class="kt-docs-label">Docs</span>
@@ -37,4 +38,3 @@ function isActive(home: string) {
     </nav>
   </header>
 </template>
-

--- a/sites/kotlin-cn/.vitepress/theme/styles.css
+++ b/sites/kotlin-cn/.vitepress/theme/styles.css
@@ -159,7 +159,7 @@ textarea {
   width: min(1180px, calc(100vw - 64px));
   min-height: max(900px, 100vh);
   margin: 0 auto;
-  padding-top: 138px;
+  padding: 138px 0 96px;
   align-items: center;
 }
 
@@ -234,6 +234,22 @@ textarea {
   width: 560px;
   height: 560px;
   object-fit: contain;
+}
+
+.kt-home-footer {
+  position: absolute;
+  right: 24px;
+  bottom: 26px;
+  left: 24px;
+  color: rgba(255, 255, 255, .76);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.55;
+  text-align: center;
+}
+
+.kt-home-footer p {
+  margin: 0;
 }
 
 .kt-doc-shell {
@@ -414,15 +430,15 @@ textarea {
   }
 
   .kt-home {
-    min-height: 100vh;
+    min-height: max(820px, 100vh);
   }
 
   .kt-home-hero {
     grid-template-columns: 1fr;
     gap: 22px;
     width: min(100vw - 32px, 620px);
-    min-height: 100vh;
-    padding-top: 92px;
+    min-height: max(820px, 100vh);
+    padding: 92px 0 96px;
   }
 
   .kt-home-copy {
@@ -439,6 +455,11 @@ textarea {
 
   .kt-developed {
     margin-top: 42px;
+  }
+
+  .kt-home-footer {
+    bottom: 20px;
+    font-size: 12px;
   }
 
   .kt-home-art {
@@ -508,6 +529,15 @@ textarea {
     min-width: 150px;
     height: 48px;
     font-size: 18px;
+  }
+
+  .kt-home {
+    min-height: max(760px, 100vh);
+  }
+
+  .kt-home-hero {
+    min-height: max(760px, 100vh);
+    padding-bottom: 90px;
   }
 
   .kt-developed {

--- a/sites/kotlin-cn/.vitepress/theme/styles.css
+++ b/sites/kotlin-cn/.vitepress/theme/styles.css
@@ -283,25 +283,6 @@ textarea {
   font-weight: 500;
 }
 
-.kt-date-short {
-  display: none;
-}
-
-.kt-home-sync em {
-  display: inline-flex;
-  align-items: center;
-  min-height: 18px;
-  padding: 0 7px;
-  border: 1px solid rgba(127, 82, 255, .46);
-  border-radius: 999px;
-  color: rgba(255, 255, 255, .82);
-  background: rgba(127, 82, 255, .12);
-  font-size: 11px;
-  font-style: normal;
-  font-weight: 650;
-  line-height: 1;
-}
-
 .kt-home-sync i {
   display: block;
   width: 4px;
@@ -540,17 +521,8 @@ textarea {
     column-gap: 6px;
   }
 
-  .kt-home-sync strong,
-  .kt-home-sync em {
+  .kt-home-sync strong {
     font-size: 10px;
-  }
-
-  .kt-date-full {
-    display: none;
-  }
-
-  .kt-date-short {
-    display: inline;
   }
 
   .kt-home-art {
@@ -629,10 +601,6 @@ textarea {
   .kt-home-hero {
     min-height: max(760px, 100vh);
     padding-bottom: 112px;
-  }
-
-  .kt-home-sync span {
-    white-space: normal;
   }
 
   .kt-developed {

--- a/sites/kotlin-cn/.vitepress/theme/styles.css
+++ b/sites/kotlin-cn/.vitepress/theme/styles.css
@@ -238,18 +238,83 @@ textarea {
 
 .kt-home-footer {
   position: absolute;
-  right: 24px;
-  bottom: 26px;
-  left: 24px;
-  color: rgba(255, 255, 255, .76);
-  font-size: 13px;
+  right: 0;
+  bottom: 24px;
+  left: 0;
+  padding: 0 32px;
+  color: rgba(255, 255, 255, .56);
+  font-size: 12px;
   font-weight: 500;
-  line-height: 1.55;
-  text-align: center;
+  line-height: 1.45;
 }
 
 .kt-home-footer p {
   margin: 0;
+}
+
+.kt-home-footer-inner {
+  width: min(1180px, calc(100vw - 64px));
+  margin: 0 auto;
+  padding-top: 13px;
+  border-top: 1px solid rgba(255, 255, 255, .13);
+}
+
+.kt-home-sync {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+}
+
+.kt-home-sync span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.kt-home-sync strong {
+  color: rgba(255, 255, 255, .82);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.kt-home-sync b {
+  font-weight: 500;
+}
+
+.kt-date-short {
+  display: none;
+}
+
+.kt-home-sync em {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 0 7px;
+  border: 1px solid rgba(127, 82, 255, .46);
+  border-radius: 999px;
+  color: rgba(255, 255, 255, .82);
+  background: rgba(127, 82, 255, .12);
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.kt-home-sync i {
+  display: block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--kt-purple);
+  opacity: .9;
+}
+
+.kt-home-community {
+  margin-top: 3px !important;
+  color: rgba(255, 255, 255, .82);
+  font-weight: 600;
 }
 
 .kt-doc-shell {
@@ -458,8 +523,34 @@ textarea {
   }
 
   .kt-home-footer {
-    bottom: 20px;
-    font-size: 12px;
+    bottom: 18px;
+    padding: 0 18px;
+    font-size: 11px;
+    text-align: center;
+  }
+
+  .kt-home-footer-inner {
+    width: min(100%, 620px);
+    padding-top: 12px;
+  }
+
+  .kt-home-sync {
+    justify-content: center;
+    row-gap: 5px;
+    column-gap: 6px;
+  }
+
+  .kt-home-sync strong,
+  .kt-home-sync em {
+    font-size: 10px;
+  }
+
+  .kt-date-full {
+    display: none;
+  }
+
+  .kt-date-short {
+    display: inline;
   }
 
   .kt-home-art {
@@ -537,7 +628,11 @@ textarea {
 
   .kt-home-hero {
     min-height: max(760px, 100vh);
-    padding-bottom: 90px;
+    padding-bottom: 112px;
+  }
+
+  .kt-home-sync span {
+    white-space: normal;
   }
 
   .kt-developed {


### PR DESCRIPTION
## Summary
- Read the Kotlin version from the existing OpenAIDoc Writerside variable file instead of hardcoding it in the Kotlin CN header.
- Add build-time homepage metadata for the latest docs sync time and the next scheduled Sunday 00:00 GMT update.
- Translate the Kotlin homepage tagline and add the requested community credit footer.

## Impact
- Scoped to the standalone Kotlin CN VitePress site under `sites/kotlin-cn`.
- Does not modify the existing OpenAIDoc source docs or main site layout.

## Validation
- `pnpm run kotlin-cn:build`
- `git diff --check`