### PR TITLE
[codex] Fix Kotlin version sync

### DIFF
--- a/.github/scripts/docs-pipeline.mjs
+++ b/.github/scripts/docs-pipeline.mjs
@@ -61,7 +61,7 @@ async function sync(context) {
       );
       await git.update(repoConfig.path, repoConfig.branch);
     }
-    await repoConfig.strategy.postSync(repoConfig.path);
+    await repoConfig.strategy.postSync(repoConfig.path, context, repoConfig);
   }
 }
 

--- a/.github/scripts/docs-repo-config.mjs
+++ b/.github/scripts/docs-repo-config.mjs
@@ -41,7 +41,7 @@ export const REPOS = [
   {
     name: "kotlin",
     repo: "JetBrains/kotlin-web-site",
-    branch: "origin/main",
+    branch: "origin/master",
     path: "kotlin-repo",
     docPath: "./docs",
     lastCheckFile: ".github/last_check_kotlin.txt",

--- a/.github/scripts/strategies/strategy-kotlin.mjs
+++ b/.github/scripts/strategies/strategy-kotlin.mjs
@@ -13,7 +13,8 @@ export const kotlinStrategy = {
      */
     getDocPatterns: () => ["docs/**/*.md", "docs/**/*.topic"],
 
-    postSync: async (repoPath) => {
+    postSync: async (repoPath, context, repoConfig) => {
+        await copyKotlinVersionFile(context, repoConfig);
     },
 
     /**
@@ -97,15 +98,7 @@ export const kotlinStrategy = {
      * @override
      */
     postTranslate: async (context, repoConfig) => {
-        if (repoConfig.path === "kotlin-repo") {
-            console.log(`  Copying Kotlin version file... `);
-            const versionFile = "kotlin-repo/docs/variables/v.list";
-            if (await fs.pathExists(versionFile)) {
-                await fs.copy(versionFile, "docs/.vitepress/variables/kotlin.v.list", {overwrite: true});
-                context.gitAddPaths.add("docs/.vitepress/variables/kotlin.v.list")
-                console.log(`  Copying Kotlin version file finished - ${repoConfig.path}`);
-            }
-        }
+        await copyKotlinVersionFile(context, repoConfig);
 
         console.log(`  Handling Kotlin assets: Copying images - ${repoConfig.path}... `);
         const {src, dest} = repoConfig.assets;
@@ -121,3 +114,22 @@ export const kotlinStrategy = {
         }
     },
 };
+
+async function copyKotlinVersionFile(context, repoConfig) {
+    if (!context || repoConfig?.path !== "kotlin-repo") return;
+
+    console.log(`  Copying Kotlin version file...`);
+    const versionFileCandidates = [
+        "kotlin-repo/docs/v.list",
+        "kotlin-repo/docs/variables/v.list",
+    ];
+    const versionFile = versionFileCandidates.find((candidate) => fs.pathExistsSync(candidate));
+    if (!versionFile) {
+        console.warn(`  Warning: Kotlin version file not found in known locations.`);
+        return;
+    }
+
+    await fs.copy(versionFile, "docs/.vitepress/variables/kotlin.v.list", {overwrite: true});
+    context.gitAddPaths.add("docs/.vitepress/variables/kotlin.v.list");
+    console.log(`  Copying Kotlin version file finished - ${repoConfig.path}`);
+}

--- a/docs/.vitepress/variables/kotlin.v.list
+++ b/docs/.vitepress/variables/kotlin.v.list
@@ -5,52 +5,55 @@
 <vars>
 
     <!-- Kotlin -->
-    <var name="kotlinVersion" value="2.3.0"/>
-    <var name="kotlinReleaseDate" value="December 16, 2025"/>
-    <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v2.3.0"/>
-    <var name="kotlinLatestWhatsnew" value="whatsnew23.md"/>
+    <var name="kotlinVersion" value="2.4.0"/>
+    <var name="kotlinReleaseDate" value="June 3, 2026"/>
+    <var name="kotlinLatestUrl" value="https://github.com/JetBrains/kotlin/releases/tag/v2.4.0"/>
+    <var name="kotlinLatestWhatsnew" value="whatsnew24.md"/>
 
-    <var name="languageVersion" value="2.3"/>
-    <var name="apiVersion" value="2.3"/>
+    <var name="languageVersion" value="2.4"/>
+    <var name="apiVersion" value="2.4"/>
 
     <!-- Kotlin EAP -->
-    <var name="kotlinEapVersion" value="2.3.20-Beta1"/>
-    <var name="kotlinEapReleaseDate" value="January 8, 2026"/>
+    <var name="kotlinEapVersion" value="2.4.0-RC2"/>
+    <var name="kotlinEapReleaseDate" value="May 27, 2026"/>
 
     <!-- Libraries and Frameworks -->
-    <var name="coroutinesVersion" value="1.10.2"/>
-    <var name="coroutinesEapVersion" value="1.10.2"/>
+    <var name="coroutinesVersion" value="1.11.0"/>
+    <var name="coroutinesEapVersion" value="1.11.0"/>
 
-    <var name="serializationVersion" value="1.9.0"/>
+    <var name="serializationVersion" value="1.11.0"/>
 
-    <var name="dateTimeVersion" value="0.7.1"/>
+    <var name="dateTimeVersion" value="0.8.0"/>
 
-    <var name="lincheckVersion" value="3.0"/>
+    <var name="lincheckVersion" value="3.6"/>
 
-    <var name="ktorVersion" value="3.3.3"/>
+    <var name="ktorVersion" value="3.5.0"/>
 
-    <var name="lombokVersion" value="9.1.0"/>
+    <var name="lombokVersion" value="9.5.0"/>
 
-    <var name="sqlDelightVersion" value="2.2.1"/>
+    <var name="sqlDelightVersion" value="2.3.2"/>
 
     <!-- Gradle, KGP, AGP -->
     <var name="minGradleVersion" value="7.6.3" type="string"/>
-    <var name="maxGradleVersion" value="9.0.0" type="string"/>
+    <var name="maxGradleVersion" value="9.5.0" type="string"/>
 
-    <var name="minAndroidGradleVersion" value="8.2.2" type="string"/>
-    <var name="maxAndroidGradleVersion" value="8.13.0" type="string"/>
+    <var name="minAndroidGradleVersion" value="8.5.2" type="string"/>
+    <var name="maxAndroidGradleVersion" value="9.1.0" type="string"/>
 
-    <var name="gradleVersion" value="9.0.0" type="string"/>
-    <var name="gradleLanguageVersion" value="KOTLIN_2_3" type="string"/>
-    <var name="gradleApiVersion" value="KOTLIN_2_3" type="string"/>
+    <var name="gradleVersion" value="9.5.0" type="string"/>
+    <var name="gradleLanguageVersion" value="KOTLIN_2_4" type="string"/>
+    <var name="gradleApiVersion" value="KOTLIN_2_4" type="string"/>
+
+    <!-- Maven -->
+    <var name="mavenPluginVersion" value="3.15.0" type="string"/>
+    <var name="mavenExtensionsVersion" value="3.10.1" type="string"/>
 
     <!-- KSP -->
-    <var name="kspSupportedKotlinVersion" value="2.3.3"/>
-    <var name="kspVersion" value="2.3.3"/>
+    <var name="kspVersion" value="2.3.9"/>
 
     <!-- Spring -->
-    <var name="springBootSupportedKotlinVersion" value="1.9.25"/>
-    <var name="springBootVersion" value="3.4.5"/>
+    <var name="springBootSupportedKotlinVersion" value="2.2.21"/>
+    <var name="springBootVersion" value="4.0.2"/>
 
     <!-- Other -->
     <var name="defaultJvmTargetVersion" value="1.8"/>
@@ -60,10 +63,10 @@
     <var name="webpackMajorVersion" value="5"/>
     <var name="webpackPreviousMajorVersion" value="4"/>
 
-    <var name="foojayResolver" value="0.9.0"/>
+    <var name="foojayResolver" value="1.0.0"/>
     <var name="jctoolsVersion" value="3.3.0"/>
 
-    <var name="dokkaVersion" value="2.1.0"/>
+    <var name="dokkaVersion" value="2.2.0"/>
 
     <var name="xcode" value="26"/>
 


### PR DESCRIPTION
## Summary
- update the Kotlin upstream branch config to track `origin/master`
- sync Kotlin `v.list` during `postSync`, before change detection can skip translation work
- support both current upstream `docs/v.list` and the previous `docs/variables/v.list` path
- update the checked-in Kotlin variables to 2.4.0

## Root Cause
Kotlin upstream has 2.4.0 in `docs/v.list`, but our Kotlin strategy still copied only `kotlin-repo/docs/variables/v.list`. The copy also happened only in `postTranslate`, so when the workflow found no changed markdown task, the version file was never refreshed. After `.github/last_check_kotlin.txt` advanced to the current upstream commit, reruns correctly reported no new commits and kept the stale 2.3.0 variable.

## Validation
- `pnpm run kotlin-cn:build`
- `pnpm run docs:build`
- `git diff --check`
- checked `sites/kotlin-cn/.vitepress/dist/index.html` renders `v2.4.0`