### PR TITLE
docs: backfill missing Ktor topic pages from upstream

### DIFF
--- a/docs/ja/ktor/FAQ.md
+++ b/docs/ja/ktor/FAQ.md
@@ -1,0 +1,156 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="FAQ"
+       id="FAQ">
+    <chapter title="Ktorの正しい発音を教えてください。" id="pronounce">
+        <p>
+            <emphasis>/keɪ-tor/</emphasis> （ケイ・ター）です。
+        </p>
+    </chapter>
+    <chapter title='"Ktor"という名前にはどのような意味がありますか？' id="name-meaning">
+        <p>
+            Ktorという名前は、略語の <code>ctor</code> (constructor: コンストラクタ) に由来しており、最初の文字をKotlinの「K」に置き換えたものです。
+        </p>
+    </chapter>
+    <chapter title="質問、バグ報告、連絡、貢献、フィードバックなどはどのようにすればよいですか？" id="feedback">
+        <p>
+            利用可能なサポートチャネルの詳細については、<a href="https://ktor.io/support/">Support</a>ページをご覧ください。
+            Ktorへの貢献方法については、<a href="https://github.com/ktorio/ktor/blob/main/CONTRIBUTING.md">How to contribute</a>ガイドに記載されています。
+        </p>
+    </chapter>
+    <chapter title="CIOとはどういう意味ですか？" id="cio">
+        <p>
+            CIOは <emphasis>Coroutine-based I/O</emphasis> （コルーチンベースのI/O）の略です。
+            通常、外部のJVMベースのライブラリに依存せず、Kotlinとコルーチンを使用してIETF RFCやその他のプロトコルを実装したロジックを持つエンジンのことを指します。
+        </p>
+    </chapter>
+    <chapter title="解決されない（赤字の）Ktorのインポートを修正するにはどうすればよいですか？" id="ktor-artifact">
+        <p>
+            対応する <Links href="//server-dependencies" summary="既存のGradle/MavenプロジェクトにKtorサーバーの依存関係を追加する方法を学びます。">Ktorアーティファクト</Links> がビルドスクリプトに追加されていることを確認してください。
+        </p>
+    </chapter>
+    <chapter
+            title="Ktorは、サーバーのシャットダウンを正常に処理できるように、IPCシグナル（SIGTERMやSIGINTなど）をキャッチする方法を提供していますか？"
+            id="sigterm">
+        <p>
+            <a href="#engine-main">EngineMain</a> を使用して実行している場合は、自動的に処理されます。
+            それ以外の場合は、手動で処理する必要があります。JVMの機能である <code>Runtime.getRuntime().addShutdownHook</code> を使用できます。
+        </p>
+    </chapter>
+    <chapter title="プロキシ経由でクライアントのIPを取得するにはどうすればよいですか？" id="proxy-ip">
+        <p>
+            プロキシが適切なヘッダーを提供し、<Links href="//server-forward-headers" summary="必要な依存関係: io.ktor:%artifact_name%">ForwardedHeader</Links> プラグインがインストールされている場合、<code>call.request.origin</code> プロパティから元の呼び出し元（プロキシ）に関する <a href="#request_information">接続情報</a> を取得できます。
+        </p>
+    </chapter>
+    <chapter title="mainブランチの最新コミットをテストするにはどうすればよいですか？" id="bleeding-edge">
+        <p>
+            <code>jetbrains.space</code> からKtorのナイトリービルドを取得できます。
+            詳細は <a href="https://ktor.io/eap/">Early Access Program</a> をご確認ください。
+        </p>
+    </chapter>
+    <chapter title="使用しているKtorのバージョンを確実に確認するにはどうすればよいですか？" id="ktor-version-used">
+        <p>
+            <Links href="//server-default-headers" summary="必要な依存関係: io.ktor:%artifact_name%">DefaultHeaders</Links> プラグインを使用すると、以下のようにKtorのバージョンを含む <code>Server</code> レスポンスヘッダーを送信できます。
+        </p>
+        <code-block code="            Server: ktor-server-core/%ktor_version%"/>
+    </chapter>
+    <chapter title="ルートが実行されません。どのようにデバッグすればよいですか？" id="route-not-executing">
+        <p>
+            Ktorはルーティングの決定に関するトラブルシューティングを支援するトレースメカニズムを提供しています。
+            <a href="#trace_routes">Tracing routes</a> セクションを確認してください。
+        </p>
+    </chapter>
+    <chapter title="'Response has already been sent' を解決するにはどうすればよいですか？" id="response-already-sent">
+        <p>
+            これは、あなた自身、あるいはプラグインやインターセプターがすでに <code>call.respond&#42;</code> 関数を呼び出しているにもかかわらず、再度それを呼び出そうとしていることを意味します。
+        </p>
+    </chapter>
+    <chapter title="Ktorのイベントを購読するにはどうすればよいですか？" id="ktor-events">
+        <p>
+            詳細は <Links href="//server-events" summary="">Application monitoring</Links> ページをご覧ください。
+        </p>
+    </chapter>
+    <chapter title="'No configuration setting found for key ktor' を解決するにはどうすればよいですか？" id="cannot-find-application-conf">
+        <p>
+            これは、Ktorが <Links href="//server-configuration-file" summary="設定ファイルでさまざまなサーバーパラメータを設定する方法を学びます。">設定ファイル</Links> を見つけられなかったことを意味します。
+            <code>resources</code> フォルダに設定ファイルが存在し、その <code>resources</code> フォルダがリソースフォルダとして正しくマークされていることを確認してください。
+            ベースとなる動作プロジェクトを作成するために、<a href="https://start.ktor.io/">Ktorプロジェクトジェネレーター</a> や <a href="https://plugins.jetbrains.com/plugin/16008-ktor">IntelliJ IDEA Ultimate用のKtorプラグイン</a> の使用を検討してください。詳細については、<Links href="//server-create-a-new-project" summary="Ktorでサーバーアプリケーションを作成、開き、実行、テストする方法を学びます。">Ktorプロジェクトの作成、開封、実行</Links> を参照してください。
+        </p>
+    </chapter>
+    <chapter title="AndroidでKtorを使用できますか？" id="android-support">
+        <p>
+            はい、Ktorのサーバーとクライアントは、少なくともNettyエンジンを使用する場合、Android 5 (API 21) 以上で動作することが確認されています。
+        </p>
+    </chapter>
+    <chapter title="なぜ 'CURL -I' が '404 Not Found' を返すのですか？" id="curl-head-not-found">
+        <p>
+            <code>CURL -I</code> は <code>HEAD</code> リクエストを実行する <code>CURL --head</code> のエイリアスです。
+            デフォルトでは、Ktorは <code>GET</code> ハンドラーに対する <code>HEAD</code> リクエストを処理しません。
+            この機能を有効にするには、<Links href="//server-autoheadresponse" summary="%plugin_name% は、GETが定義されているすべてのルートに対してHEADリクエストに自動的に応答する機能を提供します。">AutoHeadResponse</Links> プラグインをインストールしてください。
+        </p>
+    </chapter>
+    <chapter title="'HttpsRedirect' プラグイン使用時の無限リダイレクトを解決するにはどうすればよいですか？" id="infinite-redirect">
+        <p>
+            最も可能性の高い原因は、バックエンドがリバースプロキシやロードバランサーの背後にあり、その中間機器がバックエンドに対して通常のHTTPリクエストを行っていることです。そのため、Ktorバックエンド内の <code>HttpsRedirect</code> プラグインがそれを通常のHTTPリクエストであると判断し、リダイレクトを返してしまいます。
+        </p>
+        <p>
+            通常、リバースプロキシは元のリクエストに関する情報を記述するヘッダー（HTTPSであったかどうかや元のIPアドレスなど）を送信します。それらのヘッダーを解析するための <Links href="//server-forward-headers" summary="必要な依存関係: io.ktor:%artifact_name%">ForwardedHeader</Links> プラグインを使用することで、<Links href="//server-https-redirect" summary="必要な依存関係: io.ktor:%artifact_name%">HttpsRedirect</Links> プラグインは元のリクエストがHTTPSであったことを認識できるようになります。
+        </p>
+    </chapter>
+    <chapter title="Kotlin/Nativeで対応するエンジンを使用するために、Windowsに 'curl' をインストールするにはどうすればよいですか？" id="native-curl">
+        <p>
+            <a href="#curl">Curl</a> クライアントエンジンには <code>curl</code> ライブラリのインストールが必要です。
+            Windowsでは、MinGW/MSYS2の <code>curl</code> バイナリの利用を検討してください。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    <a href="https://www.msys2.org/">MinGW/MSYS2</a> の説明に従ってインストールします。
+                </p>
+            </step>
+            <step>
+                <p>
+                    以下のコマンドを使用して <code>libcurl</code> をインストールします。
+                </p>
+                <code-block lang="shell" code="                    pacman -S mingw-w64-x86_64-curl"/>
+            </step>
+            <step>
+                <p>
+                    MinGW/MSYS2をデフォルトの場所にインストールした場合は、環境変数 <code>PATH</code> に <Path>C:\\msys64\\mingw64\\bin\\</Path> を追加します。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="'NoTransformationFoundException' を解決するにはどうすればよいですか？" id="no-transformation-found-exception">
+        <p>
+            <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.call/-no-transformation-found-exception/index.html">NoTransformationFoundException</a> は、<i>受信したボディ</i> に対して、<b>結果の</b> 型からクライアントが <b>期待する</b> 型への適切な変換が見つからないことを表します。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    リクエストの <code>Accept</code> ヘッダーが目的のコンテンツタイプを指定していること、およびサーバーのレスポンスの <code>Content-Type</code> ヘッダーがクライアント側の期待する型と一致していることを確認してください。
+                </p>
+            </step>
+            <step>
+                <p>
+                    使用している特定のコンテンツタイプに対して、必要なコンテンツ変換を登録してください。
+                </p>
+                <p>
+                    クライアント側では <a href="https://ktor.io/docs/serialization-client.html">ContentNegotiation</a> プラグインを使用できます。
+                    このプラグインを使用すると、異なるコンテンツタイプに対してデータをシリアライズおよびデシリアライズする方法を指定できます。
+                </p>
+                <code-block lang="kotlin" code="                    val client = HttpClient(CIO) {&#10;                        install(ContentNegotiation) {&#10;                            json() // 例: JSONコンテンツ変換を登録&#10;                            // 必要に応じて他のコンテンツタイプの変換を追加&#10;                        }&#10;                    }"/>
+            </step>
+            <step>
+                <p>
+                    必要なプラグインがすべてインストールされていることを確認してください。不足している可能性がある機能：
+                </p>
+                <list type="bullet">
+                    <li>クライアントの <a href="https://ktor.io/docs/websocket-client.html">WebSockets</a> および サーバーの <a href="https://ktor.io/docs/websocket.html">WebSockets</a></li>
+                    <li>クライアントの <a href="https://ktor.io/docs/serialization-client.html">ContentNegotiation</a> および サーバーの <a href="https://ktor.io/docs/server-serialization.html">ContentNegotiation</a></li>
+                    <li><a href="https://ktor.io/docs/compression.html">Compression</a></li>
+                </list>
+            </step>
+        </procedure>
+    </chapter>
+</topic>

--- a/docs/ja/ktor/client-create-new-application.md
+++ b/docs/ja/ktor/client-create-new-application.md
@@ -1,0 +1,272 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="クライアントアプリケーションの作成"
+       id="client-create-new-application"
+       help-id="getting_started_ktor_client;client-getting-started;client-get-started;client-create-a-new-application">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <var name="example_name" value="tutorial-client-get-started"/>
+    <p>
+        <b>コード例</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+</tldr>
+<link-summary>
+    リクエストを送信してレスポンスを受信する、最初のクライアントアプリケーションを作成します。
+</link-summary>
+<p>
+    Ktor にはマルチプラットフォーム対応の非同期 HTTP クライアントが含まれており、これを使用することで <Links href="//client-requests" summary="リクエストの作成方法と、リクエスト URL、HTTP メソッド、ヘッダー、リクエスト本文などのさまざまなリクエストパラメータの指定方法について学びます。">リクエストの送信</Links>や <Links href="//client-responses" summary="レスポンスの受信、レスポンス本文の取得、レスポンスパラメータの取得方法について学びます。">レスポンスの処理</Links>を行うことができます。また、<Links href="//client-plugins" summary="ロギング、シリアル化、認可などの一般的な機能を追加するためのクライアントプラグインの使用方法を学びます。">プラグイン</Links>を使用して、<Links href="//client-auth" summary="Auth プラグインは、クライアントアプリケーションでの認証と認可を処理します。">認証</Links>や <Links href="//client-serialization" summary="ContentNegotiation プラグインは、主に 2 つの目的を果たします。クライアントとサーバー間でのメディアタイプのネゴシエーションと、リクエスト送信時およびレスポンス受信時に特定の形式でコンテンツをシリアル化/デシリアル化することです。">JSON シリアル化</Links>などの機能拡張も可能です。
+</p>
+<p>
+    このチュートリアルでは、リクエストを送信してレスポンスを出力する、最初の Ktor クライアントアプリケーションの作成方法を説明します。
+</p>
+<chapter title="前提条件" id="prerequisites">
+    <p>
+        このチュートリアルを始める前に、<a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA Community または Ultimate をインストール</a>してください。
+    </p>
+</chapter>
+<chapter title="新規プロジェクトの作成" id="new-project">
+    <p>
+        既存のプロジェクトに手動で Ktor クライアントを <Links href="//client-create-and-configure" summary="Ktor クライアントの作成と構成方法について学びます。">作成および構成</Links>することもできますが、ゼロから始める便利な方法は、IntelliJ IDEA に同梱されている Kotlin プラグインを使用して新しいプロジェクトを生成することです。
+    </p>
+    <p>
+        新しい Kotlin プロジェクトを作成するには、<a href="https://www.jetbrains.com/help/idea/run-for-the-first-time.html">IntelliJ IDEA を開き</a>、以下の手順に従います。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                ウェルカム画面で <control>New Project</control> をクリックします。
+            </p>
+            <p>
+                または、メインメニューから <ui-path>File | New | Project</ui-path> を選択します。
+            </p>
+        </step>
+        <step>
+            <p>
+                <control>New Project</control> ウィザードで、左側のリストから <control>Kotlin</control> を選択します。
+            </p>
+        </step>
+        <step>
+            <p>
+                右側のペインで、以下の設定を指定します。
+            </p>
+            <img src="client_get_started_new_project.png" alt="IntelliJ IDEA の New Kotlin project ウィンドウ"
+                 border-effect="rounded"
+                 width="706"/>
+            <list id="kotlin_app_settings">
+                <li>
+                    <p>
+                        <control>Name</control>: プロジェクト名を指定します。
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <control>Location</control>: プロジェクトのディレクトリを指定します。
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <control>Build system</control>: <control>Gradle</control> が選択されていることを確認します。
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <control>Gradle DSL</control>: <control>Kotlin</control> を選択します。
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <control>Add sample code</control>: 生成されるプロジェクトにサンプルコードを含めるために、このオプションを選択します。
+                    </p>
+                </li>
+            </list>
+        </step>
+        <step>
+            <p>
+                <control>Create</control> をクリックし、IntelliJ IDEA がプロジェクトを生成して依存関係をインストールするまで待ちます。
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="依存関係の追加" id="add-dependencies">
+    <p>
+        Ktor クライアントに必要な依存関係を追加しましょう。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                <Path>gradle.properties</Path> ファイルを開き、Ktor のバージョンを指定するために次の行を追加します。
+            </p>
+            <code-block lang="kotlin" code="                    ktor_version=%ktor_version%"/>
+            <note id="eap-note">
+                <p>
+                    Ktor の EAP バージョンを使用するには、<a href="#repositories">Space リポジトリ</a>を追加する必要があります。
+                </p>
+            </note>
+        </step>
+        <step>
+            <p>
+                <Path>build.gradle.kts</Path> ファイルを開き、dependencies ブロックに次のアーティファクトを追加します。
+            </p>
+            <code-block lang="kotlin" code="val ktor_version: String by project&#10;&#10;dependencies {&#10;    implementation(&quot;io.ktor:ktor-client-core:$ktor_version&quot;)&#10;    implementation(&quot;io.ktor:ktor-client-cio:$ktor_version&quot;)&#10;}"/>
+            <list>
+                <li><code>ktor-client-core</code> は、メインのクライアント機能を提供するコア依存関係です。</li>
+                <li>
+                    <code>ktor-client-cio</code> は、ネットワークリクエストを処理する <Links href="//client-engines" summary="ネットワークリクエストを処理するエンジンについて学びます。">エンジン</Links> のための依存関係です。
+                </li>
+            </list>
+        </step>
+        <step>
+            <p>
+                <Path>build.gradle.kts</Path> ファイルの右上隅にある <control>Load Gradle Changes</control> アイコンをクリックして、新しく追加された依存関係をインストールします。
+            </p>
+            <img src="client_get_started_load_gradle_changes_name.png" alt="Load Gradle Changes" width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="クライアントの作成" id="create-client">
+    <p>
+        クライアントの実装を追加するには、<Path>src/main/kotlin</Path> に移動し、以下の手順に従います。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                <Path>Main.kt</Path> ファイルを開き、既存のコードを次の実装に置き換えます。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.client.*&#10;                    import io.ktor.client.engine.cio.*&#10;&#10;                    fun main() {&#10;                        val client = HttpClient(CIO)&#10;                    }"/>
+            <p>
+                Ktor では、クライアントは <a
+                    href="https://api.ktor.io/ktor-client-core/io.ktor.client/-http-client/index.html">HttpClient</a> クラスによって表されます。
+            </p>
+        </step>
+        <step>
+            <p>
+                <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.request/get.html"><code>HttpClient.get()</code></a> メソッドを使用して <Links href="//client-requests" summary="リクエストの作成方法と、リクエスト URL、HTTP メソッド、ヘッダー、リクエスト本文などのさまざまなリクエストパラメータの指定方法について学びます。">GET リクエストを送信</Links>します。
+                <Links href="//client-responses" summary="レスポンスの受信、レスポンス本文の取得、レスポンスパラメータの取得方法について学びます。">レスポンス</Links> は <code>HttpResponse</code> クラスのオブジェクトとして受け取ります。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.client.*&#10;                    import io.ktor.client.engine.cio.*&#10;                    import io.ktor.client.request.*&#10;                    import io.ktor.client.statement.*&#10;&#10;                    fun main() {&#10;                        val client = HttpClient(CIO)&#10;                        val response: HttpResponse = client.get(&quot;https://ktor.io/&quot;)&#10;                    }"/>
+            <p>
+                上記のコードを追加すると、IDE は <code>get()</code> 関数に対して次のエラーを表示します。
+                <emphasis>Suspend function 'get' should be called only from a coroutine or another suspend
+                    function
+                </emphasis>（Suspend 関数 'get' は、コルーチンまたは別の suspend 関数からのみ呼び出す必要があります）。
+            </p>
+            <img src="client_get_started_suspend_error.png" alt="Suspend 関数のエラー" width="706"/>
+            <p>
+                これを修正するには、<code>main()</code> 関数を <code>suspend</code> にする必要があります。
+            </p>
+            <tip>
+                <code>suspend</code> 関数の呼び出しについての詳細は、<a
+                    href="https://kotlinlang.org/docs/coroutines-basics.html">コルーチンの基本</a>を参照してください。
+            </tip>
+        </step>
+        <step>
+            <p>
+                IntelliJ IDEA で、定義の横にある赤い電球をクリックし、<control>Make main suspend</control> を選択します。
+            </p>
+            <img src="client_get_started_suspend_error_fix.png" alt="main を suspend にする" width="706"/>
+        </step>
+        <step>
+            <p>
+                <code>println()</code> 関数を使用してサーバーから返された <a href="#status">ステータスコード</a> を出力し、<code>close()</code> 関数を使用してストリームを閉じ、関連するリソースを解放します。
+                <Path>Main.kt</Path> ファイルは次のようになります。
+            </p>
+            <code-block lang="kotlin" code="import io.ktor.client.*&#10;import io.ktor.client.engine.cio.*&#10;import io.ktor.client.request.*&#10;import io.ktor.client.statement.*&#10;&#10;suspend fun main() {&#10;    val client = HttpClient(CIO)&#10;    val response: HttpResponse = client.get(&quot;https://ktor.io/&quot;)&#10;    println(response.status)&#10;    client.close()&#10;}"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="アプリケーションの実行" id="make-request">
+    <p>
+        アプリケーションを実行するには、<Path>Main.kt</Path> ファイルに移動し、以下の手順に従います。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                IntelliJ IDEA で、<code>main()</code> 関数の横にあるガターアイコンをクリックし、<control>Run 'MainKt'</control> を選択します。
+            </p>
+            <img src="client_get_started_run_main.png" alt="アプリケーションの実行" width="706"/>
+        </step>
+        <step>
+            IntelliJ IDEA がアプリケーションを実行するまで待ちます。
+        </step>
+        <step>
+            <p>
+                IDE の下部にある <control>Run</control> ペインに出力が表示されます。
+            </p>
+            <img src="client_get_started_run_output_with_warning.png" alt="サーバーのレスポンス" width="706"/>
+            <p>
+                サーバーは <code>200 OK</code> メッセージを返しますが、SLF4J が <code>StaticLoggerBinder</code> クラスを見つけられず、デフォルトで NOP（何もしない）ロガー実装が使用されることを示すエラーメッセージも表示されます。これは事実上、ロギングが無効であることを意味します。
+            </p>
+            <p>
+                これで、動作するクライアントアプリケーションが作成されました。ただし、この警告を修正し、ロギングを使用して HTTP 呼び出しをデバッグできるようにするには、<a href="#enable-logging">追加の手順</a>が必要です。
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="ロギングの有効化" id="enable-logging">
+    <p>
+        Ktor は JVM 上のロギングに SLF4J 抽象化レイヤーを使用しているため、ロギングを有効にするには <a href="https://logback.qos.ch/">Logback</a> などの <a href="#jvm">ロギングフレームワークを提供</a> する必要があります。
+    </p>
+    <procedure id="enable-logging-procedure">
+        <step>
+            <p>
+                <Path>gradle.properties</Path> ファイルで、ロギングフレームワークのバージョンを指定します。
+            </p>
+            <code-block lang="kotlin" code="                    logback_version=%logback_version%"/>
+        </step>
+        <step>
+            <p>
+                <Path>build.gradle.kts</Path> ファイルを開き、dependencies ブロックに次のアーティファクトを追加します。
+            </p>
+            <code-block lang="kotlin" code="                    //...&#10;                    val logback_version: String by project&#10;&#10;                    dependencies {&#10;                        //...&#10;                        implementation(&quot;ch.qos.logback:logback-classic:$logback_version&quot;)&#10;                    }"/>
+        </step>
+        <step>
+            <control>Load Gradle Changes</control> アイコンをクリックして、新しく追加された依存関係をインストールします。
+        </step>
+        <step>
+            <p>
+                IntelliJ IDEA で、再実行ボタン (<img src="intellij_idea_rerun_icon.svg"
+                                                               style="inline" height="16" width="16"
+                                                               alt="IntelliJ IDEA 再実行アイコン"/>) をクリックしてアプリケーションを再起動します。
+            </p>
+        </step>
+        <step>
+            <p>
+                エラーが表示されなくなり、IDE 下部の <control>Run</control> ペインに同じ <code>200 OK</code> メッセージが表示されるはずです。
+            </p>
+            <img src="client_get_started_run_output.png" alt="サーバーのレスポンス" width="706"/>
+            <p>
+                これでロギングが有効になりました。ログの表示を開始するには、ロギング構成を追加する必要があります。
+            </p>
+        </step>
+        <step>
+            <p><Path>src/main/resources</Path> に移動し、以下の実装を持つ新しい <Path>logback.xml</Path> ファイルを作成します。
+            </p>
+            <code-block lang="xml" ignore-vars="true" code="                    &lt;configuration&gt;&#10;                        &lt;appender name=&quot;APPENDER&quot; class=&quot;ch.qos.logback.core.ConsoleAppender&quot;&gt;&#10;                            &lt;encoder&gt;&#10;                                &lt;pattern&gt;%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n&lt;/pattern&gt;&#10;                            &lt;/encoder&gt;&#10;                        &lt;/appender&gt;&#10;                        &lt;root level=&quot;trace&quot;&gt;&#10;                            &lt;appender-ref ref=&quot;APPENDER&quot;/&gt;&#10;                        &lt;/root&gt;&#10;                    &lt;/configuration&gt;"/>
+        </step>
+        <step>
+            <p>
+                IntelliJ IDEA で、再実行ボタン (<img src="intellij_idea_rerun_icon.svg"
+                                                               style="inline" height="16" width="16"
+                                                               alt="IntelliJ IDEA 再実行アイコン"/>) をクリックしてアプリケーションを再起動します。
+            </p>
+        </step>
+        <step>
+            <p>
+                <control>Run</control> ペイン内の出力されたレスポンスの上に、トレースログが表示されるはずです。
+            </p>
+            <img src="client_get_started_run_output_with_logs.png" alt="サーバーのレスポンス" width="706"/>
+        </step>
+    </procedure>
+    <tip>
+        Ktor は、<Links href="//client-logging" summary="必要な依存関係: io.ktor:ktor-client-logging">Logging</Links> プラグインを通じて HTTP 呼び出しのログを追加するシンプルで直接的な方法を提供します。一方、構成ファイルを追加すると、複雑なアプリケーションでのロギングの動作を微調整できます。
+    </tip>
+</chapter>
+<chapter title="次のステップ" id="next-steps">
+    <p>
+        この構成をより深く理解し拡張するために、<Links href="//client-create-and-configure" summary="Ktor クライアントの作成と構成方法について学びます。">Ktor クライアントの作成と構成</Links> 方法を確認してください。
+    </p>
+</chapter>
+</topic>

--- a/docs/ja/ktor/client-server-sent-events.md
+++ b/docs/ja/ktor/client-server-sent-events.md
@@ -1,0 +1,207 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="client-server-sent-events" title="Ktor Client における Server-Sent Events" help-id="sse_client">
+    <show-structure for="chapter" depth="2"/>
+    <primary-label ref="client-plugin"/>
+    <tldr>
+        <var name="example_name" value="client-sse"/>
+        <p>
+            <b>コード例</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+    </tldr>
+    <link-summary>
+        SSE プラグインを使用すると、クライアントは HTTP 接続を介してサーバーからイベントベースの更新を受信できます。
+    </link-summary>
+    <p>
+        Server-Sent Events (SSE) は、サーバーが HTTP 接続を介してクライアントにイベントを継続的にプッシュできるようにする技術です。これは、クライアントがサーバーに対して繰り返しポーリングを行う必要なく、サーバーがイベントベースの更新を送信する必要がある場合に特に有用です。
+    </p>
+    <p>
+        Ktor がサポートする SSE プラグインは、サーバーとクライアントの間に一方向の接続を作成するための簡単な方法を提供します。
+    </p>
+    <tip>
+        <p>サーバー側のサポートのための SSE プラグインの詳細については、
+            <Links href="//server-server-sent-events" summary="The SSE plugin allows a server to send event-based updates to a client over an HTTP connection.">SSE サーバープラグイン</Links>
+            を参照してください。
+        </p>
+    </tip>
+    <chapter title="依存関係の追加" id="add_dependencies">
+        <p>
+            <code>SSE</code> は <Links href="//client-dependencies" summary="Learn how to add client dependencies to an existing project.">ktor-client-core</Links> アーティファクトのみを必要とし、特定の依存関係は必要ありません。
+        </p>
+    </chapter>
+    <chapter title="SSE のインストール" id="install_plugin">
+        <p>
+            <code>SSE</code> プラグインをインストールするには、<a href="#configure-client">クライアント設定ブロック</a>内の <code>install</code> 関数に渡します。
+        </p>
+        <code-block lang="kotlin" code="            import io.ktor.client.*&#10;            import io.ktor.client.engine.cio.*&#10;            import io.ktor.client.plugins.sse.*&#10;&#10;            //...&#10;            val client = HttpClient(CIO) {&#10;                install(SSE)&#10;            }"/>
+    </chapter>
+    <chapter title="SSE プラグインの設定" id="configure">
+        <p>
+            必要に応じて、
+            <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-s-s-e-config/index.html">SSEConfig</a>
+            クラスのサポートされているプロパティを設定することで、<code>install</code> ブロック内で SSE プラグインを設定できます。
+        </p>
+        <chapter title="SSE の再接続" id="sse-reconnect">
+            <p>
+                自動再接続を有効にするには、
+                <code>maxReconnectionAttempts</code> を <code>0</code> より大きい値に設定します。また、<code>reconnectionTime</code> を使用して試行間の遅延を設定することもできます。
+            </p>
+            <code-block lang="kotlin" code="                install(SSE) {&#10;                    maxReconnectionAttempts = 4&#10;                    reconnectionTime = 2.seconds&#10;                }"/>
+            <p>
+                サーバーへの接続が失われた場合、クライアントは再接続を試みる前に、指定された
+                <code>reconnectionTime</code> だけ待機します。接続を再確立するために、指定された <code>maxReconnectionAttempts</code> まで試行を繰り返します。
+            </p>
+        </chapter>
+        <chapter title="イベントのフィルタリング" id="filter-events">
+            <p>
+                以下の例では、SSE プラグインを HTTP クライアントにインストールし、受信フローにコメントのみを含むイベントと、<code>retry</code> フィールドのみを含むイベントを含めるように設定しています。
+            </p>
+            <code-block lang="kotlin" code="        install(SSE) {&#10;            showCommentEvents()&#10;            showRetryEvents()&#10;        }"/>
+        </chapter>
+        <chapter title="レスポンスのバッファリング" id="response-buffering">
+            <p>
+                SSE のレスポンスは本質的にストリーミングであるため、フルボディをキャプチャすることは現実的ではありません。SSE ストリームが失敗したときにレスポンスボディを安全に取得するために、診断バッファを有効にできます。このバッファには、すでに処理されたデータのみが含まれ（ネットワークからの再読み込みは行われません）、失敗した場合のロギングやエラー分析を目的としています。
+            </p>
+            <code-block lang="kotlin" code="                install(SSE) {&#10;                    bufferPolicy = SSEBufferPolicy.LastEvents(10)&#10;                }"/>
+            <p>
+                コールごとにバッファを設定することもできます。
+            </p>
+            <code-block lang="kotlin" code="                client.sse(url, {&#10;                    bufferPolicy(SSEBufferPolicy.All)&#10;                }) {&#10;                    // ...&#10;                }"/>
+            <chapter title="バッファポリシー" id="buffer-policies">
+                <p>
+                    <code>SSEBufferPolicy</code> 型は、処理された SSE データを保存するためのいくつかの戦略を提供します。
+                    これらのポリシーは、ストリームのどの程度をメモリに保持し、エラー発生時に利用可能にするかを制御します。
+                </p>
+                <deflist>
+                    <def id="buffer-off">
+                        <title><code>Off</code> (デフォルト)</title>
+                        バッファリングなし。
+                    </def>
+                    <def id="buffer-lastlines">
+                        <title><code>LastLines(n)</code></title>
+                        直近の n 行を保持します。
+                    </def>
+                    <def id="buffer-lastevent">
+                        <title><code>LastEvent</code></title>
+                        最後に完了した SSE イベントを保持します。
+                    </def>
+                    <def id="buffer-lastevents">
+                        <title><code>LastEvents(n)</code></title>
+                        直近の n 個の完了した SSE イベントを保持します。
+                    </def>
+                    <def id="buffer-all">
+                        <title><code>All</code></title>
+                        これまでに処理されたすべてのイベントを保持します。
+                        <note>長期間存続するストリームでは注意して使用してください。</note>
+                    </def>
+                </deflist>
+                <p>
+                    失敗した場合は、ネットワークから再読み込みすることなく、<code>response?.bodyAsText()</code> を使用してバッファにアクセスできます。
+                </p>
+            </chapter>
+        </chapter>
+    </chapter>
+    <chapter title="SSE セッションの処理" id="handle-sse-sessions">
+        <p>
+            クライアントの SSE セッションは
+            <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session/index.html">
+                <code>ClientSSESession</code>
+            </a>
+            インターフェースによって表されます。このインターフェースは、サーバーからサーバー送信イベントを受信できるようにする API を公開しています。
+        </p>
+        <chapter title="SSE セッションへのアクセス" id="access-sse-session">
+            <p><code>HttpClient</code> を使用すると、次のいずれかの方法で SSE セッションにアクセスできます。</p>
+            <list>
+                <li>
+                    <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/sse.html">
+                        <code>sse()</code>
+                    </a>
+                    関数は、SSE セッションを作成し、それに対してアクションを実行できるようにします。
+                </li>
+                <li>
+                    <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/sse-session.html">
+                        <code>sseSession()</code>
+                    </a>
+                    関数を使用すると、SSE セッションを開くことができます。
+                </li>
+            </list>
+            <p>URL エンドポイントを指定するには、次の 2 つのオプションから選択できます。</p>
+            <list>
+                <li><code>urlString</code> パラメータを使用して、URL 全体を文字列として指定します。</li>
+                <li><code>schema</code>、<code>host</code>、<code>port</code>、<code>path</code> パラメータを使用して、それぞれプロトコルスキーム、ドメイン名、ポート番号、パス名を指定します。
+                </li>
+            </list>
+            <code-block lang="kotlin" code="                runBlocking {&#10;                    client.sse(host = &amp;quot;127.0.0.1&amp;quot;, port = 8080, path = &amp;quot;/events&amp;quot;) {&#10;                        // this: ClientSSESession&#10;                    }&#10;                }"/>
+            <note>
+                <code>ClientSSESession</code> および <code>ClientSSESessionWithDeserialization</code> のインスタンスは、セッションの期間中のみ有効です。<code>serverSentEvents { ... }</code> ブロックが完了するか、接続が閉じられると、それらのスコープは自動的にキャンセルされます。
+            </note>
+            <p>オプションで、接続を設定するために以下のパラメータを使用できます。</p>
+            <deflist>
+                <def id="reconnectionTime-param">
+                    <title><code>reconnectionTime</code></title>
+                    再接続の遅延を設定します。
+                </def>
+                <def id="showCommentEvents-param">
+                    <title><code>showCommentEvents</code></title>
+                    受信フローにコメントのみを含むイベントを表示するかどうかを指定します。
+                </def>
+                <def id="showRetryEvents-param">
+                    <title><code>showRetryEvents</code></title>
+                    受信フローに <code>retry</code> フィールドのみを含むイベントを表示するかどうかを指定します。
+                </def>
+                <def id="deserialize-param">
+                    <title><code>deserialize</code></title>
+                    <code>TypedServerSentEvent</code> の <code>data</code> フィールドをオブジェクトに変換するためのデシリアライザー関数。詳細については、<a href="#deserialization">デシリアライズ</a>を参照してください。
+                </def>
+            </deflist>
+        </chapter>
+        <chapter title="SSE セッションブロック" id="sse-session-block">
+            <p>
+                ラムダ引数内では、
+                <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session/index.html"><code>ClientSSESession</code></a>
+                コンテキストにアクセスできます。ブロック内では以下のプロパティが利用可能です。
+            </p>
+            <deflist>
+                <def id="call">
+                    <title><code>call</code></title>
+                    セッションを開始した、関連付けられた <code>HttpClientCall</code>。
+                </def>
+                <def id="incoming">
+                    <title><code>incoming</code></title>
+                    受信するサーバー送信イベントのフロー。
+                </def>
+            </deflist>
+            <p>
+                以下の例では、<code>events</code> エンドポイントを使用して新しい SSE セッションを作成し、<code>incoming</code> プロパティを通じてイベントを読み取り、受信した
+                <a href="https://api.ktor.io/ktor-sse/io.ktor.sse/-server-sent-event/index.html"><code>ServerSentEvent</code></a>
+                を出力します。
+            </p>
+            <code-block lang="kotlin" code="fun main() {&#10;    val client = HttpClient {&#10;        install(SSE) {&#10;            showCommentEvents()&#10;            showRetryEvents()&#10;        }&#10;    }&#10;    runBlocking {&#10;        client.sse(host = &quot;0.0.0.0&quot;, port = 8080, path = &quot;/events&quot;) {&#10;            while (true) {&#10;                incoming.collect { event -&gt;&#10;                    println(&quot;Event from server:&quot;)&#10;                    println(event)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>完全な例については、
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-sse">client-sse</a> を参照してください。
+            </p>
+        </chapter>
+        <chapter title="デシリアライズ" id="deserialization">
+            <p>
+                SSE プラグインは、サーバー送信イベントの型安全な Kotlin オブジェクトへのデシリアライズをサポートしています。この機能は、サーバーからの構造化されたデータを扱う場合に特に有用です。
+            </p>
+            <p>
+                デシリアライズを有効にするには、SSE アクセス関数の <code>deserialize</code> パラメータを使用してカスタムデシリアライズ関数を提供し、
+                <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session-with-deserialization/index.html">
+                    <code>ClientSSESessionWithDeserialization</code>
+                </a>
+                クラスを使用してデシリアライズされたイベントを処理します。
+            </p>
+            <p>
+                以下は、<code>kotlinx.serialization</code> を使用して JSON データをデシリアライズする例です。
+            </p>
+            <code-block lang="Kotlin" code="        client.sse({&#10;            url(&quot;http://localhost:8080/serverSentEvents&quot;)&#10;        }, deserialize = {&#10;                typeInfo, jsonString -&gt;&#10;            val serializer = Json.serializersModule.serializer(typeInfo.kotlinType!!)&#10;            Json.decodeFromString(serializer, jsonString)!!&#10;        }) { // `this` is `ClientSSESessionWithDeserialization`&#10;            incoming.collect { event: TypedServerSentEvent&lt;String&gt; -&gt;&#10;                when (event.event) {&#10;                    &quot;customer&quot; -&gt; {&#10;                        val customer: Customer? = deserialize&lt;Customer&gt;(event.data)&#10;                    }&#10;                    &quot;product&quot; -&gt; {&#10;                        val product: Product? = deserialize&lt;Product&gt;(event.data)&#10;                    }&#10;                }&#10;            }&#10;        }"/>
+            <p>完全な例については、
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-sse">client-sse</a> を参照してください。
+            </p>
+        </chapter>
+    </chapter>
+</topic>

--- a/docs/ja/ktor/client-websockets.md
+++ b/docs/ja/ktor/client-websockets.md
@@ -1,0 +1,146 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="client-websockets" title="Ktor ClientにおけるWebSockets">
+<show-structure for="chapter" depth="3"/>
+<primary-label ref="client-plugin"/>
+<var name="example_name" value="client-websockets"/>
+<var name="artifact_name" value="ktor-client-websockets"/>
+<tldr>
+    <p>
+        <b>必要な依存関係</b>: <code>io.ktor:ktor-client-websockets</code>
+    </p>
+    <p>
+        <b>コード例</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+</tldr>
+<link-summary>
+    WebSocketsプラグインを使用すると、サーバーとクライアント間で多方向の通信セッションを作成できます。
+</link-summary>
+WebSocketは、単一のTCP接続を介してユーザーのブラウザとサーバー間にフルデュプレックス（全二重）通信セッションを提供するプロトコルです。これは、サーバーとの間でのリアルタイムのデータ転送が必要なアプリケーションを作成する場合に特に有用です。
+Ktorは、サーバー側とクライアント側の両方でWebSocketプロトコルをサポートしています。
+<p>クライアント用のWebSocketsプラグインを使用すると、サーバーとメッセージを交換するためのWebSocketセッションを処理できます。</p>
+<note>
+    <p>すべてのエンジンがWebSocketsをサポートしているわけではありません。サポートされているエンジンの概要については、<a href="client-engines.md#limitations">制限事項</a>を参照してください。</p>
+</note>
+<tip>
+    <p>サーバー側のWebSocketサポートについては、<Links href="//server-websockets" summary="WebSocketsプラグインを使用すると、サーバーとクライアント間で多方向の通信セッションを作成できます。">Ktor ServerにおけるWebSockets</Links>を参照してください。</p>
+</tip>
+<chapter title="依存関係の追加" id="add_dependencies">
+    <p><code>WebSockets</code>を使用するには、ビルドスクリプトに <code>%artifact_name%</code> アーティファクトを含める必要があります。</p>
+    <Tabs group="languages">
+        <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+            <code-block lang="Kotlin" code="                    implementation(&quot;io.ktor:%artifact_name%:$ktor_version&quot;)"/>
+        </TabItem>
+        <TabItem title="Gradle (Groovy)" group-key="groovy">
+            <code-block lang="Groovy" code="                    implementation &quot;io.ktor:%artifact_name%:$ktor_version&quot;"/>
+        </TabItem>
+        <TabItem title="Maven" group-key="maven">
+            <code-block lang="XML" code="                    &lt;dependency&gt;&#10;                        &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                        &lt;artifactId&gt;%artifact_name%-jvm&lt;/artifactId&gt;&#10;                        &lt;version&gt;${ktor_version}&lt;/version&gt;&#10;                    &lt;/dependency&gt;"/>
+        </TabItem>
+    </Tabs>
+    <tip>
+        Ktorクライアントに必要なアーティファクトの詳細については、<Links href="//client-dependencies" summary="既存のプロジェクトにクライアントの依存関係を追加する方法を学びます。">クライアントの依存関係の追加</Links>を参照してください。
+    </tip>
+</chapter>
+<chapter title="WebSocketsのインストール" id="install_plugin">
+    <p><code>WebSockets</code>プラグインをインストールするには、<a href="#configure-client">クライアント設定ブロック</a>内の <code>install</code> 関数に渡します。</p>
+    <code-block lang="kotlin" code="            import io.ktor.client.*&#10;            import io.ktor.client.engine.cio.*&#10;            import io.ktor.client.plugins.websocket.*&#10;&#10;            //...&#10;            val client = HttpClient(CIO) {&#10;                install(WebSockets)&#10;            }"/>
+</chapter>
+<chapter title="設定" id="configure_plugin">
+    <p>オプションで、<a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/-web-sockets/-config/index.html">WebSockets.Config</a> のサポートされているプロパティを渡すことで、<code>install</code> ブロック内でプラグインを設定できます。
+    </p>
+    <deflist>
+        <def id="maxFrameSize">
+            <title><code>maxFrameSize</code></title>
+            受信または送信可能な <code>Frame</code> の最大サイズを設定します。
+        </def>
+        <def id="contentConverter">
+            <title><code>contentConverter</code></title>
+            シリアライズ/デシリアライズ用のコンバーターを設定します。
+        </def>
+        <def id="pingIntervalMillis">
+            <title><code>pingIntervalMillis</code></title>
+            pingの間隔を <code>Long</code> 形式で指定します。
+        </def>
+        <def id="pingInterval">
+            <title><code>pingInterval</code></title>
+            pingの間隔を <code>Duration</code> 形式で指定します。
+        </def>
+    </deflist>
+    <warning>
+        <p><code>pingInterval</code> および <code>pingIntervalMillis</code> プロパティは、OkHttpエンジンには適用されません。OkHttpのping間隔を設定するには、<a href="#okhttp">エンジン設定</a>を使用できます。
+        </p>
+        <code-block lang="kotlin" code="                import io.ktor.client.engine.okhttp.OkHttp&#10;&#10;                val client = HttpClient(OkHttp) {&#10;                    engine {&#10;                        preconfigured = OkHttpClient.Builder()&#10;                            .pingInterval(20, TimeUnit.SECONDS)&#10;                            .build()&#10;                    }&#10;                }"/>
+    </warning>
+    <p>
+        以下の例では、WebSocketsプラグインを20秒（<code>20_000</code>ミリ秒）のping間隔で設定し、pingフレームを自動的に送信してWebSocket接続を維持するようにしています。
+    </p>
+    <code-block lang="kotlin" code="    val client = HttpClient(CIO) {&#10;        install(WebSockets) {&#10;            pingIntervalMillis = 20_000&#10;        }&#10;    }"/>
+</chapter>
+<chapter title="WebSocketセッションの操作" id="working-wtih-session">
+    <p>クライアントのWebSocketセッションは、<a href="https://api.ktor.io/ktor-websockets/io.ktor.websocket/-default-web-socket-session/index.html">DefaultClientWebSocketSession</a> インターフェースによって表されます。このインターフェースは、WebSocketフレームの送受信やセッションのクローズを可能にするAPIを公開しています。
+    </p>
+    <chapter title="WebSocketセッションへのアクセス" id="access-session">
+        <p>
+            <code>HttpClient</code> は、WebSocketセッションにアクセスするための2つの主要な方法を提供します。
+        </p>
+        <list>
+            <li>
+                <p><a
+                        href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/web-socket.html">webSocket()</a>
+                    関数は、ブロック引数として <code>DefaultClientWebSocketSession</code> を受け取ります。</p>
+                <code-block lang="kotlin" code="                        runBlocking {&#10;                            client.webSocket(&#10;                                method = HttpMethod.Get,&#10;                                host = &quot;127.0.0.1&quot;,&#10;                                port = 8080,&#10;                                path = &quot;/echo&quot;&#10;                            ) {&#10;                                // this: DefaultClientWebSocketSession&#10;                            }&#10;                        }"/>
+            </li>
+            <li>
+                <a
+                    href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/web-socket-session.html">webSocketSession()</a>
+                関数は <code>DefaultClientWebSocketSession</code> インスタンスを返し、<code>runBlocking</code> や <code>launch</code> スコープの外でセッションにアクセスすることを可能にします。
+            </li>
+        </list>
+    </chapter>
+    <chapter title="WebSocketセッションの処理" id="handle-session">
+        <p>関数ブロック内で、指定されたパスのハンドラーを定義します。ブロック内では以下の関数とプロパティが利用可能です。</p>
+        <deflist>
+            <def id="send">
+                <title><code>send()</code></title>
+                サーバーにテキストコンテンツを送信するには、<code>send()</code> 関数を使用します。
+            </def>
+            <def id="outgoing">
+                <title><code>outgoing</code></title>
+                WebSocketフレームを送信するためのチャネルにアクセスするには、<code>outgoing</code> プロパティを使用します。フレームは <code>Frame</code> クラスによって表されます。
+            </def>
+            <def id="incoming">
+                <title><code>incoming</code></title>
+                WebSocketフレームを受信するためのチャネルにアクセスするには、<code>incoming</code> プロパティを使用します。フレームは <code>Frame</code> クラスによって表されます。
+            </def>
+            <def id="close">
+                <title><code>close()</code></title>
+                指定された理由でクローズフレームを送信するには、<code>close()</code> 関数を使用します。
+            </def>
+        </deflist>
+    </chapter>
+    <chapter title="フレームの種類" id="frame-types">
+        <p>
+            WebSocketフレームのタイプを確認し、それに応じて処理できます。一般的なフレームタイプは以下の通りです。
+        </p>
+        <list>
+            <li><code>Frame.Text</code> はテキストフレームを表します。内容を読み取るには <code>Frame.Text.readText()</code> を使用します。
+            </li>
+            <li><code>Frame.Binary</code> はバイナリフレームを表します。内容を読み取るには <code>Frame.Binary.readBytes()</code> を使用します。
+            </li>
+            <li><code>Frame.Close</code> はクローズフレームを表します。セッション終了の理由を取得するには <code>Frame.Close.readReason()</code> を使用します。
+            </li>
+        </list>
+    </chapter>
+    <chapter title="例" id="example">
+        <p>以下の例では、<code>echo</code> WebSocketエンドポイントを作成し、サーバーとの間でメッセージを送受信する方法を示します。</p>
+        <code-block lang="kotlin"
+                    include-symbol="main" code="package com.example&#10;&#10;import io.ktor.client.*&#10;import io.ktor.client.engine.cio.*&#10;import io.ktor.client.plugins.websocket.*&#10;import io.ktor.http.*&#10;import io.ktor.websocket.*&#10;import kotlinx.coroutines.*&#10;import java.util.*&#10;&#10;fun main() {&#10;    val client = HttpClient(CIO) {&#10;        install(WebSockets) {&#10;            pingIntervalMillis = 20_000&#10;        }&#10;    }&#10;    runBlocking {&#10;        client.webSocket(method = HttpMethod.Get, host = &quot;127.0.0.1&quot;, port = 8080, path = &quot;/echo&quot;) {&#10;            while(true) {&#10;                val othersMessage = incoming.receive() as? Frame.Text&#10;                println(othersMessage?.readText())&#10;                val myMessage = Scanner(System.`in`).next()&#10;                if(myMessage != null) {&#10;                    send(myMessage)&#10;                }&#10;            }&#10;        }&#10;    }&#10;    client.close()&#10;}"/>
+        <p>完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-websockets">client-websockets</a> を参照してください。
+        </p>
+    </chapter>
+</chapter>
+</topic>

--- a/docs/ja/ktor/docker-compose.md
+++ b/docs/ja/ktor/docker-compose.md
@@ -1,0 +1,123 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="docker-compose" title="Docker Compose">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <p>
+        <control>初期プロジェクト</control>
+        : <a
+            href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-db-integration">tutorial-server-db-integration</a>
+    </p>
+    <p>
+        <control>最終プロジェクト</control>
+        : <a
+            href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-docker-compose">tutorial-server-docker-compose</a>
+    </p>
+</tldr>
+<p>このトピックでは、<a href="https://docs.docker.com/compose/">Docker Compose</a>の下でサーバーKtorアプリケーションを実行する方法を紹介します。ここでは、<Links href="//server-integrate-database" summary="Exposed SQLライブラリを使用してKtorサービスをデータベースリポジトリに接続するプロセスを学びます。">データベースの統合</Links>チュートリアルで作成したプロジェクトを使用します。このプロジェクトでは、<a href="https://github.com/JetBrains/Exposed">Exposed</a>を使用して<a href="https://www.postgresql.org/docs/">PostgreSQL</a>データベースに接続しており、データベースとWebアプリケーションは別々に動作します。</p>
+<chapter title="アプリケーションの準備" id="prepare-app">
+    <chapter title="データベース設定の抽出" id="extract-db-settings">
+        <p>
+            <a href="server-integrate-database.topic#config-db-connection">データベース接続の設定</a>チュートリアルで作成されたプロジェクトでは、データベース接続を確立するためにハードコードされた属性を使用しています。</p>
+        <p>
+            PostgreSQLデータベースの接続設定を<Links href="//server-configuration-file" summary="設定ファイルでさまざまなサーバーパラメータを設定する方法を学びます。">カスタム設定グループ</Links>に抽出しましょう。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    <Path>src/main/resources</Path>にある<Path>application.yaml</Path>ファイルを開き、以下のように<code>ktor</code>グループの外側に<code>storage</code>グループを追加します。
+                </p>
+                <code-block lang="yaml" code="ktor:&#10;  application:&#10;    modules:&#10;      - com.example.ApplicationKt.module&#10;  deployment:&#10;    port: 8080&#10;storage:&#10;  driverClassName: &quot;org.postgresql.Driver&quot;&#10;  jdbcURL: &quot;jdbc:postgresql://localhost:5432/ktor_tutorial_db&quot;&#10;  user: &quot;postgres&quot;&#10;  password: &quot;password&quot;"/>
+                <p>これらの設定は、後で<a href="#configure-docker">
+                    <Path>compose.yml</Path>
+                </a>ファイルで構成されます。
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>src/main/kotlin/com/example/plugins/</Path>にある<Path>Databases.kt</Path>ファイルを開き、設定ファイルからストレージ設定をロードするように<code>configureDatabases()</code>関数を更新します。
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureDatabases(config: ApplicationConfig) {&#10;    val url = config.property(&quot;storage.jdbcURL&quot;).getString()&#10;    val user = config.property(&quot;storage.user&quot;).getString()&#10;    val password = config.property(&quot;storage.password&quot;).getString()&#10;&#10;    Database.connect(&#10;        url,&#10;        user = user,&#10;        password = password&#10;    )&#10;}"/>
+                <p>
+                    <code>configureDatabases()</code>関数は<code>ApplicationConfig</code>を受け取るようになり、<code>config.property</code>を使用してカスタム設定をロードします。
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>src/main/kotlin/com/example/</Path>にある<Path>Application.kt</Path>ファイルを開き、アプリケーション起動時に接続設定をロードするために<code>environment.config</code>を<code>configureDatabases()</code>に渡します。
+                </p>
+                <code-block lang="kotlin" code="fun Application.module() {&#10;    val repository = PostgresTaskRepository()&#10;&#10;    configureSerialization(repository)&#10;    configureDatabases(environment.config)&#10;    configureRouting()&#10;}"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="Ktorプラグインの設定" id="configure-ktor-plugin">
+        <p>Dockerで実行するには、アプリケーションに必要なすべてのファイルがコンテナにデプロイされている必要があります。使用しているビルドシステムに応じて、これを実現するためのさまざまなプラグインがあります。</p>
+        <list>
+            <li><Links href="//server-fatjar" summary="Ktor Gradleプラグインを使用して実行可能なfat JARを作成して実行する方法を学びます。">Ktor Gradleプラグインを使用したfat JARの作成</Links></li>
+            <li><Links href="//maven-assembly-plugin" summary="サンプルプロジェクト: tutorial-server-get-started-maven">Maven Assemblyプラグインを使用したfat JARの作成</Links></li>
+        </list>
+        <p>この例では、Ktorプラグインはすでに<Path>build.gradle.kts</Path>ファイルに適用されています。
+        </p>
+        <code-block lang="kotlin" code="plugins {&#10;    application&#10;    kotlin(&quot;jvm&quot;)&#10;    id(&quot;io.ktor.plugin&quot;) version &quot;3.5.1&quot;&#10;    id(&quot;org.jetbrains.kotlin.plugin.serialization&quot;) version &quot;2.2.20&quot;&#10;}"/>
+    </chapter>
+</chapter>
+<chapter title="Dockerの設定" id="configure-docker">
+    <chapter title="Dockerイメージの準備" id="prepare-docker-image">
+        <p>
+            アプリケーションをDocker化（Dockerize）するには、プロジェクトのルートディレクトリに新しい<Path>Dockerfile</Path>を作成し、以下の内容を挿入します。
+        </p>
+        <code-block lang="Docker" code="# Stage 1: Cache Gradle dependencies&#10;FROM gradle:latest AS cache&#10;RUN mkdir -p /home/gradle/cache_home&#10;ENV GRADLE_USER_HOME=/home/gradle/cache_home&#10;COPY build.gradle.* gradle.properties /home/gradle/app/&#10;COPY gradle /home/gradle/app/gradle&#10;WORKDIR /home/gradle/app&#10;RUN gradle dependencies --no-daemon&#10;&#10;# Stage 2: Build Application&#10;FROM gradle:latest AS build&#10;COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle&#10;COPY --chown=gradle:gradle . /home/gradle/src&#10;WORKDIR /home/gradle/src&#10;# Build the fat JAR, Gradle also supports shadow&#10;# and boot JAR by default.&#10;RUN gradle buildFatJar --no-daemon&#10;&#10;# Stage 3: Create the Runtime Image&#10;FROM amazoncorretto:22 AS runtime&#10;EXPOSE 8080&#10;RUN mkdir /app&#10;COPY --from=build /home/gradle/src/build/libs/*.jar /app/ktor-docker-sample.jar&#10;ENTRYPOINT [&quot;java&quot;,&quot;-jar&quot;,&quot;/app/ktor-docker-sample.jar&quot;]"/>
+        <tip>
+            このマルチステージビルド（multi-stage build）の仕組みの詳細については、<a href="docker.md#prepare-docker">Dockerイメージの準備</a>を参照してください。
+        </tip>
+        <p>
+            この例では Amazon Corretto の Docker イメージを使用していますが、以下のような他の適切な代替イメージに置き換えることもできます。
+        </p>
+        <list>
+          <li><a href="https://hub.docker.com/_/eclipse-temurin">Eclipse Temurin</a></li>
+          <li><a href="https://hub.docker.com/_/ibm-semeru-runtimes">IBM Semeru</a></li>
+          <li><a href="https://hub.docker.com/_/ibmjava">IBM Java</a></li>
+          <li><a href="https://hub.docker.com/_/sapmachine">SAP Machine JDK</a></li>
+        </list>
+    </chapter>
+    <chapter title="Docker Composeの設定" id="configure-docker-compose">
+        <p>プロジェクトのルートディレクトリに新しい<Path>compose.yml</Path>ファイルを作成し、以下の内容を追加します。
+        </p>
+        <code-block lang="yaml" code="services:&#10;  web:&#10;    build: .&#10;    ports:&#10;      - &quot;8080:8080&quot;&#10;    depends_on:&#10;      db:&#10;        condition: service_healthy&#10;  db:&#10;    image: postgres&#10;    volumes:&#10;      - ./tmp/db:/var/lib/postgresql/data&#10;    environment:&#10;      POSTGRES_DB: ktor_tutorial_db&#10;      POSTGRES_HOST_AUTH_METHOD: trust&#10;    ports:&#10;      - &quot;5432:5432&quot;&#10;    healthcheck:&#10;      test: [ &quot;CMD-SHELL&quot;, &quot;pg_isready -U postgres&quot; ]&#10;      interval: 1s"/>
+        <list>
+            <li><code>web</code>サービスは、<a href="#prepare-docker-image">イメージ</a>内にパッケージ化されたKtorアプリケーションを実行するために使用されます。
+            </li>
+            <li><code>db</code>サービスは、<code>postgres</code>イメージを使用して、タスクを保存するための<code>ktor_tutorial_db</code>データベースを作成します。
+            </li>
+        </list>
+    </chapter>
+</chapter>
+<chapter title="サービスのビルドと実行" id="build-run">
+    <procedure>
+        <step>
+            <p>
+                以下のコマンドを実行して、Ktorアプリケーションを含む<a href="#configure-ktor-plugin">fat JAR</a>を作成します。
+            </p>
+            <code-block lang="Bash" code="                    ./gradlew :tutorial-server-docker-compose:buildFatJar"/>
+        </step>
+        <step>
+            <p>
+                <code>docker compose up</code>コマンドを使用して、イメージをビルドしコンテナを起動します。
+            </p>
+            <code-block lang="Bash" code="                    docker compose --project-directory snippets/tutorial-server-docker-compose up"/>
+        </step>
+        <step>
+            Docker Composeがイメージのビルドを完了するまで待ちます。
+        </step>
+        <step>
+            <p>
+                <a href="http://localhost:8080/static/index.html">http://localhost:8080/static/index.html</a>にアクセスしてWebアプリケーションを開きます。タスクのフィルタリングと新規追加のための3つのフォーム、およびタスクのテーブルが表示されたTask Manager Clientページが表示されるはずです。
+            </p>
+            <img src="tutorial_server_db_integration_manual_test.gif"
+                 alt="Task Manager Clientを表示しているブラウザウィンドウ"
+                 border-effect="rounded"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+</topic>

--- a/docs/ja/ktor/full-stack-development-with-kotlin-multiplatform.md
+++ b/docs/ja/ktor/full-stack-development-with-kotlin-multiplatform.md
@@ -1,0 +1,643 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Kotlin Multiplatformでフルスタックアプリケーションを構築する" id="full-stack-development-with-kotlin-multiplatform">
+<show-structure for="chapter, procedure" depth="2"/>
+<web-summary>
+    KotlinとKtorを使用して、クロスプラットフォームのフルスタックアプリケーションを開発する方法を学びます。このチュートリアルでは、Kotlin Multiplatformを使用してAndroid、iOS、デスクトップ向けにビルドし、Ktorを使用してデータを簡単に処理する方法を紹介します。
+</web-summary>
+<link-summary>
+    KotlinとKtorを使用して、クロスプラットフォームのフルスタックアプリケーションを開発する方法を学びます。
+</link-summary>
+<card-summary>
+    KotlinとKtorを使用して、クロスプラットフォームのフルスタックアプリケーションを開発する方法を学びます。
+</card-summary>
+<tldr>
+    <var name="example_name" value="full-stack-task-manager"/>
+    <p>
+        <b>コード例</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+    <p>
+        <b>使用されているプラグイン</b>: <Links href="//server-routing" summary="Routingは、サーバーアプリケーションで受信リクエストを処理するためのコアプラグインです。">Routing</Links>、
+        <a href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>、
+        <Links href="//server-serialization" summary="ContentNegotiationプラグインは、クライアントとサーバー間のメディアタイプの交渉と、特定の形式でのコンテンツのシリアライズ/デシリアライズという2つの主要な目的を果たします。">Content Negotiation</Links>、
+        <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a>、
+        <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">Kotlin Multiplatform</a>
+    </p>
+</tldr>
+<p>
+    この記事では、Android、iOS、Web、デスクトップの各プラットフォームで動作し、Ktorを活用してシームレスなデータ処理を行うフルスタックアプリケーションをKotlinで開発する方法を学びます。
+</p>
+<p>このチュートリアルの終わりまでに、以下のことができるようになります：</p>
+<list>
+    <li><a
+            href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">
+        Kotlin Multiplatform</a>を使用してフルスタックアプリケーションを作成する。
+    </li>
+    <li>IntelliJ IDEAで生成されたプロジェクトの構造を理解する。</li>
+    <li>Ktorサービスを呼び出す<a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a>クライアントを作成する。
+    </li>
+    <li>設計の異なるレイヤー間で共有型を再利用する。</li>
+    <li>マルチプラットフォームライブラリを正しく導入し、設定する。</li>
+</list>
+<p>
+    これまでのチュートリアルでは、タスクマネージャーの例を使用して、
+    <Links href="//server-requests-and-responses" summary="KotlinとKtorでタスクマネージャーアプリケーションを構築することで、ルーティング、リクエスト処理、パラメータの基本を学びます。">リクエストの処理</Links>、
+    <Links href="//server-create-restful-apis" summary="KotlinとKtorを使用して、JSONファイルを生成するRESTful APIの例を含むバックエンドサービスの構築方法を学びます。">RESTful APIの作成</Links>、
+    <Links href="//server-integrate-database" summary="Exposed SQLライブラリを使用して、Ktorサービスをデータベースリポジトリに接続するプロセスを学びます。">Exposedによるデータベースの統合</Links>を行いました。
+    Ktorの基礎学習に集中できるよう、クライアントアプリケーションは可能な限り最小限に抑えられていました。
+</p>
+<p>
+    今回は、Android、iOS、Web、デスクトップのプラットフォームを対象としたクライアントを作成し、Ktorサービスを使用して表示するデータを取得します。可能な限りクライアントとサーバー間でデータ型を共有することで、開発をスピードアップし、エラーの可能性を減らします。
+</p>
+<chapter title="前提条件" id="prerequisites">
+    <p>
+        これまでの記事と同様に、IDEとしてIntelliJ IDEAを使用します。環境のインストールと設定については、
+        <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/quickstart.html">
+            Kotlin Multiplatform クイックスタート
+        </a>
+        を参照してください。
+    </p>
+    <p>
+        Compose Multiplatformを初めて使用する場合は、このチュートリアルを開始する前に
+        <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-getting-started.html">
+            Compose Multiplatformを始める
+        </a>
+        チュートリアルを完了することをお勧めします。タスクの複雑さを軽減するために、単一のクライアントプラットフォームに集中することもできます。例えば、iOSを使用したことがない場合は、デスクトップまたはAndroidの開発に集中するのが賢明かもしれません。
+    </p>
+</chapter>
+<chapter title="新しいプロジェクトを作成する" id="create-project">
+    <p>
+        Ktorプロジェクトジェネレーターの代わりに、IntelliJ IDEAのKotlin Multiplatformプロジェクトウィザードを使用します。
+        これにより、クライアントとサービスを追加して拡張できる基本的なマルチプラットフォームプロジェクトが作成されます。クライアントはSwiftUIなどのネイティブUIライブラリを使用することもできますが、このチュートリアルでは
+        <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a>を使用して、すべてのプラットフォームで共通の共有UIを作成します。
+    </p>
+    <procedure id="generate-project">
+        <step>
+            IntelliJ IDEAを起動します。
+        </step>
+        <step>
+            IntelliJ IDEAで
+            <ui-path>File | New | Project</ui-path>
+            を選択します。
+        </step>
+        <step>
+            左側のパネルで
+            <ui-path>Kotlin Multiplatform</ui-path>
+            を選択します。
+        </step>
+        <step>
+            <ui-path>New Project</ui-path>
+            ウィンドウで以下のフィールドを指定します：
+            <list>
+                <li>
+                    <ui-path>Name</ui-path>
+                    : full-stack-task-manager
+                </li>
+                <li>
+                    <ui-path>Project ID</ui-path>
+                    : com.example.ktor
+                </li>
+            </list>
+        </step>
+        <step>
+            <p>
+                ターゲットプラットフォームとして
+                <ui-path>Android</ui-path>、
+                <ui-path>Desktop</ui-path>、
+                <ui-path>Web</ui-path>、
+                <ui-path>Server</ui-path>
+                を選択します。
+            </p>
+        </step>
+        <step>
+            <p>
+                Macを使用している場合は、
+                <ui-path>iOS</ui-path>
+                も選択してください。
+                <ui-path>Share UI</ui-path>
+                オプションが選択されていることを確認してください。
+                <img style="block" src="full_stack_development_tutorial_create_project.png"
+                     alt="Kotlin Multiplatformウィザードの設定" width="706" border-effect="rounded"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                <control>Create</control>
+                ボタンをクリックし、IDEがプロジェクトを生成してインポートするまで待ちます。
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="サービスを実行する" id="run-service">
+    <procedure id="run-service-procedure">
+        <step>
+            IntelliJ IDEAで
+            <Path>ApplicationKt</Path>
+            実行構成を選択します。
+            <img src="full_stack_development_tutorial_server_run_configuration.png"
+                 alt="実行とデバッグのウィンドウ" width="300"
+                 border-effect="line" style="block"/>
+        </step>
+        <step>
+            <ui-path>実行</ui-path>
+            ボタン
+            (<img src="intellij_idea_run_icon.svg"
+                  style="inline" height="16" width="16"
+                  alt="IntelliJ IDEAの実行アイコン"/>)
+            をクリックして構成を実行します。
+            <p>
+                <ui-path>実行</ui-path>
+                ツールウィンドウに新しいタブが開きます。
+            </p>
+        </step>
+        <step>
+            <p>
+                ブラウザで <a href="http://0.0.0.0:8080/">http://0.0.0.0:8080/</a> にアクセスしてアプリケーションを開きます。
+                ブラウザにKtorからのメッセージが表示されるはずです。
+                <img src="full_stack_development_tutorial_run.png"
+                     alt="ブラウザに表示されたKtorサーバーのレスポンス" width="706"
+                     border-effect="rounded" style="block"/>
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="プロジェクトを詳しく見る" id="examine-project">
+    <p>
+        <Path>server</Path>
+        フォルダーは、プロジェクト内にある3つのKotlinモジュールの1つです。残りの2つは
+        <Path>core</Path>
+        と
+        <Path>app</Path>
+        です。
+    </p>
+    <p>
+        <Path>server</Path>
+        モジュールの構造は、<a href="https://start.ktor.io/">Ktorプロジェクトジェネレーター</a>で生成されたものと非常によく似ています。
+        プラグインと依存関係を宣言するための専用のビルドファイルがあり、Ktorサービスをビルドして起動するためのコードを含むソースセットがあります：
+    </p>
+    <img src="full_stack_development_tutorial_server_folder.png"
+         alt="Kotlin Multiplatformプロジェクト内のserverフォルダーの内容" width="300"
+         border-effect="line"/>
+    <p>
+        <Path>Application.kt</Path>
+        ファイル内のルーティング手順を見ると、<code>sayHello()</code>関数の呼び出しがあることがわかります：
+    </p>
+    <code-block lang="kotlin" code="            fun Application.module() {&#10;                routing {&#10;                    get(&quot;/&quot;) {&#10;                        call.respondText(sayHello(&quot;Ktor&quot;))&#10;                    }&#10;                }&#10;            }"/>
+    <p>
+        <code>sayHello()</code>関数は
+        <Path>core</Path>
+        モジュールで定義されています。ここには、サーバーとすべての異なるクライアントプラットフォーム間で共有される共通コードを配置します。
+    </p>
+    <p>
+       <Path>app/shared/src/commonMain</Path> モジュール内の <Path>Greeting.kt</Path> ファイルを開くと、そこでも
+        <code>sayHello()</code> 関数が使用されていることがわかります：
+    </p>
+    <code-block lang="kotlin" code="            class Greeting {&#10;                private val platform = getPlatform()&#10;&#10;                fun greet(): String {&#10;                    return sayHello(platform.name)&#10;                }&#10;            }"/>
+    <p>
+        <Path>app</Path> モジュールには以下のサブモジュールが含まれています：
+    </p>
+    <list>
+        <li>
+            <Path>androidApp</Path>、<Path>desktopApp</Path>、<Path>iosApp</Path>、<Path>webApp</Path> サブモジュールには、それぞれ Android、デスクトップ、iOS、Web クライアントアプリ用のプラットフォーム固有のコードが含まれています。現時点では、これらのクライアントアプリはいずれも Ktor サービスにリンクされていません。
+        </li>
+        <li>
+            <p>
+                <Path>shared</Path>
+                サブモジュールには、クライアントを提供したい各プラットフォーム用のソースセットが含まれています。これは、
+                <Path>commonMain</Path>
+                内で宣言された型が、ターゲットプラットフォームによって異なる機能を必要とするためです。
+            </p>
+            <p>
+                たとえば、<code>Greeting</code> 型では、<a
+                    href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-connect-to-apis.html">期待宣言と実効宣言 (expected and actual declarations)</a> を通じて、プラットフォーム固有の API を使用して現在のプラットフォームの名前を取得します。
+            </p>
+            <p>
+                <Path>shared</Path>
+                サブモジュールの
+                <Path>commonMain</Path>
+                ソースセットでは、<code>getPlatform()</code> 関数が <code>expect</code> キーワードとともに宣言されています：
+            </p>
+            <Tabs>
+                <TabItem title="commonMain/Platform.kt" id="commonMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;interface Platform {&#10;    val name: String&#10;}&#10;&#10;expect fun getPlatform(): Platform"/>
+                </TabItem>
+            </Tabs>
+            <p>
+                次に、以下に示すように、各ターゲットプラットフォームが <code>getPlatform()</code> 関数の <code>actual</code> 宣言を提供します：
+            </p>
+            <Tabs>
+                <TabItem title="Platform.ios.kt" id="iosMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import platform.UIKit.UIDevice&#10;&#10;class IOSPlatform : Platform {&#10;    override val name: String = UIDevice.currentDevice.systemName() + &quot; &quot; + UIDevice.currentDevice.systemVersion&#10;}&#10;&#10;actual fun getPlatform(): Platform = IOSPlatform()"/>
+                </TabItem>
+                <TabItem title="Platform.android.kt" id="androidMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import android.os.Build&#10;&#10;class AndroidPlatform : Platform {&#10;    override val name: String = &quot;Android ${Build.VERSION.SDK_INT}&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = AndroidPlatform()"/>
+                </TabItem>
+                <TabItem title="Platform.jvm.kt" id="jvmMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;class JVMPlatform : Platform {&#10;    override val name: String = &quot;Java ${System.getProperty(&quot;java.version&quot;)}&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = JVMPlatform()"/>
+                </TabItem>
+                <TabItem title="Platform.wasmJs.kt" id="wasmJsMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;class WasmPlatform : Platform {&#10;    override val name: String = &quot;Web with Kotlin/Wasm&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = WasmPlatform()"/>
+                </TabItem>
+            </Tabs>
+        </li>
+    </list>
+</chapter>
+<chapter title="クライアントアプリケーションを実行する" id="run-client-app">
+    <p>
+        ターゲットの実行構成を実行することで、クライアントアプリケーションを起動できます。iOSシミュレーターでアプリケーションを実行するには、以下の手順に従ってください：
+    </p>
+    <procedure id="run-ios-app-procedure">
+        <step>
+            IntelliJ IDEAで、
+            <Path>iosApp</Path>
+            の実行構成とシミュレートされたデバイスを選択します。
+            <img src="full_stack_development_tutorial_run_configurations.png"
+                 alt="実行とデバッグのウィンドウ" width="400"
+                 border-effect="line" style="block"/>
+        </step>
+        <step>
+            <ui-path>実行</ui-path>
+            ボタン
+            (<img src="intellij_idea_run_icon.svg"
+                  style="inline" height="16" width="16"
+                  alt="IntelliJ IDEAの実行アイコン"/>)
+            をクリックして構成を実行します。
+        </step>
+        <step>
+            <p>
+                iOSアプリを実行すると、バックグラウンドでXcodeを使用してビルドされ、iOSシミュレーターで起動されます。
+                アプリには、クリックで画像を切り替えるボタンが表示されます。
+                <img style="block" src="full_stack_development_tutorial_run_ios.gif"
+                     alt="iOSシミュレーターでのアプリの実行" width="300" border-effect="rounded"/>
+            </p>
+            <p>
+                ボタンが初めて押されると、現在のプラットフォームの詳細がそのテキストに追加されます。これを実現するコードは
+                <Path>app/shared/src/commonMain/kotlin/com/example/ktor/App.kt</Path>
+                にあります：
+            </p>
+            <code-block lang="kotlin" code="                @Composable&#10;                @Preview&#10;                fun App() {&#10;                    MaterialTheme {&#10;                        var showContent by remember { mutableStateOf(false) }&#10;                        Column(&#10;                            modifier = Modifier&#10;                                .background(MaterialTheme.colorScheme.primaryContainer)&#10;                                .safeContentPadding()&#10;                                .fillMaxSize(),&#10;                            horizontalAlignment = Alignment.CenterHorizontally,&#10;                        ) {&#10;                            Button(onClick = { showContent = !showContent }) {&#10;                                Text(&quot;Click me!&quot;)&#10;                            }&#10;                            AnimatedVisibility(showContent) {&#10;                                val greeting = remember { Greeting().greet() }&#10;                                Column(&#10;                                    modifier = Modifier.fillMaxWidth(),&#10;                                    horizontalAlignment = Alignment.CenterHorizontally,&#10;                                ) {&#10;                                    Image(painterResource(Res.drawable.compose_multiplatform), null)&#10;                                    Text(&quot;Compose: $greeting&quot;)&#10;                                }&#10;                            }&#10;                        }&#10;                    }&#10;                }"/>
+            <p>
+                これはコンポーザブル関数であり、この記事の後半で修正します。現時点で重要なのは、これがUIを表示し、共有された <code>Greeting</code> 型を利用しているということです。そして、この型は共通の <code>Platform</code> インターフェースを実装するプラットフォーム固有のクラスを使用しています。
+            </p>
+        </step>
+    </procedure>
+    <p>
+        生成されたプロジェクトの構造を理解したところで、タスクマネージャーの機能を段階的に追加していきましょう。
+    </p>
+</chapter>
+<chapter title="モデル型を追加する" id="add-model-types">
+    <p>
+        まず、モデル型を追加し、クライアントとサーバーの両方からアクセスできるようにします。
+    </p>
+    <procedure id="add-model-types-procedure">
+        <step>
+            <Path>gradle/libs.versions.toml</Path>
+            に移動し、以下の <code>kotlinx.serialization</code> 依存関係を定義します：
+            <code-block lang="toml" code="[versions]&#10;kotlinx-serialization-json = &quot;1.11.0&quot;&#10;&#10;[libraries]&#10;kotlinx-serialization-json = { module = &quot;org.jetbrains.kotlinx:kotlinx-serialization-json&quot;, version.ref = &quot;kotlinx-serialization-json&quot; }&#10;&#10;[plugins]&#10;kotlinSerialization = { id = &quot;org.jetbrains.kotlin.plugin.serialization&quot;, version.ref = &quot;kotlin&quot; }"/>
+        </step>
+        <step>
+            <p>
+                <Path>core/build.gradle.kts</Path>
+                に移動し、シリアライズプラグインを追加します：
+            </p>
+            <code-block lang="kotlin" code="plugins {&#10;    //...&#10;    alias(libs.plugins.kotlinSerialization)&#10;}"/>
+        </step>
+        <step>
+            <p>
+                同じファイル内の
+                <Path>commonMain</Path>
+                ソースセットに新しい依存関係を追加します：
+            </p>
+            <code-block lang="kotlin" code="    sourceSets {&#10;        commonMain.dependencies {&#10;            // Multiplatformの依存関係をここに記述します&#10;            implementation(libs.kotlinx.serialization.json)&#10;        }&#10;        //...&#10;    }"/>
+        </step>
+        <step>
+            IntelliJ IDEAで、
+            <ui-path>Build | Sync Project with Gradle Files</ui-path>
+            を選択して更新を適用します。Gradleのインポートが完了すると、
+            <Path>Task.kt</Path>
+            ファイルが正常にコンパイルされるようになります。
+        </step>
+        <step>
+            <Path>core/src/commonMain/kotlin/com/example/ktor</Path>
+            に移動し、
+            <Path>model</Path>
+            という名前の新しいパッケージを作成します。
+        </step>
+        <step>
+            新しいパッケージの中に、
+            <Path>Task.kt</Path>
+            という名前の新しいファイルを作成します。
+        </step>
+        <step>
+            <p>
+                優先度を表す列挙型（enum）と、タスクを表すクラスを追加します。
+                <code>Task</code>
+                クラスは、<code>kotlinx.serialization</code>
+                ライブラリの <code>Serializable</code> 型でアノテーションされています：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="サーバーを作成する" id="create-server">
+    <p>
+        次の段階は、タスクマネージャーのサーバー実装を作成することです。
+    </p>
+    <procedure id="create-server-procedure">
+        <step>
+            <Path>server/src/main/kotlin/com/example/ktor</Path>
+            フォルダーに移動し、
+            <Path>model</Path>
+            というサブパッケージを作成します。
+        </step>
+        <step>
+            <p>
+                このパッケージ内に、新しい
+                <Path>TaskRepository.kt</Path>
+                ファイルを作成し、リポジトリ用の以下のインターフェースを追加します：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;interface TaskRepository {&#10;    fun allTasks(): List&lt;Task&gt;&#10;    fun tasksByPriority(priority: Priority): List&lt;Task&gt;&#10;    fun taskByName(name: String): Task?&#10;    fun addOrUpdateTask(task: Task)&#10;    fun removeTask(name: String): Boolean&#10;}"/>
+        </step>
+        <step>
+            <p>
+                同じパッケージ内に、以下のクラスを含む
+                <Path>InMemoryTaskRepository.kt</Path>
+                という新しいファイルを作成します：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;class InMemoryTaskRepository : TaskRepository {&#10;    private var tasks = listOf(&#10;        Task(&quot;Cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;Gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;Shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;Painting&quot;, &quot;Paint the fence&quot;, Priority.Low),&#10;        Task(&quot;Cooking&quot;, &quot;Cook the dinner&quot;, Priority.Medium),&#10;        Task(&quot;Relaxing&quot;, &quot;Take a walk&quot;, Priority.High),&#10;        Task(&quot;Exercising&quot;, &quot;Go to the gym&quot;, Priority.Low),&#10;        Task(&quot;Learning&quot;, &quot;Read a book&quot;, Priority.Medium),&#10;        Task(&quot;Snoozing&quot;, &quot;Go for a nap&quot;, Priority.High),&#10;        Task(&quot;Socializing&quot;, &quot;Go to a party&quot;, Priority.High)&#10;    )&#10;&#10;    override fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    override fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    override fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    override fun addOrUpdateTask(task: Task) {&#10;        var notFound = true&#10;&#10;        tasks = tasks.map {&#10;            if (it.name == task.name) {&#10;                notFound = false&#10;                task&#10;            } else {&#10;                it&#10;            }&#10;        }&#10;        if (notFound) {&#10;            tasks = tasks.plus(task)&#10;        }&#10;    }&#10;&#10;    override fun removeTask(name: String): Boolean {&#10;        val oldTasks = tasks&#10;        tasks = tasks.filterNot { it.name == name }&#10;        return oldTasks.size &gt; tasks.size&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                <Path>server/src/main/kotlin/.../Application.kt</Path>
+                に移動し、既存のコードを以下の実装に置き換えます：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import com.example.ktor.model.InMemoryTaskRepository&#10;import com.example.ktor.model.Priority&#10;import com.example.ktor.model.Task&#10;import io.ktor.http.*&#10;import io.ktor.serialization.*&#10;import io.ktor.serialization.kotlinx.json.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.plugins.contentnegotiation.*&#10;import io.ktor.server.plugins.cors.routing.*&#10;import io.ktor.server.request.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;, module = Application::module)&#10;        .start(wait = true)&#10;}&#10;&#10;fun Application.module() {&#10;    install(ContentNegotiation) {&#10;        json()&#10;    }&#10;    install(CORS) {&#10;        allowHeader(HttpHeaders.ContentType)&#10;        allowMethod(HttpMethod.Delete)&#10;        // デモンストレーションを容易にするため、すべての接続を許可しています。&#10;        // 本番環境ではこのようにしないでください。&#10;        anyHost()&#10;    }&#10;    val repository = InMemoryTaskRepository()&#10;&#10;    routing {&#10;        route(&quot;/tasks&quot;) {&#10;            get {&#10;                val tasks = repository.allTasks()&#10;                call.respond(tasks)&#10;            }&#10;            get(&quot;/byName/{taskName}&quot;) {&#10;                val name = call.parameters[&quot;taskName&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                val task = repository.taskByName(name)&#10;                if (task == null) {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                    return@get&#10;                }&#10;                call.respond(task)&#10;            }&#10;            get(&quot;/byPriority/{priority}&quot;) {&#10;                val priorityAsText = call.parameters[&quot;priority&quot;]&#10;                if (priorityAsText == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(priorityAsText)&#10;                    val tasks = repository.tasksByPriority(priority)&#10;&#10;&#10;                    if (tasks.isEmpty()) {&#10;                        call.respond(HttpStatusCode.NotFound)&#10;                        return@get&#10;                    }&#10;                    call.respond(tasks)&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;            post {&#10;                try {&#10;                    val task = call.receive&lt;Task&gt;()&#10;                    repository.addOrUpdateTask(task)&#10;                    call.respond(HttpStatusCode.NoContent)&#10;                } catch (ex: IllegalStateException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                } catch (ex: JsonConvertException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;            delete(&quot;/{taskName}&quot;) {&#10;                val name = call.parameters[&quot;taskName&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@delete&#10;                }&#10;                if (repository.removeTask(name)) {&#10;                    call.respond(HttpStatusCode.NoContent)&#10;                } else {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                この実装は以前のチュートリアルと非常によく似ていますが、簡略化のためにすべてのルーティングコードを <code>Application.module()</code> 関数内に配置している点が異なります。
+            </p>
+            <p>
+                このコードを入力してインポートを追加すると、複数のコンパイルエラーが発生します。これは、Webクライアントとの対話に必要な <Links href="//server-cors" summary="必須の依存関係: io.ktor:%artifact_name%">CORS</Links> プラグインなど、依存関係として含める必要がある複数のKtorプラグインをコードが使用しているためです。
+            </p>
+        </step>
+        <step>
+            <Path>gradle/libs.versions.toml</Path>
+            ファイルを開き、以下のライブラリを定義します：
+            <code-block lang="toml" code="[libraries]&#10;ktor-serialization-kotlinx-json-jvm = { module = &quot;io.ktor:ktor-serialization-kotlinx-json-jvm&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-server-content-negotiation-jvm = { module = &quot;io.ktor:ktor-server-content-negotiation-jvm&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-server-cors-jvm = { module = &quot;io.ktor:ktor-server-cors-jvm&quot;, version.ref = &quot;ktor&quot; }"/>
+        </step>
+        <step>
+            <p>
+                サーバーモジュールのビルドファイル（
+                <Path>server/build.gradle.kts</Path>
+                ）を開き、以下の依存関係を追加します：
+            </p>
+            <code-block lang="kotlin" code="dependencies {&#10;    //...&#10;    implementation(libs.ktor.serialization.kotlinx.json-jvm)&#10;    implementation(libs.ktor.server.content-negotiation-jvm)&#10;    implementation(libs.ktor.server.cors-jvm)&#10;}"/>
+        </step>
+        <step>
+            もう一度、メインメニューから <ui-path>Build | Sync Project with Gradle Files</ui-path> を実行します。
+            インポートが完了すると、<code>ContentNegotiation</code> 型と <code>json()</code> 関数のインポートが正しく機能するはずです。
+        </step>
+        <step>
+            サーバーを再起動します。ブラウザからルートにアクセスできることが確認できるはずです。
+        </step>
+        <step>
+            <p>
+                <a href="http://0.0.0.0:8080/tasks"></a>
+                および <a href="http://0.0.0.0:8080/tasks/byPriority/Medium"></a>
+                にアクセスして、JSON形式のタスクが含まれるサーバーレスポンスを確認します。
+                <img style="block" src="full_stack_development_tutorial_run_server.gif"
+                     width="707" border-effect="rounded" alt="ブラウザでのサーバーレスポンス"/>
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="クライアントを作成する" id="create-client">
+    <p>
+        クライアントがサーバーにアクセスできるようにするには、Ktor Clientを含める必要があります。これには以下の3種類の依存関係が関係します：
+    </p>
+    <list>
+        <li>Ktor Clientのコア機能。</li>
+        <li>ネットワーク処理を行うプラットフォーム固有のエンジン。</li>
+        <li>コンテンツ交渉とシリアライズのサポート。</li>
+    </list>
+    <procedure id="create-client-procedure">
+        <step>
+            <Path>gradle/libs.versions.toml</Path>
+            ファイルに、以下のライブラリを追加します：
+            <code-block lang="toml" code="[libraries]&#10;ktor-client-android = { module = &quot;io.ktor:ktor-client-android&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-cio = { module = &quot;io.ktor:ktor-client-cio&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-content-negotiation = { module = &quot;io.ktor:ktor-client-content-negotiation&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-core = { module = &quot;io.ktor:ktor-client-core&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-darwin = { module = &quot;io.ktor:ktor-client-darwin&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-wasm = { module = &quot;io.ktor:ktor-client-js-wasm-js&quot;, version.ref = &quot;ktor&quot;}&#10;ktor-serialization-kotlinx-json = { module = &quot;io.ktor:ktor-serialization-kotlinx-json&quot;, version.ref = &quot;ktor&quot; }"/>
+        </step>
+        <step>
+            <Path>app/shared/build.gradle.kts</Path>
+            に移動し、以下の依存関係を追加します：
+            <code-block lang="kotlin" code="kotlin {&#10;    //...&#10;    sourceSets {&#10;        androidMain.dependencies {&#10;            //...&#10;            implementation(libs.ktor.client.android)&#10;        }&#10;        commonMain.dependencies {&#10;            //...&#10;            implementation(libs.ktor.client.core)&#10;            implementation(libs.ktor.client.content-negotiation)&#10;            implementation(libs.ktor.serialization.kotlinx.json)&#10;        }&#10;        jvmMain.dependencies {&#10;            implementation(libs.ktor.client.cio)&#10;        }&#10;        iosMain.dependencies {&#10;            implementation(libs.ktor.client.darwin)&#10;        }&#10;        wasmJsMain.dependencies {&#10;            implementation(libs.ktor.client.wasm)&#10;        }&#10;    }&#10;}"/>
+            <p>
+                これが完了したら、Ktor Clientの薄いラッパーとして機能する <code>TaskApi</code> 型をクライアントに追加できます。
+            </p>
+        </step>
+        <step>
+            メインメニューから <ui-path>Build | Sync Project with Gradle Files</ui-path> を選択して、ビルドファイルの変更をインポートします。
+        </step>
+        <step>
+            <Path>app/shared/src/commonMain/kotlin/com/example/ktor</Path>
+            に移動し、
+            <Path>network</Path>
+            という新しいパッケージを作成します。
+        </step>
+        <step>
+            <p>
+                新しいパッケージの中に、クライアント設定用の新しい
+                <Path>HttpClientManager.kt</Path>
+                ファイルを作成します：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.network&#10;&#10;import io.ktor.client.HttpClient&#10;import io.ktor.client.plugins.contentnegotiation.ContentNegotiation&#10;import io.ktor.client.plugins.defaultRequest&#10;import io.ktor.serialization.kotlinx.json.json&#10;import kotlinx.serialization.json.Json&#10;&#10;fun createHttpClient() = HttpClient {&#10;    install(ContentNegotiation) {&#10;        json(Json {&#10;            encodeDefaults = true&#10;            isLenient = true&#10;            coerceInputValues = true&#10;            ignoreUnknownKeys = true&#10;        })&#10;    }&#10;    defaultRequest {&#10;        host = &quot;1.2.3.4&quot; // 現在のマシンのIPアドレスに置き換えてください。&#10;        port = 8080&#10;    }&#10;}"/>
+            <p>
+                <code>1.2.3.4</code> を現在のマシンのIPアドレスに置き換えてください。Android仮想デバイスやiOSシミュレーター上で動作するコードからは、<code>0.0.0.0</code> や <code>localhost</code> への呼び出しを行うことはできません。
+            </p>
+            <tip>
+                <p><b>IPアドレスの確認方法:</b></p>
+                <p>
+                    モバイルシミュレーターは <code>localhost</code> にアクセスできないため、マシンの実際のIPアドレスが必要です。IPアドレスを確認するには、以下のいずれかのコマンドを実行してください：
+                </p>
+                <list>
+                    <li><b>macOS:</b> <code>ifconfig | grep "inet " | grep -v 127.0.0.1</code></li>
+                    <li><b>Linux:</b> <code>hostname -I | awk '{print $1}'</code></li>
+                    <li><b>Windows:</b> <code>ipconfig</code> を実行し、「IPv4 アドレス」を探します</li>
+                </list>
+            </tip>
+        </step>
+        <step>
+            <p>
+                同じ
+                <Path>app/shared/.../network</Path>
+                パッケージ内に、以下の実装で新しい
+                <Path>TaskApi.kt</Path>
+                ファイルを作成します：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.network&#10;&#10;import com.example.ktor.model.Task&#10;import io.ktor.client.HttpClient&#10;import io.ktor.client.call.body&#10;import io.ktor.client.request.delete&#10;import io.ktor.client.request.get&#10;import io.ktor.client.request.post&#10;import io.ktor.client.request.setBody&#10;import io.ktor.http.ContentType&#10;import io.ktor.http.contentType&#10;&#10;class TaskApi(private val httpClient: HttpClient) {&#10;&#10;    suspend fun getAllTasks(): List&lt;Task&gt; {&#10;        return httpClient.get(&quot;tasks&quot;).body()&#10;    }&#10;&#10;    suspend fun removeTask(task: Task) {&#10;        httpClient.delete(&quot;tasks/${task.name}&quot;)&#10;    }&#10;&#10;    suspend fun updateTask(task: Task) {&#10;        httpClient.post(&quot;tasks&quot;) {&#10;            contentType(ContentType.Application.Json)&#10;            setBody(task)&#10;        }&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                <Path>app/shared/.../App.kt</Path>
+                に移動し、コードを以下の実装に置き換えます。
+                これにより、<code>TaskApi</code> 型を使用してサーバーからタスクのリストを取得し、各タスクの名前を列（カラム）に表示します：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import com.example.ktor.network.TaskApi&#10;import com.example.ktor.network.createHttpClient&#10;import com.example.ktor.model.Task&#10;import androidx.compose.foundation.layout.Column&#10;import androidx.compose.foundation.layout.fillMaxSize&#10;import androidx.compose.foundation.layout.safeContentPadding&#10;import androidx.compose.material3.Button&#10;import androidx.compose.material3.MaterialTheme&#10;import androidx.compose.material3.Text&#10;import androidx.compose.runtime.*&#10;import androidx.compose.ui.Alignment&#10;import androidx.compose.ui.Modifier&#10;import kotlinx.coroutines.launch&#10;&#10;@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        val tasks = remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;&#10;        Column(&#10;            modifier = Modifier&#10;                .safeContentPadding()&#10;                .fillMaxSize(),&#10;            horizontalAlignment = Alignment.CenterHorizontally,&#10;        ) {&#10;            Button(onClick = {&#10;                scope.launch {&#10;                    tasks.value = taskApi.getAllTasks()&#10;                }&#10;            }) {&#10;                Text(&quot;Fetch Tasks&quot;)&#10;            }&#10;            for (task in tasks.value) {&#10;                Text(task.name)&#10;            }&#10;        }&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                サーバーを実行したまま、<ui-path>iosApp</ui-path> 実行構成を実行してiOSアプリケーションをテストします。
+            </p>
+        </step>
+        <step>
+            <p>
+                <control>Fetch Tasks</control>
+                ボタンをクリックしてタスクのリストを表示します：
+                <img style="block" src="full_stack_development_tutorial_run_iOS.png"
+                     alt="iOSで動作するアプリ" width="363" border-effect="rounded"/>
+            </p>
+            <note>
+                このデモでは、わかりやすさのためにプロセスを簡略化しています。実際のアプリケーションでは、暗号化されていないデータをネットワーク経由で送信しないようにすることが極めて重要です。
+            </note>
+        </step>
+        <step>
+            <p>
+                Androidプラットフォームでは、アプリケーションにネットワーク権限を明示的に与え、クリアテキストでのデータの送受信を許可する必要があります。これらの権限を有効にするには、
+                <Path>app/androidApp/src/main/AndroidManifest.xml</Path>
+                を開き、以下の設定を追加します：
+            </p>
+            <code-block lang="xml" code="                    &lt;manifest&gt;&#10;                        ...&#10;                        &lt;application&#10;                                android:usesCleartextTraffic=&quot;true&quot;&gt;&#10;                        ...&#10;                        ...&#10;                        &lt;/application&gt;&#10;                        &lt;uses-permission android:name=&quot;android.permission.INTERNET&quot;/&gt;&#10;                    &lt;/manifest&gt;"/>
+        </step>
+        <step>
+            <p>
+                <ui-path>app.androidApp</ui-path> 実行構成を使用してAndroidアプリケーションを実行します。
+                Androidクライアントも同様に動作することが確認できるはずです：
+                <img style="block" src="full_stack_development_tutorial_run_android.png"
+                     alt="Androidで動作するアプリ" width="350" />
+            </p>
+        </step>
+        <step>
+            <p>
+                デスクトップクライアントについては、コンテナウィンドウにサイズとタイトルを割り当てます。
+                <Path>app/desktopApp/src/.../main.kt</Path>
+                ファイルを開き、<code>title</code> を変更し、<code>state</code> プロパティを設定してコードを修正します：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import androidx.compose.ui.unit.DpSize&#10;import androidx.compose.ui.unit.dp&#10;import androidx.compose.ui.window.Window&#10;import androidx.compose.ui.window.WindowPosition&#10;import androidx.compose.ui.window.WindowState&#10;import androidx.compose.ui.window.application&#10;&#10;fun main() = application {&#10;    val state = WindowState(&#10;        size = DpSize(400.dp, 600.dp),&#10;        position = WindowPosition(200.dp, 100.dp)&#10;    )&#10;    Window(&#10;        title = &quot;Task Manager (Desktop)&quot;,&#10;        state = state,&#10;        onCloseRequest = ::exitApplication,&#10;    ) {&#10;        App()&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                <ui-path>app [hot] 🔥</ui-path> 実行構成を使用してデスクトップアプリケーションを実行します：
+                <img style="block" src="full_stack_development_tutorial_run_desktop_resized.png"
+                     alt="デスクトップで動作するアプリ" width="400" border-effect="rounded"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                以下のいずれかの実行構成を使用して、Webクライアントを実行します：
+            </p>
+            <list>
+                <li>
+                    <ui-path>app [js]</ui-path>: Kotlin/JSアプリケーションを実行します。
+                </li>
+                <li>
+                    <ui-path>app [wasmJs]</ui-path>: Kotlin/Wasmアプリケーションを実行します。
+                </li>
+            </list>
+            <img style="block" src="full_stack_development_tutorial_run_web.png"
+                 alt="Webで動作するアプリ" width="400" border-effect="rounded"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="UIを改善する" id="improve-ui">
+    <p>
+        クライアントはサーバーと通信できるようになりましたが、まだ魅力的なUIとは言えません。
+    </p>
+    <procedure id="improve-ui-procedure">
+        <step>
+            <p>
+                <Path>app/shared/src/commonMain/.../ktor</Path>
+                にある
+                <Path>App.kt</Path>
+                ファイルを開き、既存の <code>App</code> を以下の <code>App</code> および <code>TaskCard</code> コンポーザブルに置き換えます：
+            </p>
+            <code-block lang="kotlin" collapsed-title-line-number="31" collapsible="true" code="package com.example.ktor&#10;&#10;import com.example.ktor.network.TaskApi&#10;import com.example.ktor.model.Priority&#10;import com.example.ktor.model.Task&#10;import androidx.compose.foundation.layout.Column&#10;import androidx.compose.foundation.layout.Row&#10;import androidx.compose.foundation.layout.Spacer&#10;import androidx.compose.foundation.layout.fillMaxSize&#10;import androidx.compose.foundation.layout.fillMaxWidth&#10;import androidx.compose.foundation.layout.padding&#10;import androidx.compose.foundation.layout.safeContentPadding&#10;import androidx.compose.foundation.layout.width&#10;import androidx.compose.foundation.lazy.LazyColumn&#10;import androidx.compose.foundation.lazy.items&#10;import androidx.compose.foundation.shape.CornerSize&#10;import androidx.compose.foundation.shape.RoundedCornerShape&#10;import androidx.compose.material3.Card&#10;import androidx.compose.material3.MaterialTheme&#10;import androidx.compose.material3.OutlinedButton&#10;import androidx.compose.material3.Text&#10;import androidx.compose.runtime.*&#10;import androidx.compose.ui.Modifier&#10;import androidx.compose.ui.text.font.FontWeight&#10;import androidx.compose.ui.unit.dp&#10;import androidx.compose.ui.unit.sp&#10;import com.example.ktor.network.createHttpClient&#10;import kotlinx.coroutines.launch&#10;&#10;@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        var tasks by remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;&#10;        LaunchedEffect(Unit) {&#10;            tasks = taskApi.getAllTasks()&#10;        }&#10;&#10;        LazyColumn(&#10;            modifier = Modifier&#10;                .safeContentPadding()&#10;                .fillMaxSize()&#10;        ) {&#10;            items(tasks) { task -&gt;&#10;                TaskCard(&#10;                    task,&#10;                    onDelete = {&#10;                        scope.launch {&#10;                            taskApi.removeTask(it)&#10;                            tasks = taskApi.getAllTasks()&#10;                        }&#10;                    },&#10;                    onUpdate = {&#10;                    }&#10;                )&#10;            }&#10;        }&#10;    }&#10;}&#10;&#10;@Composable&#10;fun TaskCard(&#10;    task: Task,&#10;    onDelete: (Task) -&gt; Unit,&#10;    onUpdate: (Task) -&gt; Unit&#10;) {&#10;    fun pickWeight(priority: Priority) = when (priority) {&#10;        Priority.Low -&gt; FontWeight.SemiBold&#10;        Priority.Medium -&gt; FontWeight.Bold&#10;        Priority.High, Priority.Vital -&gt; FontWeight.ExtraBold&#10;    }&#10;&#10;    Card(&#10;        modifier = Modifier.fillMaxWidth().padding(4.dp),&#10;        shape = RoundedCornerShape(CornerSize(4.dp))&#10;    ) {&#10;        Column(modifier = Modifier.padding(10.dp)) {&#10;            Text(&#10;                &quot;${task.name}: ${task.description}&quot;,&#10;                fontSize = 20.sp,&#10;                fontWeight = pickWeight(task.priority)&#10;            )&#10;&#10;            Row {&#10;                OutlinedButton(onClick = { onDelete(task) }) {&#10;                    Text(&quot;Delete&quot;)&#10;                }&#10;                Spacer(Modifier.width(8.dp))&#10;                OutlinedButton(onClick = { onUpdate(task) }) {&#10;                    Text(&quot;Update&quot;)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                この実装により、クライアントにいくつかの基本的な機能が備わりました。
+            </p>
+            <p>
+                <code>LaunchedEffect</code> 型を使用することで起動時にすべてのタスクが読み込まれ、<code>LazyColumn</code> コンポーザブルによってユーザーはタスクをスクロールできるようになります。
+            </p>
+            <p>
+                最後に、独立した <code>TaskCard</code> コンポーザブルが作成され、これには各 <code>Task</code> の詳細を表示するための <code>Card</code> が使用されています。タスクを削除および更新するためのボタンも追加されました。
+            </p>
+        </step>
+        <step>
+            <p>
+                クライアントアプリケーション（例：Androidアプリ）を再起動します。
+                タスクをスクロールし、詳細を確認し、削除できるようになります：
+                <img style="block" src="full_stack_development_tutorial_improved_ui.gif"
+                     alt="改善されたUIで動作するAndroidアプリ" width="350" border-effect="rounded"/>
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="更新機能を追加する" id="add-update-functionality">
+    <p>
+        クライアントを完成させるために、タスクの詳細を更新できる機能を組み込みます。
+    </p>
+    <procedure id="add-update-func-procedure">
+        <step>
+            <Path>app/shared/src/commonMain/.../ktor</Path>
+            にある
+            <Path>App.kt</Path>
+            ファイルに移動します。
+        </step>
+        <step>
+            <p>
+                以下に示すように、<code>UpdateTaskDialog</code> コンポーザブルと必要なインポートを追加します：
+            </p>
+            <code-block lang="kotlin" code="import androidx.compose.material3.TextField&#10;import androidx.compose.material3.TextFieldDefaults&#10;import androidx.compose.ui.graphics.Color&#10;import androidx.compose.ui.window.Dialog&#10;&#10;@Composable&#10;fun UpdateTaskDialog(&#10;    task: Task,&#10;    onConfirm: (Task) -&gt; Unit&#10;) {&#10;    var description by remember { mutableStateOf(task.description) }&#10;    var priorityText by remember { mutableStateOf(task.priority.toString()) }&#10;    val colors = TextFieldDefaults.colors(&#10;        focusedTextColor = Color.Blue,&#10;        focusedContainerColor = Color.White,&#10;    )&#10;&#10;    Dialog(onDismissRequest = {}) {&#10;        Card(&#10;            modifier = Modifier.fillMaxWidth().padding(4.dp),&#10;            shape = RoundedCornerShape(CornerSize(4.dp))&#10;        ) {&#10;            Column(modifier = Modifier.padding(10.dp)) {&#10;                Text(&quot;Update ${task.name}&quot;, fontSize = 20.sp)&#10;                TextField(&#10;                    value = description,&#10;                    onValueChange = { description = it },&#10;                    label = { Text(&quot;Description&quot;) },&#10;                    colors = colors&#10;                )&#10;                TextField(&#10;                    value = priorityText,&#10;                    onValueChange = { priorityText = it },&#10;                    label = { Text(&quot;Priority&quot;) },&#10;                    colors = colors&#10;                )&#10;                OutlinedButton(onClick = {&#10;                    val newTask = Task(&#10;                        task.name,&#10;                        description,&#10;                        try {&#10;                            Priority.valueOf(priorityText)&#10;                        } catch (e: IllegalArgumentException) {&#10;                            Priority.Low&#10;                        }&#10;                    )&#10;                    onConfirm(newTask)&#10;                }) {&#10;                    Text(&quot;Update&quot;)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                これは、ダイアログボックスで <code>Task</code> の詳細を表示するコンポーザブルです。<code>description</code>（説明）と <code>priority</code>（優先度）は、更新できるように <code>TextField</code> コンポーザブル内に配置されています。ユーザーが更新ボタンを押すと、<code>onConfirm()</code> コールバックが実行されます。
+            </p>
+        </step>
+        <step>
+            <p>
+                同じファイル内の <code>App</code> コンポーザブルを更新します：
+            </p>
+            <code-block lang="kotlin" code="@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        var tasks by remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;        var currentTask by remember { mutableStateOf&lt;Task?&gt;(null) }&#10;&#10;        LaunchedEffect(Unit) {&#10;            tasks = taskApi.getAllTasks()&#10;        }&#10;&#10;        if (currentTask != null) {&#10;            UpdateTaskDialog(&#10;                currentTask!!,&#10;                onConfirm = {&#10;                    scope.launch {&#10;                        taskApi.updateTask(it)&#10;                        tasks = taskApi.getAllTasks()&#10;                    }&#10;                    currentTask = null&#10;                }&#10;            )&#10;        }&#10;&#10;        LazyColumn(modifier = Modifier&#10;            .safeContentPadding()&#10;            .fillMaxSize()&#10;        ) {&#10;            items(tasks) { task -&gt;&#10;                TaskCard(&#10;                    task,&#10;                    onDelete = {&#10;                        scope.launch {&#10;                            taskApi.removeTask(it)&#10;                            tasks = taskApi.getAllTasks()&#10;                        }&#10;                    },&#10;                    onUpdate = {&#10;                        currentTask = task&#10;                    }&#10;                )&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                現在選択されているタスクを保持するための追加の状態（State）を保存しています。この値が null でない場合、<code>UpdateTaskDialog</code> コンポーザブルを呼び出します。その際、<code>onConfirm()</code> コールバックには <code>TaskApi</code> を使用してサーバーに POST リクエストを送信するように設定されています。
+            </p>
+            <p>
+                最後に、<code>TaskCard</code> コンポーザブルを作成する際に、<code>onUpdate()</code> コールバックを使用して <code>currentTask</code> 状態変数を設定します。
+            </p>
+        </step>
+        <step>
+            クライアントアプリケーションを再起動します。ボタンを使用して各タスクの詳細を更新できるようになります。
+            <img style="block" src="full_stack_development_tutorial_update_task.gif"
+                 alt="Androidでのタスク更新" width="350" border-effect="rounded"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="次のステップ" id="next-steps">
+    <p>
+        この記事では、Kotlin Multiplatformアプリケーションのコンテキスト内でKtorを使用しました。これで、さまざまなプラットフォームを対象とした、複数のサービスとクライアントを含むプロジェクトを作成できるようになりました。
+    </p>
+    <p>
+        見てきたように、コードの重複や冗長性なしに機能を構築することが可能です。プロジェクトのすべてのレイヤーで必要とされる型は、
+        <Path>core</Path>
+        マルチプラットフォームモジュール内に配置できます。サービスにのみ必要な機能は
+        <Path>server</Path>
+        モジュールに、クライアントにのみ必要な機能は
+        <Path>app</Path>
+        モジュールに配置します。
+    </p>
+    <p>
+        この種の本発には、必然的にクライアントとサーバーの両方の技術に関する知識が必要になります。しかし、<a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">Kotlin
+        Multiplatform</a> ライブラリと <a href="https://www.jetbrains.com/lp/compose-multiplatform/">
+        Compose Multiplatform</a> を使用することで、新しく学ぶ必要がある事柄を最小限に抑えることができます。最初は単一のプラットフォームにのみ焦点を当てている場合でも、アプリケーションの需要が高まるにつれて、他のプラットフォームを簡単に追加することができます。
+    </p>
+</chapter>
+</topic>

--- a/docs/ja/ktor/migration-from-express-js.md
+++ b/docs/ja/ktor/migration-from-express-js.md
@@ -1,0 +1,892 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="Express から Ktor への移行"
+       id="migration-from-express-js" help-id="express-js;migrating-from-express-js">
+    <show-structure for="chapter" depth="2"/>
+    <link-summary>このガイドでは、シンプルな Ktor アプリケーションの作成、実行、テスト方法について説明します。</link-summary>
+    <tldr>
+        <p>
+            <b>コード例</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express">migrating-express</a>
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor">migrating-express-ktor</a>
+        </p>
+    </tldr>
+    <p>
+        このガイドでは、アプリケーションの生成や最初のアプリケーションの記述から、アプリケーションの機能を拡張するためのミドルウェアの作成まで、基本的なシナリオにおいて Express アプリケーションを Ktor へ移行する方法を見ていきます。
+    </p>
+    <chapter title="アプリの生成" id="generate">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        <code>express-generator</code> ツールを使用して、新しい Express アプリケーションを生成できます。
+                    </p>
+                    <code-block lang="shell" code="                        npx express-generator"/>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor は、アプリケーションのスケルトンを生成するために以下の方法を提供しています。
+                    </p>
+                    <list>
+                        <li>
+                            <p>
+                                <a href="https://start.ktor.io/">Ktor プロジェクトジェネレーター</a> — Web ベースのジェネレーターを使用します。
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <a href="https://github.com/ktorio/ktor-cli">
+                                    Ktor CLI ツール
+                                </a> — コマンドラインインターフェースから <code>ktor new</code> コマンドを使用して Ktor プロジェクトを生成します。
+                            </p>
+                            <code-block lang="shell" code="                                ktor new ktor-sample"/>
+                        </li>
+                        <li>
+                            <p>
+                                <a href="https://www.npmjs.com/package/generator-ktor">
+                                    Yeoman ジェネレーター
+                                </a>
+                                — プロジェクト設定を対話的に構成し、必要なプラグインを選択します。
+                            </p>
+                            <code-block lang="shell" code="                                yo ktor"/>
+                        </li>
+                        <li>
+                            <p>
+                                <a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 内蔵の Ktor プロジェクトウィザードを使用します。
+                            </p>
+                        </li>
+                    </list>
+                    <p>
+                        詳細な手順については、<Links href="//server-create-a-new-project" summary="Ktor を使用してサーバーアプリケーションを開き、実行し、テストする方法を学びます。">新しい Ktor プロジェクトの作成、オープン、実行</Links>のチュートリアルを参照してください。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="Hello world" id="hello">
+        <p>
+            このセクションでは、<code>GET</code> リクエストを受け取り、定義済みのプレーンテキストで応答する、最もシンプルなサーバーアプリケーションを作成する方法を見ていきます。
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        以下の例は、サーバーを起動し、ポート <control>3000</control> で接続を待機する Express アプリケーションを示しています。
+                    </p>
+                    <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor では、コード内でサーバーパラメータを構成し、アプリケーションを素早く実行するために <a href="#embedded-server">embeddedServer</a> 関数を使用できます。
+                    </p>
+                    <code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a> プロジェクトを参照してください。
+                    </p>
+                    <p>
+                        また、HOCON または YAML 形式を使用する<a href="#engine-main">外部構成ファイル</a>でサーバー設定を指定することもできます。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+        <p>
+            上記の Express アプリケーションは、<control>Date</control>、<control>X-Powered-By</control>、および <control>ETag</control> レスポンスヘッダーを追加することに注意してください。これらは次のように表示される場合があります。
+        </p>
+        <code-block code="            Date: Fri, 05 Aug 2022 06:30:48 GMT&#10;            X-Powered-By: Express&#10;            ETag: W/&quot;c-Lve95gjOVATpfV8EL5X4nxwjKHE&quot;"/>
+        <p>
+            Ktor で各レスポンスにデフォルトの <control>Server</control> および <control>Date</control> ヘッダーを追加するには、<Links href="//server-default-headers" summary="必要な依存関係: io.ktor:%artifact_name%">DefaultHeaders</Links> プラグインをインストールする必要があります。<control>Etag</control> レスポンスヘッダーを構成するには、<Links href="//server-conditional-headers" summary="必要な依存関係: io.ktor:%artifact_name%">ConditionalHeaders</Links> プラグインを使用できます。
+        </p>
+    </chapter>
+    <chapter title="静的コンテンツの配信" id="static">
+        <p>
+            このセクションでは、Express と Ktor で画像、CSS ファイル、JavaScript ファイルなどの静的ファイルを配信する方法を見ていきます。
+            メインの <Path>index.html</Path> ページとリンクされたアセット一式が含まれる <Path>public</Path> フォルダーがあると仮定します。
+        </p>
+        <code-block code="            public&#10;            ├── index.html&#10;            ├── ktor_logo.png&#10;            ├── css&#10;            │   └──styles.css&#10;            └── js&#10;                └── script.js"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express では、フォルダー名を <control>express.static</control> 関数に渡します。
+                    </p>
+                    <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor では、<a href="#folders"><code>staticFiles()</code></a> 関数を使用して、<Path>/</Path> パスに対して行われたリクエストを <Path>public</Path> 物理フォルダーにマッピングします。
+                        この関数により、<Path>public</Path> フォルダー内のすべてのファイルを再帰的に配信できます。
+                    </p>
+                    <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+        <p>
+            静的コンテンツを配信する際、Express は次のような複数のレスポンスヘッダーを追加します。
+        </p>
+        <code-block code="            Accept-Ranges: bytes&#10;            Cache-Control: public, max-age=0&#10;            ETag: W/&quot;181-1823feafeb1&quot;&#10;            Last-Modified: Wed, 27 Jul 2022 13:49:01 GMT"/>
+        <p>
+            Ktor でこれらのヘッダーを管理するには、次のプラグインをインストールする必要があります。
+        </p>
+        <list>
+            <li>
+                <p>
+                    <control>Accept-Ranges</control>: <Links href="//server-partial-content" summary="必要な依存関係: io.ktor:%artifact_name% サーバー例: download-file, クライアント例: client-download-file-range">PartialContent</Links>
+                </p>
+            </li>
+            <li>
+                <p>
+                    <control>Cache-Control</control>: <Links href="//server-caching-headers" summary="必要な依存関係: io.ktor:%artifact_name%">CachingHeaders</Links>
+                </p>
+            </li>
+            <li>
+                <p>
+                    <control>ETag</control> および <control>Last-Modified</control>: <Links href="//server-conditional-headers" summary="必要な依存関係: io.ktor:%artifact_name%">ConditionalHeaders</Links>
+                </p>
+            </li>
+        </list>
+    </chapter>
+    <chapter title="ルーティング" id="routing">
+        <p>
+            <Links href="//server-routing" summary="ルーティングは、サーバーアプリケーションでの着信リクエストを処理するためのコアプラグインです。">ルーティング</Links>により、特定の HTTP リクエストメソッド (<code>GET</code>、<code>POST</code> など) とパスで定義された特定のエンドポイントに対して行われた着信リクエストを処理できます。
+            以下の例は、<Path>/</Path> パスに対して行われた <code>GET</code> および <code>POST</code> リクエストを処理する方法を示しています。
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
+                    <tip>
+                        <p>
+                            <code>POST</code>、<code>PUT</code>、または <code>PATCH</code> リクエストのリクエストボディを受信する方法については、<a href="#receive-request">リクエストの受信</a>を参照してください。
+                        </p>
+                    </tip>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+        <p>
+            次の例は、ルートハンドラーをパスごとにグループ化する方法を示しています。
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express では、<code>app.route()</code> を使用して、ルートパスに対してチェーン可能なルートハンドラーを作成できます。
+                    </p>
+                    <code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor は <code>route</code> 関数を提供しており、これによってパスを定義し、そのパスの HTTP メソッドをネストされた関数として配置します。
+                    </p>
+                    <code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+        <p>
+            どちらのフレームワークでも、関連するルートを単一のファイルにグループ化できます。
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express は、マウント可能なルートハンドラーを作成するための <code>express.Router</code> クラスを提供しています。
+                        アプリケーションのディレクトリに <Path>birds.js</Path> ルーターファイルがあると仮定します。
+                        このルーターモジュールは、<Path>app.js</Path> に示すようにアプリケーションにロードできます。
+                    </p>
+                    <Tabs>
+                        <TabItem title="birds.js">
+                            <code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
+                        </TabItem>
+                        <TabItem title="app.js">
+                            <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                        </TabItem>
+                    </Tabs>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor では、<code>Routing</code> 型の拡張関数を使用して実際のルートを定義するのが一般的なパターンです。
+                        以下のサンプル (<Path>Birds.kt</Path>) は <code>birdsRoutes</code> 拡張関数を定義しています。
+                        アプリケーション (<Path>Application.kt</Path>) の <code>routing</code> ブロック内でこの関数を呼び出すことで、対応するルートを含めることができます。
+                    </p>
+                    <Tabs>
+                        <TabItem title="Birds.kt" id="birds-kt">
+                            <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
+                        </TabItem>
+                        <TabItem title="Application.kt" id="application-kt">
+                            <code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
+                        </TabItem>
+                    </Tabs>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+        <p>
+            URL パスを文字列として指定する以外に、Ktor には<Links href="//server-resources" summary="Resources プラグインを使用すると、型安全なルーティングを実装できます。">型安全なルート</Links>を実装する機能が含まれています。
+        </p>
+    </chapter>
+    <chapter title="ルートパラメータとクエリパラメータ" id="route-query-param">
+        <p>
+            このセクションでは、ルートパラメータとクエリパラメータへのアクセス方法について説明します。
+        </p>
+        <p>
+            ルート（またはパス）パラメータは、URL 内のその位置に指定された値をキャプチャするために使用される名前付きの URL セグメントです。
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express でルートパラメータにアクセスするには、<code>Request.params</code> を使用できます。
+                        たとえば、以下のコードスニペットの <code>req.params["login"]</code> は、<Path>/user/admin</Path> パスに対して <emphasis>admin</emphasis> を返します。
+                    </p>
+                    <code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor では、ルートパラメータは <code>{param}</code> 構文を使用して定義されます。
+                        ルートハンドラーでルートパラメータにアクセスするには、<code>call.parameters</code> を使用できます。
+                    </p>
+                    <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+        <p>
+            以下の表は、クエリ文字列のパラメータにアクセスする方法を比較しています。
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express でクエリパラメータにアクセスするには、<code>Request.query</code> を使用できます。
+                        たとえば、以下のコードスニペットの <code>req.query['price']</code> は、<Path>/products?price=asc</Path> パスに対して <emphasis>asc</emphasis> を返します。
+                    </p>
+                    <code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor では、<code>call.request.queryParameters</code> を使用してクエリパラメータにアクセスできます。
+                    </p>
+                    <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="レスポンスの送信" id="send-response">
+        <p>
+            前のセクションでは、プレーンテキストの内容で応答する方法をすでに見てきました。
+            JSON、ファイル、およびリダイレクトのレスポンスを送信する方法を見ていきましょう。
+        </p>
+        <chapter title="JSON" id="send-json">
+            <table style="header-column">
+                
+<tr>
+<td>
+                        <control>Express</control>
+                    </td>
+                    <td>
+                        <p>
+                            Express で適切なコンテンツタイプで JSON レスポンスを送信するには、<code>res.json</code> 関数を呼び出します。
+                        </p>
+                        <code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+                
+<tr>
+<td>
+                        <control>Ktor</control>
+                    </td>
+                    <td>
+                        <p>
+                            Ktor では、<Links href="//server-serialization" summary="ContentNegotiation プラグインは、クライアントとサーバー間のメディアタイプのネゴシエーションと、特定の形式でのコンテンツのシリアル化/非シリアル化の 2 つの主要な目的を果たします。">ContentNegotiation</Links> プラグインをインストールし、JSON シリアライザーを構成する必要があります。
+                        </p>
+                        <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
+                        <p>
+                            データを JSON にシリアル化するには、<code>@Serializable</code> アノテーションを付けたデータクラスを作成する必要があります。
+                        </p>
+                        <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+                        <p>
+                            その後、<code>call.respond</code> を使用して、レスポンスでこのクラスのオブジェクトを送信できます。
+                        </p>
+                        <code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+            </table>
+        </chapter>
+        <chapter title="ファイル" id="send-file">
+            <table style="header-column">
+                
+<tr>
+<td>
+                        <control>Express</control>
+                    </td>
+                    <td>
+                        <p>
+                            Express でファイルを使用して応答するには、<code>res.sendFile</code> を使用します。
+                        </p>
+                        <code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+                
+<tr>
+<td>
+                        <control>Ktor</control>
+                    </td>
+                    <td>
+                        <p>
+                            Ktor は、クライアントにファイルを送信するための <code>call.respondFile</code> 関数を提供しています。
+                        </p>
+                        <code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+            </table>
+            <p>
+                Express アプリケーションは、ファイルで応答する際に <control>Accept-Ranges</control> HTTP レスポンスヘッダーを追加します。
+                サーバーはこのヘッダーを使用して、クライアントからのファイルダウンロードの部分リクエスト（Partial requests）のサポートを通知します。
+                Ktor で部分リクエストをサポートするには、<Links href="//server-partial-content" summary="必要な依存関係: io.ktor:%artifact_name% サーバー例: download-file, クライアント例: client-download-file-range">PartialContent</Links> プラグインをインストールする必要があります。
+            </p>
+        </chapter>
+        <chapter title="ファイルの添付" id="send-file-attachment">
+            <table style="header-column">
+                
+<tr>
+<td>
+                        <control>Express</control>
+                    </td>
+                    <td>
+                        <p>
+                            <code>res.download</code> 関数は、指定されたファイルを添付ファイルとして転送します。
+                        </p>
+                        <code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+                
+<tr>
+<td>
+                        <control>Ktor</control>
+                    </td>
+                    <td>
+                        <p>
+                            Ktor では、ファイルを添付ファイルとして転送するために <control>Content-Disposition</control> ヘッダーを手動で構成する必要があります。
+                        </p>
+                        <code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+            </table>
+        </chapter>
+        <chapter title="リダイレクト" id="redirect">
+            <table style="header-column">
+                
+<tr>
+<td>
+                        <control>Express</control>
+                    </td>
+                    <td>
+                        <p>
+                            Express でリダイレクトレスポンスを生成するには、<code>redirect</code> 関数を呼び出します。
+                        </p>
+                        <code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+                
+<tr>
+<td>
+                        <control>Ktor</control>
+                    </td>
+                    <td>
+                        <p>
+                            Ktor では、リダイレクトレスポンスを送信するために <code>respondRedirect</code> を使用します。
+                        </p>
+                        <code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+            </table>
+        </chapter>
+    </chapter>
+    <chapter title="テンプレート" id="templates">
+        <p>
+            Express と Ktor はどちらも、ビューを処理するためのテンプレートエンジンの使用をサポートしています。
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        <Path>views</Path> フォルダーに次の Pug テンプレートがあると仮定します。
+                    </p>
+                    <code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
+                    <p>
+                        このテンプレートで応答するには、<code>res.render</code> を呼び出します。
+                    </p>
+                    <code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor は、FreeMarker、Velocity など、いくつかの <Links href="//server-templating" summary="HTML/CSS または JVM テンプレートエンジンを使用して構築されたビューを操作する方法を学びます。">JVM テンプレートエンジン</Links>をサポートしています。
+                        たとえば、アプリケーションリソースに配置された FreeMarker テンプレートで応答する必要がある場合は、<code>FreeMarker</code> プラグインをインストールして構成し、<code>call.respond</code> を使用してテンプレートを送信します。
+                    </p>
+                    <code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="リクエストの受信" id="receive-request">
+        <p>
+            このセクションでは、さまざまな形式のリクエストボディを受信する方法について説明します。
+        </p>
+        <chapter title="生テキスト" id="receive-raw-text">
+            <p>
+                以下の <code>POST</code> リクエストは、テキストデータをサーバーに送信します。
+            </p>
+            <code-block lang="http" code="POST http://0.0.0.0:3000/text&#10;Content-Type: text/plain&#10;&#10;Hello, world!"/>
+            <p>
+                サーバー側でこのリクエストのボディをプレーンテキストとして受信する方法を見てみましょう。
+            </p>
+            <table style="header-column">
+                
+<tr>
+<td>
+                        <control>Express</control>
+                    </td>
+                    <td>
+                        <p>
+                            Express で着信リクエストボディを解析するには、<code>body-parser</code> を追加する必要があります。
+                        </p>
+                        <code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
+                        <p>
+                            <code>post</code> ハンドラーでは、テキストパーサー (<code>bodyParser.text</code>) を渡す必要があります。
+                            リクエストボディは <code>req.body</code> プロパティから利用できます。
+                        </p>
+                        <code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+                
+<tr>
+<td>
+                        <control>Ktor</control>
+                    </td>
+                    <td>
+                        <p>
+                            Ktor では、<code>call.receiveText</code> を使用してボディをテキストとして受信できます。
+                        </p>
+                        <code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+            </table>
+        </chapter>
+        <chapter title="JSON" id="receive-json">
+            <p>
+                このセクションでは、JSON ボディを受信する方法を見ていきます。
+                以下のサンプルは、ボディに JSON オブジェクトを含む <code>POST</code> リクエストを示しています。
+            </p>
+            <code-block lang="http" code="POST http://0.0.0.0:3000/json&#10;Content-Type: application/json&#10;&#10;{&#10;  &quot;type&quot;: &quot;Fiat&quot;,&#10;  &quot;model&quot; : &quot;500&quot;,&#10;  &quot;color&quot;: &quot;white&quot;&#10;}"/>
+            <table style="header-column">
+                
+<tr>
+<td>
+                        <control>Express</control>
+                    </td>
+                    <td>
+                        <p>
+                            Express で JSON を受信するには、<code>bodyParser.json</code> を使用します。
+                        </p>
+                        <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+                
+<tr>
+<td>
+                        <control>Ktor</control>
+                    </td>
+                    <td>
+                        <p>
+                            Ktor では、<Links href="//server-serialization" summary="ContentNegotiation プラグインは、クライアントとサーバー間のメディアタイプのネゴシエーションと、特定の形式でのコンテンツのシリアル化/非シリアル化の 2 つの主要な目的を果たします。">ContentNegotiation</Links> プラグインをインストールし、<code>Json</code> シリアライザーを構成する必要があります。
+                        </p>
+                        <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
+                        <p>
+                            受信したデータをオブジェクトにデシリアライズするには、データクラスを作成する必要があります。
+                        </p>
+                        <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+                        <p>
+                            次に、このデータクラスをパラメータとして受け取る <code>receive</code> メソッドを使用します。
+                        </p>
+                        <code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+            </table>
+        </chapter>
+        <chapter title="URL エンコード" id="receive-url-encoded">
+            <p>
+                次に、<control>application/x-www-form-urlencoded</control> タイプを使用して送信されたフォームデータを受信する方法を見てみましょう。
+                以下のコードスニペットは、フォームデータを含む <code>POST</code> リクエストのサンプルを示しています。
+            </p>
+            <code-block lang="http" code="POST http://localhost:3000/urlencoded&#10;Content-Type: application/x-www-form-urlencoded&#10;&#10;username=JetBrains&amp;email=example@jetbrains.com&amp;password=foobar&amp;confirmation=foobar"/>
+            <table style="header-column">
+                
+<tr>
+<td>
+                        <control>Express</control>
+                    </td>
+                    <td>
+                        <p>
+                            プレーンテキストや JSON と同様に、Express では <code>body-parser</code> が必要です。
+                            パーサーのタイプを <code>bodyParser.urlencoded</code> に設定する必要があります。
+                        </p>
+                        <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+                
+<tr>
+<td>
+                        <control>Ktor</control>
+                    </td>
+                    <td>
+                        <p>
+                            Ktor では、<code>call.receiveParameters</code> 関数を使用します。
+                        </p>
+                        <code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+            </table>
+        </chapter>
+        <chapter title="生データ" id="receive-raw-data">
+            <p>
+                次のユースケースは、バイナリデータの処理です。
+                以下のリクエストは、<control>application/octet-stream</control> を使用して PNG 画像をサーバーに送信します。
+            </p>
+            <code-block lang="http" code="POST http://localhost:3000/raw&#10;Content-Type: application/octet-stream&#10;&#10;&lt; ./ktor_logo.png"/>
+            <table style="header-column">
+                
+<tr>
+<td>
+                        <control>Express</control>
+                    </td>
+                    <td>
+                        <p>
+                            Express でバイナリデータを処理するには、パーサーのタイプを <code>raw</code> に設定します。
+                        </p>
+                        <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+                
+<tr>
+<td>
+                        <control>Ktor</control>
+                    </td>
+                    <td>
+                        <p>
+                            Ktor は、バイトシーケンスを非同期で読み書きするための <code>ByteReadChannel</code> および <code>ByteWriteChannel</code> を提供しています。
+                        </p>
+                        <code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive request</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+            </table>
+        </chapter>
+        <chapter title="マルチパート" id="receive-multipart">
+            <p>
+                最後のセクションでは、<emphasis>マルチパート</emphasis>ボディの処理方法を見ていきましょう。
+                以下の <code>POST</code> リクエストは、<control>multipart/form-data</control> タイプを使用して、説明付きの PNG 画像を送信します。
+            </p>
+            <code-block lang="http" code="POST http://localhost:3000/multipart&#10;Content-Type: multipart/form-data; boundary=WebAppBoundary&#10;&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;description&quot;&#10;Content-Type: text/plain&#10;&#10;Ktor logo&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;image&quot;; filename=&quot;ktor_logo.png&quot;&#10;Content-Type: image/png&#10;&#10;&lt; ./ktor_logo.png&#10;--WebAppBoundary--"/>
+            <table style="header-column">
+                
+<tr>
+<td>
+                        <control>Express</control>
+                    </td>
+                    <td>
+                        <p>
+                            Express ではマルチパートデータを解析するために別のモジュールが必要です。
+                            以下の例では、<control>multer</control> を使用してサーバーにファイルをアップロードしています。
+                        </p>
+                        <code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+                
+<tr>
+<td>
+                        <control>Ktor</control>
+                    </td>
+                    <td>
+                        <p>
+                            Ktor では、マルチパートリクエストの一部として送信されたファイルを受信する必要がある場合、<code>receiveMultipart</code> 関数を呼び出し、必要に応じて各パートをループします。
+                            以下の例では、<code>PartData.FileItem</code> を使用してファイルをバイトストリームとして受信しています。
+                        </p>
+                        <code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
+                        <p>
+                            完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a> プロジェクトを参照してください。
+                        </p>
+                    </td>
+</tr>
+
+            </table>
+        </chapter>
+    </chapter>
+    <chapter title="ミドルウェアの作成" id="middleware">
+        <p>
+            最後に、サーバー機能を拡張するためのミドルウェアの作成方法について説明します。
+            以下の例は、Express と Ktor を使用してリクエストログを実装する方法を示しています。
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express では、ミドルウェアは <code>app.use</code> を使用してアプリケーションにバインドされた関数です。
+                    </p>
+                    <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor では、<Links href="//server-custom-plugins" summary="独自のカスタムプラグインを作成する方法を学びます。">カスタムプラグイン</Links>を使用して機能を拡張できます。
+                        以下のコード例は、リクエストログを実装するために <code>onCall</code> を処理する方法を示しています。
+                    </p>
+                    <code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
+                    <p>
+                        完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a> プロジェクトを参照してください。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="次のステップ" id="next">
+        <p>
+            このガイドではまだカバーされていないユースケースが、セッション管理、認可、データベース統合など多数あります。
+            これらの機能のほとんどについて、Ktor はアプリケーションにインストールして必要に応じて構成できる専用のプラグインを提供しています。
+            Ktor での開発を続けるには、一連のステップバイステップのガイドとすぐに使えるサンプルを提供している<control><a href="https://ktor.io/learn/">学習ページ</a></control>にアクセスしてください。
+        </p>
+    </chapter>
+</topic>

--- a/docs/ja/ktor/migration-from-express-js.md
+++ b/docs/ja/ktor/migration-from-express-js.md
@@ -16,106 +16,98 @@
     </p>
     <chapter title="アプリの生成" id="generate">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
-                        <code>express-generator</code> ツールを使用して、新しい Express アプリケーションを生成できます。
+<control>Express</control>
+</td>
+<td>
+<p>
+<code>express-generator</code> ツールを使用して、新しい Express アプリケーションを生成できます。
                     </p>
-                    <code-block lang="shell" code="                        npx express-generator"/>
-                </td>
+<code-block lang="shell" code="                        npx express-generator"/>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor は、アプリケーションのスケルトンを生成するために以下の方法を提供しています。
                     </p>
-                    <list>
-                        <li>
-                            <p>
-                                <a href="https://start.ktor.io/">Ktor プロジェクトジェネレーター</a> — Web ベースのジェネレーターを使用します。
+<list>
+<li>
+<p>
+<a href="https://start.ktor.io/">Ktor プロジェクトジェネレーター</a> — Web ベースのジェネレーターを使用します。
                             </p>
-                        </li>
-                        <li>
-                            <p>
-                                <a href="https://github.com/ktorio/ktor-cli">
+</li>
+<li>
+<p>
+<a href="https://github.com/ktorio/ktor-cli">
                                     Ktor CLI ツール
                                 </a> — コマンドラインインターフェースから <code>ktor new</code> コマンドを使用して Ktor プロジェクトを生成します。
                             </p>
-                            <code-block lang="shell" code="                                ktor new ktor-sample"/>
-                        </li>
-                        <li>
-                            <p>
-                                <a href="https://www.npmjs.com/package/generator-ktor">
+<code-block lang="shell" code="                                ktor new ktor-sample"/>
+</li>
+<li>
+<p>
+<a href="https://www.npmjs.com/package/generator-ktor">
                                     Yeoman ジェネレーター
                                 </a>
                                 — プロジェクト設定を対話的に構成し、必要なプラグインを選択します。
                             </p>
-                            <code-block lang="shell" code="                                yo ktor"/>
-                        </li>
-                        <li>
-                            <p>
-                                <a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 内蔵の Ktor プロジェクトウィザードを使用します。
+<code-block lang="shell" code="                                yo ktor"/>
+</li>
+<li>
+<p>
+<a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 内蔵の Ktor プロジェクトウィザードを使用します。
                             </p>
-                        </li>
-                    </list>
-                    <p>
+</li>
+</list>
+<p>
                         詳細な手順については、<Links href="//server-create-a-new-project" summary="Ktor を使用してサーバーアプリケーションを開き、実行し、テストする方法を学びます。">新しい Ktor プロジェクトの作成、オープン、実行</Links>のチュートリアルを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="Hello world" id="hello">
         <p>
             このセクションでは、<code>GET</code> リクエストを受け取り、定義済みのプレーンテキストで応答する、最もシンプルなサーバーアプリケーションを作成する方法を見ていきます。
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         以下の例は、サーバーを起動し、ポート <control>3000</control> で接続を待機する Express アプリケーションを示しています。
                     </p>
-                    <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor では、コード内でサーバーパラメータを構成し、アプリケーションを素早く実行するために <a href="#embedded-server">embeddedServer</a> 関数を使用できます。
                     </p>
-                    <code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
-                    <p>
+<code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a> プロジェクトを参照してください。
                     </p>
-                    <p>
+<p>
                         また、HOCON または YAML 形式を使用する<a href="#engine-main">外部構成ファイル</a>でサーバー設定を指定することもできます。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
         <p>
             上記の Express アプリケーションは、<control>Date</control>、<control>X-Powered-By</control>、および <control>ETag</control> レスポンスヘッダーを追加することに注意してください。これらは次のように表示される場合があります。
         </p>
@@ -131,40 +123,36 @@
         </p>
         <code-block code="            public&#10;            ├── index.html&#10;            ├── ktor_logo.png&#10;            ├── css&#10;            │   └──styles.css&#10;            └── js&#10;                └── script.js"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express では、フォルダー名を <control>express.static</control> 関数に渡します。
                     </p>
-                    <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor では、<a href="#folders"><code>staticFiles()</code></a> 関数を使用して、<Path>/</Path> パスに対して行われたリクエストを <Path>public</Path> 物理フォルダーにマッピングします。
                         この関数により、<Path>public</Path> フォルダー内のすべてのファイルを再帰的に配信できます。
                     </p>
-                    <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
-                    <p>
+<code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
         <p>
             静的コンテンツを配信する際、Express は次のような複数のレスポンスヘッダーを追加します。
         </p>
@@ -196,130 +184,118 @@
             以下の例は、<Path>/</Path> パスに対して行われた <code>GET</code> および <code>POST</code> リクエストを処理する方法を示しています。
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
-                    <tip>
-                        <p>
-                            <code>POST</code>、<code>PUT</code>、または <code>PATCH</code> リクエストのリクエストボディを受信する方法については、<a href="#receive-request">リクエストの受信</a>を参照してください。
+<control>Ktor</control>
+</td>
+<td>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
+<tip>
+<p>
+<code>POST</code>、<code>PUT</code>、または <code>PATCH</code> リクエストのリクエストボディを受信する方法については、<a href="#receive-request">リクエストの受信</a>を参照してください。
                         </p>
-                    </tip>
-                    <p>
+</tip>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
         <p>
             次の例は、ルートハンドラーをパスごとにグループ化する方法を示しています。
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express では、<code>app.route()</code> を使用して、ルートパスに対してチェーン可能なルートハンドラーを作成できます。
                     </p>
-                    <code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
-                    <p>
+<code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor は <code>route</code> 関数を提供しており、これによってパスを定義し、そのパスの HTTP メソッドをネストされた関数として配置します。
                     </p>
-                    <code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
-                    <p>
+<code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
         <p>
             どちらのフレームワークでも、関連するルートを単一のファイルにグループ化できます。
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express は、マウント可能なルートハンドラーを作成するための <code>express.Router</code> クラスを提供しています。
                         アプリケーションのディレクトリに <Path>birds.js</Path> ルーターファイルがあると仮定します。
                         このルーターモジュールは、<Path>app.js</Path> に示すようにアプリケーションにロードできます。
                     </p>
-                    <Tabs>
-                        <TabItem title="birds.js">
-                            <code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
-                        </TabItem>
-                        <TabItem title="app.js">
-                            <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                        </TabItem>
-                    </Tabs>
-                    <p>
+<Tabs>
+<TabItem title="birds.js">
+<code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
+</TabItem>
+<TabItem title="app.js">
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+</TabItem>
+</Tabs>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor では、<code>Routing</code> 型の拡張関数を使用して実際のルートを定義するのが一般的なパターンです。
                         以下のサンプル (<Path>Birds.kt</Path>) は <code>birdsRoutes</code> 拡張関数を定義しています。
                         アプリケーション (<Path>Application.kt</Path>) の <code>routing</code> ブロック内でこの関数を呼び出すことで、対応するルートを含めることができます。
                     </p>
-                    <Tabs>
-                        <TabItem title="Birds.kt" id="birds-kt">
-                            <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
-                        </TabItem>
-                        <TabItem title="Application.kt" id="application-kt">
-                            <code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
-                        </TabItem>
-                    </Tabs>
-                    <p>
+<Tabs>
+<TabItem title="Birds.kt" id="birds-kt">
+<code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
+</TabItem>
+<TabItem title="Application.kt" id="application-kt">
+<code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
+</TabItem>
+</Tabs>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
         <p>
             URL パスを文字列として指定する以外に、Ktor には<Links href="//server-resources" summary="Resources プラグインを使用すると、型安全なルーティングを実装できます。">型安全なルート</Links>を実装する機能が含まれています。
         </p>
@@ -332,79 +308,71 @@
             ルート（またはパス）パラメータは、URL 内のその位置に指定された値をキャプチャするために使用される名前付きの URL セグメントです。
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express でルートパラメータにアクセスするには、<code>Request.params</code> を使用できます。
                         たとえば、以下のコードスニペットの <code>req.params["login"]</code> は、<Path>/user/admin</Path> パスに対して <emphasis>admin</emphasis> を返します。
                     </p>
-                    <code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor では、ルートパラメータは <code>{param}</code> 構文を使用して定義されます。
                         ルートハンドラーでルートパラメータにアクセスするには、<code>call.parameters</code> を使用できます。
                     </p>
-                    <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
-                    <p>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
         <p>
             以下の表は、クエリ文字列のパラメータにアクセスする方法を比較しています。
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express でクエリパラメータにアクセスするには、<code>Request.query</code> を使用できます。
                         たとえば、以下のコードスニペットの <code>req.query['price']</code> は、<Path>/products?price=asc</Path> パスに対して <emphasis>asc</emphasis> を返します。
                     </p>
-                    <code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor では、<code>call.request.queryParameters</code> を使用してクエリパラメータにアクセスできます。
                     </p>
-                    <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
-                    <p>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="レスポンスの送信" id="send-response">
         <p>
@@ -413,83 +381,75 @@
         </p>
         <chapter title="JSON" id="send-json">
             <table style="header-column">
-                
 <tr>
 <td>
-                        <control>Express</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                             Express で適切なコンテンツタイプで JSON レスポンスを送信するには、<code>res.json</code> 関数を呼び出します。
                         </p>
-                        <code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
-                        <p>
+<code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-                
 <tr>
 <td>
-                        <control>Ktor</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                             Ktor では、<Links href="//server-serialization" summary="ContentNegotiation プラグインは、クライアントとサーバー間のメディアタイプのネゴシエーションと、特定の形式でのコンテンツのシリアル化/非シリアル化の 2 つの主要な目的を果たします。">ContentNegotiation</Links> プラグインをインストールし、JSON シリアライザーを構成する必要があります。
                         </p>
-                        <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
-                        <p>
+<code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
+<p>
                             データを JSON にシリアル化するには、<code>@Serializable</code> アノテーションを付けたデータクラスを作成する必要があります。
                         </p>
-                        <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
-                        <p>
+<code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+<p>
                             その後、<code>call.respond</code> を使用して、レスポンスでこのクラスのオブジェクトを送信できます。
                         </p>
-                        <code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
-                        <p>
+<code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-            </table>
+</table>
         </chapter>
         <chapter title="ファイル" id="send-file">
             <table style="header-column">
-                
 <tr>
 <td>
-                        <control>Express</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                             Express でファイルを使用して応答するには、<code>res.sendFile</code> を使用します。
                         </p>
-                        <code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
-                        <p>
+<code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-                
 <tr>
 <td>
-                        <control>Ktor</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                             Ktor は、クライアントにファイルを送信するための <code>call.respondFile</code> 関数を提供しています。
                         </p>
-                        <code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
-                        <p>
+<code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-            </table>
+</table>
             <p>
                 Express アプリケーションは、ファイルで応答する際に <control>Accept-Ranges</control> HTTP レスポンスヘッダーを追加します。
                 サーバーはこのヘッダーを使用して、クライアントからのファイルダウンロードの部分リクエスト（Partial requests）のサポートを通知します。
@@ -498,75 +458,67 @@
         </chapter>
         <chapter title="ファイルの添付" id="send-file-attachment">
             <table style="header-column">
-                
 <tr>
 <td>
-                        <control>Express</control>
-                    </td>
-                    <td>
-                        <p>
-                            <code>res.download</code> 関数は、指定されたファイルを添付ファイルとして転送します。
+<control>Express</control>
+</td>
+<td>
+<p>
+<code>res.download</code> 関数は、指定されたファイルを添付ファイルとして転送します。
                         </p>
-                        <code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
-                        <p>
+<code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-                
 <tr>
 <td>
-                        <control>Ktor</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                             Ktor では、ファイルを添付ファイルとして転送するために <control>Content-Disposition</control> ヘッダーを手動で構成する必要があります。
                         </p>
-                        <code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
-                        <p>
+<code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-            </table>
+</table>
         </chapter>
         <chapter title="リダイレクト" id="redirect">
             <table style="header-column">
-                
 <tr>
 <td>
-                        <control>Express</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                             Express でリダイレクトレスポンスを生成するには、<code>redirect</code> 関数を呼び出します。
                         </p>
-                        <code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
-                        <p>
+<code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-                
 <tr>
 <td>
-                        <control>Ktor</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                             Ktor では、リダイレクトレスポンスを送信するために <code>respondRedirect</code> を使用します。
                         </p>
-                        <code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
-                        <p>
+<code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-            </table>
+</table>
         </chapter>
     </chapter>
     <chapter title="テンプレート" id="templates">
@@ -574,44 +526,40 @@
             Express と Ktor はどちらも、ビューを処理するためのテンプレートエンジンの使用をサポートしています。
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
-                        <Path>views</Path> フォルダーに次の Pug テンプレートがあると仮定します。
+<control>Express</control>
+</td>
+<td>
+<p>
+<Path>views</Path> フォルダーに次の Pug テンプレートがあると仮定します。
                     </p>
-                    <code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
-                    <p>
+<code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
+<p>
                         このテンプレートで応答するには、<code>res.render</code> を呼び出します。
                     </p>
-                    <code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor は、FreeMarker、Velocity など、いくつかの <Links href="//server-templating" summary="HTML/CSS または JVM テンプレートエンジンを使用して構築されたビューを操作する方法を学びます。">JVM テンプレートエンジン</Links>をサポートしています。
                         たとえば、アプリケーションリソースに配置された FreeMarker テンプレートで応答する必要がある場合は、<code>FreeMarker</code> プラグインをインストールして構成し、<code>call.respond</code> を使用してテンプレートを送信します。
                     </p>
-                    <code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
-                    <p>
+<code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="リクエストの受信" id="receive-request">
         <p>
@@ -626,44 +574,40 @@
                 サーバー側でこのリクエストのボディをプレーンテキストとして受信する方法を見てみましょう。
             </p>
             <table style="header-column">
-                
 <tr>
 <td>
-                        <control>Express</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                             Express で着信リクエストボディを解析するには、<code>body-parser</code> を追加する必要があります。
                         </p>
-                        <code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
-                        <p>
-                            <code>post</code> ハンドラーでは、テキストパーサー (<code>bodyParser.text</code>) を渡す必要があります。
+<code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
+<p>
+<code>post</code> ハンドラーでは、テキストパーサー (<code>bodyParser.text</code>) を渡す必要があります。
                             リクエストボディは <code>req.body</code> プロパティから利用できます。
                         </p>
-                        <code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
-                        <p>
+<code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-                
 <tr>
 <td>
-                        <control>Ktor</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                             Ktor では、<code>call.receiveText</code> を使用してボディをテキストとして受信できます。
                         </p>
-                        <code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
-                        <p>
+<code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-            </table>
+</table>
         </chapter>
         <chapter title="JSON" id="receive-json">
             <p>
@@ -672,47 +616,43 @@
             </p>
             <code-block lang="http" code="POST http://0.0.0.0:3000/json&#10;Content-Type: application/json&#10;&#10;{&#10;  &quot;type&quot;: &quot;Fiat&quot;,&#10;  &quot;model&quot; : &quot;500&quot;,&#10;  &quot;color&quot;: &quot;white&quot;&#10;}"/>
             <table style="header-column">
-                
 <tr>
 <td>
-                        <control>Express</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                             Express で JSON を受信するには、<code>bodyParser.json</code> を使用します。
                         </p>
-                        <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
-                        <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-                
 <tr>
 <td>
-                        <control>Ktor</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                             Ktor では、<Links href="//server-serialization" summary="ContentNegotiation プラグインは、クライアントとサーバー間のメディアタイプのネゴシエーションと、特定の形式でのコンテンツのシリアル化/非シリアル化の 2 つの主要な目的を果たします。">ContentNegotiation</Links> プラグインをインストールし、<code>Json</code> シリアライザーを構成する必要があります。
                         </p>
-                        <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
-                        <p>
+<code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
+<p>
                             受信したデータをオブジェクトにデシリアライズするには、データクラスを作成する必要があります。
                         </p>
-                        <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
-                        <p>
+<code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+<p>
                             次に、このデータクラスをパラメータとして受け取る <code>receive</code> メソッドを使用します。
                         </p>
-                        <code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
-                        <p>
+<code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-            </table>
+</table>
         </chapter>
         <chapter title="URL エンコード" id="receive-url-encoded">
             <p>
@@ -721,40 +661,36 @@
             </p>
             <code-block lang="http" code="POST http://localhost:3000/urlencoded&#10;Content-Type: application/x-www-form-urlencoded&#10;&#10;username=JetBrains&amp;email=example@jetbrains.com&amp;password=foobar&amp;confirmation=foobar"/>
             <table style="header-column">
-                
 <tr>
 <td>
-                        <control>Express</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                             プレーンテキストや JSON と同様に、Express では <code>body-parser</code> が必要です。
                             パーサーのタイプを <code>bodyParser.urlencoded</code> に設定する必要があります。
                         </p>
-                        <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
-                        <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-                
 <tr>
 <td>
-                        <control>Ktor</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                             Ktor では、<code>call.receiveParameters</code> 関数を使用します。
                         </p>
-                        <code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
-                        <p>
+<code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-            </table>
+</table>
         </chapter>
         <chapter title="生データ" id="receive-raw-data">
             <p>
@@ -763,39 +699,35 @@
             </p>
             <code-block lang="http" code="POST http://localhost:3000/raw&#10;Content-Type: application/octet-stream&#10;&#10;&lt; ./ktor_logo.png"/>
             <table style="header-column">
-                
 <tr>
 <td>
-                        <control>Express</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                             Express でバイナリデータを処理するには、パーサーのタイプを <code>raw</code> に設定します。
                         </p>
-                        <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
-                        <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-                
 <tr>
 <td>
-                        <control>Ktor</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                             Ktor は、バイトシーケンスを非同期で読み書きするための <code>ByteReadChannel</code> および <code>ByteWriteChannel</code> を提供しています。
                         </p>
-                        <code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
-                        <p>
+<code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive request</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-            </table>
+</table>
         </chapter>
         <chapter title="マルチパート" id="receive-multipart">
             <p>
@@ -804,41 +736,37 @@
             </p>
             <code-block lang="http" code="POST http://localhost:3000/multipart&#10;Content-Type: multipart/form-data; boundary=WebAppBoundary&#10;&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;description&quot;&#10;Content-Type: text/plain&#10;&#10;Ktor logo&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;image&quot;; filename=&quot;ktor_logo.png&quot;&#10;Content-Type: image/png&#10;&#10;&lt; ./ktor_logo.png&#10;--WebAppBoundary--"/>
             <table style="header-column">
-                
 <tr>
 <td>
-                        <control>Express</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                             Express ではマルチパートデータを解析するために別のモジュールが必要です。
                             以下の例では、<control>multer</control> を使用してサーバーにファイルをアップロードしています。
                         </p>
-                        <code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
-                        <p>
+<code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-                
 <tr>
 <td>
-                        <control>Ktor</control>
-                    </td>
-                    <td>
-                        <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                             Ktor では、マルチパートリクエストの一部として送信されたファイルを受信する必要がある場合、<code>receiveMultipart</code> 関数を呼び出し、必要に応じて各パートをループします。
                             以下の例では、<code>PartData.FileItem</code> を使用してファイルをバイトストリームとして受信しています。
                         </p>
-                        <code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
-                        <p>
+<code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
+<p>
                             完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a> プロジェクトを参照してください。
                         </p>
-                    </td>
+</td>
 </tr>
-
-            </table>
+</table>
         </chapter>
     </chapter>
     <chapter title="ミドルウェアの作成" id="middleware">
@@ -847,40 +775,36 @@
             以下の例は、Express と Ktor を使用してリクエストログを実装する方法を示しています。
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express では、ミドルウェアは <code>app.use</code> を使用してアプリケーションにバインドされた関数です。
                     </p>
-                    <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
-                    <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor では、<Links href="//server-custom-plugins" summary="独自のカスタムプラグインを作成する方法を学びます。">カスタムプラグイン</Links>を使用して機能を拡張できます。
                         以下のコード例は、リクエストログを実装するために <code>onCall</code> を処理する方法を示しています。
                     </p>
-                    <code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
-                    <p>
+<code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
+<p>
                         完全な例については、<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a> プロジェクトを参照してください。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="次のステップ" id="next">
         <p>

--- a/docs/ja/ktor/server-auto-reload.md
+++ b/docs/ja/ktor/server-auto-reload.md
@@ -1,0 +1,186 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="オートリロード (Auto-reload)"
+       id="server-auto-reload" help-id="Auto_reload">
+<tldr>
+    <p>
+        <b>コード例</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>,
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-embedded-server">autoreload-embedded-server</a>
+    </p>
+</tldr>
+<link-summary>
+    オートリロードを使用して、コードの変更時にアプリケーションクラスをリロードする方法を学びます。
+</link-summary>
+<p>
+    開発中にサーバーを<Links href="//server-run" summary="Ktorサーバーアプリケーションの実行方法を学びます。">再起動</Links>するには時間がかかる場合があります。
+    Ktorでは、<emphasis>オートリロード (Auto-reload)</emphasis>を使用することでこの制限を克服できます。これはコードの変更時にアプリケーションクラスをリロードし、素早いフィードバックループを提供します。
+    オートリロードを使用するには、以下の手順に従ってください。
+</p>
+<list style="decimal">
+    <li>
+        <p>
+            <a href="#enable">開発モードを有効にする</a>
+        </p>
+    </li>
+    <li>
+        <p>
+            （オプション）<a href="#watch-paths">監視パスを構成する</a>
+        </p>
+    </li>
+    <li>
+        <p>
+            <a href="#recompile">変更時の再コンパイルを有効にする</a>
+        </p>
+    </li>
+</list>
+<chapter title="制限事項" id="limitations">
+    オートリロードは特定のモジュール宣言に対してのみ機能します。以下の表は、バージョンごとのサポート状況を示しています。
+    <table>
+        
+<tr>
+<td>モジュールの種類</td>
+            <td>&lt;= 3.2</td>
+            <td>&gt; 3.2</td>
+</tr>
+
+        
+<tr>
+<td>ラムダ初期化子 (Lambda initializer)</td>
+            <td>❌ サポートされていません</td>
+            <td>❌ サポートされていません</td>
+</tr>
+
+        
+<tr>
+<td>ブロッキング関数の参照</td>
+            <td>✅ サポートされています</td>
+            <td>❌ サポートされていません</td>
+</tr>
+
+        
+<tr>
+<td>サスペンド関数の参照</td>
+            <td>❌ サポートされていません</td>
+            <td>✅ サポートされています</td>
+</tr>
+
+        
+<tr>
+<td>設定の参照 (Config reference)</td>
+            <td>✅ サポートされています</td>
+            <td>✅ サポートされています</td>
+</tr>
+
+    </table>
+    <chapter title="サポートされている形式" id="supported">
+        <code-block lang="kotlin" code="                // Suspend function reference&#10;                embeddedServer(Netty, port = 8080, module = Application::mySuspendModule)&#10;&#10;                // Configuration reference&#10;                ktor {&#10;                    application {&#10;                        modules = [ com.example.ApplicationKt.mySuspendModule ]&#10;                    }&#10;                }"/>
+    </chapter>
+    <chapter title="サポートされていない形式" id="not-supported">
+        <code-block lang="kotlin" code="                // Lambda&#10;                embeddedServer(Netty, port = 8080) { configureServer() }&#10;&#10;                // Blocking function reference&#10;                embeddedServer(Netty, port = 8080, module = Application::myBlockingModule)"/>
+    </chapter>
+</chapter>
+<chapter title="開発モードを有効にする" id="enable">
+    <p>
+        オートリロードを使用するには、まず<a href="#enable">開発モード</a>を有効にする必要があります。
+        これは、<Links href="//server-create-and-configure" summary="アプリケーションのデプロイニーズに応じたサーバーの作成方法を学びます。">サーバーの作成および実行</Links>に使用した方法によって異なります。
+    </p>
+    <list>
+        <li>
+            <p>
+                <code>EngineMain</code>を使用してサーバーを実行する場合は、<a href="#application-conf">設定ファイル</a>で開発モードを有効にします。
+            </p>
+        </li>
+        <li>
+            <p>
+                <code>embeddedServer</code>を使用してサーバーを実行する場合は、
+                <a href="#system-property"><code>io.ktor.development</code></a>
+                システムプロパティを使用できます。
+            </p>
+        </li>
+    </list>
+    <p>
+        開発モードが有効になると、Ktorは作業ディレクトリからの出力ファイルを自動的に監視します。
+        必要に応じて、<a href="#watch-paths">監視パス</a>を指定することで、監視対象のフォルダーを絞り込むことができます。
+    </p>
+</chapter>
+<chapter title="監視パスを構成する" id="watch-paths">
+    <p>
+        開発モードを<a href="#enable">有効</a>にすると、Ktorは作業ディレクトリからの出力ファイルの監視を開始します。
+        例えば、Gradleでビルドされた <Path>ktor-sample</Path> プロジェクトの場合、以下のフォルダーが監視されます。
+    </p>
+    <code-block code="            ktor-sample/build/classes/kotlin/main/META-INF&#10;            ktor-sample/build/classes/kotlin/main/com/example&#10;            ktor-sample/build/classes/kotlin/main/com&#10;            ktor-sample/build/classes/kotlin/main&#10;            ktor-sample/build/resources/main"/>
+    <p>
+        監視パスを使用すると、監視対象のフォルダーのセットを絞り込むことができます。
+        これを行うには、監視パスの一部を指定します。
+        例えば、<Path>ktor-sample/build/classes</Path> サブフォルダーの変更を監視するには、監視パスとして <code>classes</code> を渡します。
+        サーバーの実行方法に応じて、以下の方法で監視パスを指定できます。
+    </p>
+    <list>
+        <li>
+            <p>
+                <Path>application.conf</Path> または <Path>application.yaml</Path> ファイルで、<code>watch</code> オプションを指定します。
+            </p>
+            <Tabs group="config">
+                <TabItem title="application.conf" group-key="hocon">
+                    <code-block code="ktor {&#10;    development = true&#10;    deployment {&#10;        watch = [ classes ]&#10;    }&#10;}"/>
+                </TabItem>
+                <TabItem title="application.yaml" group-key="yaml">
+                    <code-block lang="yaml" code="ktor:&#10;    development: true&#10;    deployment:&#10;        watch:&#10;            - classes"/>
+                </TabItem>
+            </Tabs>
+            <p>
+                次のように複数の監視パスを指定することもできます。
+            </p>
+            <Tabs group="config">
+                <TabItem title="application.conf" group-key="hocon">
+                    <code-block code="                            watch = [ classes, resources ]"/>
+                </TabItem>
+                <TabItem title="application.yaml" group-key="yaml">
+                    <code-block lang="yaml" code="                            watch:&#10;                                - classes&#10;                                - resources"/>
+                </TabItem>
+            </Tabs>
+            <p>
+                完全な例はこちらで確認できます: <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>
+            </p>
+        </li>
+        <li>
+            <p>
+                <code>embeddedServer</code> を使用している場合は、<code>watchPaths</code> パラメーターとして監視パスを渡します。
+            </p>
+            <code-block lang="Kotlin" code="fun main() {&#10;    embeddedServer(Netty, port = 8080, watchPaths = listOf(&quot;classes&quot;), host = &quot;0.0.0.0&quot;, module = Application::module)&#10;        .start(wait = true)&#10;}&#10;&#10;fun Application.module() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, world!&quot;)&#10;        }&#10;    }&#10;}"/>
+            <p>
+                完全な例については、以下を参照してください。
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-embedded-server">
+                    autoreload-embedded-server
+                </a>
+            </p>
+        </li>
+    </list>
+</chapter>
+<chapter title="変更時に再コンパイルする" id="recompile">
+    <p>
+        オートリロードは出力ファイルの変更を検出するため、プロジェクトをリビルドする必要があります。
+        これは IntelliJ IDEA で手動で行うか、Gradle の <code>-t</code> コマンドラインオプションを使用して継続的ビルド実行を有効にすることで行えます。
+    </p>
+    <list>
+        <li>
+            <p>
+                IntelliJ IDEA でプロジェクトを手動でリビルドするには、メインメニューから <ui-path>ビルド | プロジェクトのビルド</ui-path> を選択します。
+            </p>
+        </li>
+        <li>
+            <p>
+                Gradle を使用して自動的にプロジェクトをリビルドするには、ターミナルで <code>-t</code> オプションを付けて <code>build</code> タスクを実行します。
+            </p>
+            <code-block lang="Bash" code="                    ./gradlew -t build"/>
+            <tip>
+                <p>
+                    プロジェクトのリロード時にテストの実行をスキップするには、<code>build</code> タスクに <code>-x</code> オプションを渡すことができます。
+                </p>
+                <code-block lang="Bash" code="                        ./gradlew -t build -x test -i"/>
+            </tip>
+        </li>
+    </list>
+</chapter>
+</topic>

--- a/docs/ja/ktor/server-auto-reload.md
+++ b/docs/ja/ktor/server-auto-reload.md
@@ -37,42 +37,32 @@
 <chapter title="制限事項" id="limitations">
     オートリロードは特定のモジュール宣言に対してのみ機能します。以下の表は、バージョンごとのサポート状況を示しています。
     <table>
-        
 <tr>
 <td>モジュールの種類</td>
-            <td>&lt;= 3.2</td>
-            <td>&gt; 3.2</td>
+<td>&lt;= 3.2</td>
+<td>&gt; 3.2</td>
 </tr>
-
-        
 <tr>
 <td>ラムダ初期化子 (Lambda initializer)</td>
-            <td>❌ サポートされていません</td>
-            <td>❌ サポートされていません</td>
+<td>❌ サポートされていません</td>
+<td>❌ サポートされていません</td>
 </tr>
-
-        
 <tr>
 <td>ブロッキング関数の参照</td>
-            <td>✅ サポートされています</td>
-            <td>❌ サポートされていません</td>
+<td>✅ サポートされています</td>
+<td>❌ サポートされていません</td>
 </tr>
-
-        
 <tr>
 <td>サスペンド関数の参照</td>
-            <td>❌ サポートされていません</td>
-            <td>✅ サポートされています</td>
+<td>❌ サポートされていません</td>
+<td>✅ サポートされています</td>
 </tr>
-
-        
 <tr>
 <td>設定の参照 (Config reference)</td>
-            <td>✅ サポートされています</td>
-            <td>✅ サポートされています</td>
+<td>✅ サポートされています</td>
+<td>✅ サポートされています</td>
 </tr>
-
-    </table>
+</table>
     <chapter title="サポートされている形式" id="supported">
         <code-block lang="kotlin" code="                // Suspend function reference&#10;                embeddedServer(Netty, port = 8080, module = Application::mySuspendModule)&#10;&#10;                // Configuration reference&#10;                ktor {&#10;                    application {&#10;                        modules = [ com.example.ApplicationKt.mySuspendModule ]&#10;                    }&#10;                }"/>
     </chapter>

--- a/docs/ja/ktor/server-configuration-code.md
+++ b/docs/ja/ktor/server-configuration-code.md
@@ -1,0 +1,167 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   title="コードによる設定"
+   id="server-configuration-code" help-id="Configuration-code;server-configuration-in-code">
+<show-structure for="chapter"/>
+<link-summary>
+    コード内でさまざまなサーバーパラメータを設定する方法を学びます。
+</link-summary>
+<p>
+    Ktorでは、ホストアドレス、ポート、<Links href="//server-modules" summary="モジュールを使用すると、ルートをグループ化してアプリケーションを構造化できます。">サーバーモジュール</Links>など、さまざまなサーバーパラメータをコード内で直接設定できます。設定方法は、サーバーのセットアップ方法（<Links href="//server-create-and-configure" summary="アプリケーションのデプロイのニーズに応じてサーバーを作成する方法を学びます。">embeddedServerまたはEngineMain</Links>のどちらを使用するか）によって異なります。
+</p>
+<p>
+    <code>embeddedServer</code>を使用する場合、必要なパラメータを関数に直接渡すことでサーバーを設定します。
+    <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/embedded-server.html">
+        embeddedServer
+    </a>
+    関数は、<Links href="//server-engines" summary="ネットワークリクエストを処理するエンジンについて学びます。">サーバーエンジン</Links>、サーバーがリッスンするホストとポート、および追加の設定など、サーバーを構成するためのさまざまなパラメータを受け取ります。
+</p>
+<p>
+    このセクションでは、サーバーを効果的に設定する方法を示すために、<code>embeddedServer</code>を実行するいくつかの異なる例を見ていきます。
+</p>
+<chapter title="基本設定" id="embedded-basic">
+    <p>
+        以下のコードスニペットは、Nettyエンジンと<code>8080</code>ポートを使用した基本的なサーバーセットアップを示しています。
+    </p>
+    <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(Netty, port = 8080) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+    <p>
+        <code>port</code>パラメータを<code>0</code>に設定すると、サーバーをランダムなポートで実行できることに注意してください。
+        <code>embeddedServer</code>関数はエンジンインスタンスを返すため、
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/resolved-connectors.html">
+            ApplicationEngine.resolvedConnectors
+        </a>
+        関数を使用してコード内でポート値を取得できます。
+    </p>
+</chapter>
+<chapter title="エンジン設定" id="embedded-engine">
+    <snippet id="embedded-engine-configuration">
+        <p>
+            <code>embeddedServer</code>関数では、<code>configure</code>パラメータを使用してエンジン固有のオプションを渡すことができます。このパラメータには、すべてのエンジンに共通で、
+            <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/index.html">
+                ApplicationEngine.Configuration
+            </a>
+            クラスによって公開されているオプションが含まれます。
+        </p>
+        <p>
+            以下の例は、<code>Netty</code>エンジンを使用してサーバーを設定する方法を示しています。
+            <code>configure</code>ブロック内で、<code>connector</code>を定義してホストとポートを指定し、さまざまなサーバーパラメータをカスタマイズしています。
+        </p>
+        <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(Netty, configure = {&#10;        connectors.add(EngineConnectorBuilder().apply {&#10;            host = &quot;127.0.0.1&quot;&#10;            port = 8080&#10;        })&#10;        connectionGroupSize = 2&#10;        workerGroupSize = 5&#10;        callGroupSize = 10&#10;        shutdownGracePeriod = 2000&#10;        shutdownTimeout = 3000&#10;    }) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+        <p>
+            <code>connectors.add()</code>メソッドは、指定されたホスト（<code>127.0.0.1</code>）とポート（<code>8080</code>）でコネクタを定義します。
+        </p>
+        <p>これらのオプションに加えて、他のエンジン固有のプロパティを設定することもできます。</p>
+        <chapter title="Netty" id="netty-code">
+            <p>
+                Netty固有のオプションは、
+                <a href="https://api.ktor.io/ktor-server-netty/io.ktor.server.netty/-netty-application-engine/-configuration/index.html">
+                    NettyApplicationEngine.Configuration
+                </a>
+                クラスによって公開されています。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.netty.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Netty, configure = {&#10;                            requestQueueLimit = 16&#10;                            shareWorkGroup = false&#10;                            configureBootstrap = {&#10;                                // ...&#10;                            }&#10;                            responseWriteTimeoutSeconds = 10&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="Jetty" id="jetty-code">
+            <p>
+                Jetty固有のオプションは、
+                <a href="https://api.ktor.io/ktor-server-jetty-jakarta/io.ktor.server.jetty.jakarta/-jetty-application-engine-base/-configuration/index.html">
+                    JettyApplicationEngineBase.Configuration
+                </a>
+                クラスによって公開されています。
+            </p>
+            <p>
+                <a href="https://api.ktor.io/ktor-server-jetty-jakarta/io.ktor.server.jetty.jakarta/-jetty-application-engine-base/-configuration/configure-server.html">
+                    configureServer
+                </a>
+                ブロック内でJettyサーバーを設定できます。これにより、
+                <a href="https://www.eclipse.org/jetty/javadoc/jetty-11/org/eclipse/jetty/server/Server.html">Server</a>
+                インスタンスにアクセスできます。
+            </p>
+            <p>
+                <code>idleTimeout</code>プロパティを使用して、接続が閉じられるまでにアイドル状態を維持できる期間を指定します。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.jetty.jakarta.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Jetty, configure = {&#10;                            configureServer = { // this: Server -&amp;gt;&#10;                                // ...&#10;                            }&#10;                            idleTimeout = 30.seconds&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="CIO" id="cio-code">
+            <p>CIO固有のオプションは、
+                <a href="https://api.ktor.io/ktor-server-cio/io.ktor.server.cio/-c-i-o-application-engine/-configuration/index.html">
+                    CIOApplicationEngine.Configuration
+                </a>
+                クラスによって公開されています。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.cio.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(CIO, configure = {&#10;                            connectionIdleTimeoutSeconds = 45&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="Tomcat" id="tomcat-code">
+            <p>エンジンとしてTomcatを使用する場合、
+                <a href="https://api.ktor.io/ktor-server-tomcat-jakarta/io.ktor.server.tomcat.jakarta/-tomcat-application-engine/-configuration/configure-tomcat.html">
+                    configureTomcat
+                </a>
+                プロパティを使用して設定できます。これにより、
+                <a href="https://tomcat.apache.org/tomcat-10.1-doc/api/org/apache/catalina/startup/Tomcat.html">Tomcat</a>
+                インスタンスにアクセスできます。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.tomcat.jakarta.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Tomcat, configure = {&#10;                            configureTomcat = { // this: Tomcat -&amp;gt;&#10;                                // ...&#10;                            }&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+    </snippet>
+</chapter>
+<chapter title="カスタム環境" id="embedded-custom">
+    <p>
+        以下の例は、
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/index.html">
+            ApplicationEngine.Configuration
+        </a>
+        クラスで表されるカスタム設定を使用して、複数のコネクタエンドポイントでサーバーを実行する方法を示しています。
+    </p>
+    <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main() {&#10;    val appProperties = serverConfig {&#10;        module { module() }&#10;    }&#10;    embeddedServer(Netty, appProperties) {&#10;        envConfig()&#10;    }.start(true)&#10;}&#10;&#10;fun ApplicationEngine.Configuration.envConfig() {&#10;    connector {&#10;        host = &quot;0.0.0.0&quot;&#10;        port = 8080&#10;    }&#10;    connector {&#10;        host = &quot;127.0.0.1&quot;&#10;        port = 9090&#10;    }&#10;}"/>
+    <p>
+        完全な例については、
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server-multiple-connectors">
+            embedded-server-multiple-connectors
+        </a>を参照してください。
+    </p>
+    <tip>
+        <p>
+            カスタム環境を使用して
+            <a href="#embedded-server">
+                HTTPSを提供
+            </a>することもできます。
+        </p>
+    </tip>
+</chapter>
+<chapter id="command-line" title="コマンドライン設定">
+    <p>
+        Ktorでは、コマンドライン引数を使用して<code>embeddedServer</code>を動的に設定できます。これは、ポート、ホスト、タイムアウトなどの設定を実行時に指定する必要がある場合に特に便利です。
+    </p>
+    <p>
+        これを実現するには、
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-command-line-config.html">
+            CommandLineConfig
+        </a>
+        クラスを使用してコマンドライン引数を設定オブジェクトにパースし、それを設定ブロック内で渡します。
+    </p>
+    <code-block lang="kotlin" code="fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(&#10;        factory = Netty,&#10;        configure = {&#10;            val cliConfig = CommandLineConfig(args)&#10;            takeFrom(cliConfig.engineConfig)&#10;            loadCommonConfiguration(cliConfig.rootConfig.environment.config)&#10;        }&#10;    ) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+    <p>
+        この例では、<code>Application.Configuration</code>の
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/take-from.html">
+            <code>takeFrom()</code>
+        </a>
+        関数を使用して、<code>port</code>や<code>host</code>などのエンジン設定値を上書きしています。
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/load-common-configuration.html">
+            <code>loadCommonConfiguration()</code>
+        </a>
+        関数は、タイムアウトなどのルート環境からの設定をロードします。
+    </p>
+    <p>
+        サーバーを実行するには、次のように引数を指定します。
+    </p>
+    <code-block lang="shell" code="            ./gradlew run --args=&quot;-port=8080&quot;"/>
+    <tip>
+        静的な設定については、設定ファイルまたは環境変数を使用できます。
+        詳細については、
+        <a href="#command-line">
+            ファイルによる設定
+        </a>
+        を参照してください。
+    </tip>
+</chapter>
+</topic>

--- a/docs/ja/ktor/server-create-a-new-project.md
+++ b/docs/ja/ktor/server-create-a-new-project.md
@@ -1,0 +1,716 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   title="新しいKtorプロジェクトの作成、オープン、実行"
+   id="server-create-a-new-project"
+   help-id="server_create_a_new_project">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <var name="example_name" value="tutorial-server-get-started"/>
+    <p>
+        <b>コード例</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+</tldr>
+<link-summary>
+    Ktorを使用してサーバーアプリケーションをオープン、実行、およびテストする方法を学びます。
+</link-summary>
+<web-summary>
+    最初のKtorサーバーアプリケーションの構築を開始しましょう。このチュートリアルでは、新しいKtorプロジェクトの作成、オープン、および実行方法を学びます。
+</web-summary>
+<p>
+    このチュートリアルでは、最初のKtorサーバープロジェクトを作成、オープン、および実行する方法を学びます。プロジェクトが起動して実行されたら、一連のタスクを完了してKtorに慣れることができます。
+</p>
+<p>
+    これは、Ktorを使用したサーバーアプリケーション構築を開始するための一連のチュートリアルの最初のステップです。各チュートリアルは独立して行うことができますが、以下の推奨される順序に従うことを強くお勧めします。
+</p>
+<list type="decimal">
+    <li>新しいKtorプロジェクトの作成、オープン、実行。</li>
+    <li><Links href="//server-requests-and-responses" summary="タスク管理アプリケーションを構築することで、Ktorを使用したKotlinでのルーティング、リクエスト処理、およびパラメータの基本を学びます。">リクエストの処理とレスポンスの生成</Links>。</li>
+    <li><Links href="//server-create-restful-apis" summary="JSONファイルを生成するRESTful APIの例を特徴とする、KotlinとKtorを使用したバックエンドサービスの構築方法を学びます。">JSONを生成するRESTful APIの作成</Links>。</li>
+    <li><Links href="//server-create-website" summary="KtorとThymeleafテンプレートを使用してKotlinでウェブサイトを構築する方法を学びます。">Thymeleafテンプレートを使用したウェブサイトの作成</Links>。</li>
+    <li><Links href="//server-create-websocket-application" summary="WebSocketのパワーを活用してコンテンツを送信および受信する方法を学びます。">WebSocketアプリケーションの作成</Links>。</li>
+    <li><Links href="//server-integrate-database" summary="Exposed SQLライブラリを使用して、Ktorサービスをデータベースリポジトリに接続するプロセスを学びます。">Exposedを使用したデータベースの統合</Links>。</li>
+</list>
+<chapter id="create-project" title="新しいKtorプロジェクトの作成">
+    <p>
+        新しいKtorプロジェクトを作成する最も速い方法の1つは、<a href="#create-project-with-the-ktor-project-generator">ウェブベースのKtorプロジェクトジェネレーターを使用すること</a>です。
+    </p>
+    <p>
+        あるいは、<a href="#create_project_with_intellij">IntelliJ IDEA Ultimate専用のKtorプラグイン</a>または<a href="#create_project_with_ktor_cli_tool">Ktor CLIツール</a>を使用してプロジェクトを生成することもできます。
+    </p>
+    <chapter title="Ktorプロジェクトジェネレーターの使用"
+             id="create-project-with-the-ktor-project-generator">
+        <p>
+            Ktorプロジェクトジェネレーターで新しいプロジェクトを作成するには、以下の手順に従ってください。
+        </p>
+        <procedure>
+            <step>
+                <p><a href="https://start.ktor.io/">Ktorプロジェクトジェネレーター</a>にアクセスします。</p>
+            </step>
+            <step>
+                <p>
+                    <control>Project artifact</control>フィールドに、プロジェクトアーティファクトの名前として
+                    <Path>com.example.ktor-sample</Path>
+                    と入力します。
+                    <img src="ktor_343_project_generator_new_project_artifact_name.png"
+                         alt="Project Artifact名にcom.example.ktor-sampleを指定したKtorプロジェクトジェネレーター"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                </p>
+            </step>
+            <step id="configure-project-step">
+                <p>
+                    <control>Configure</control>をクリックして、設定ドロップダウンメニューを開きます。
+                    <img src="ktor_343_project_generator_new_project_configure.png"
+                         style="block"
+                         alt="Ktorプロジェクト設定の展開ビュー" border-effect="line" width="706"/>
+                </p>
+                <p>
+                    以下の設定が利用可能です：
+                </p>
+                <list>
+                    <li>
+                        <p>
+                            <control>Build System</control>：
+                            希望する<Links href="//server-dependencies" summary="既存のGradle/MavenプロジェクトにKtorサーバーの依存関係を追加する方法を学びます。">ビルドシステム</Links>を選択します。
+                            これは<emphasis>Gradle Kotlin</emphasis>、<emphasis>Gradle Groovy</emphasis>、<emphasis>Maven</emphasis>、または<emphasis>Amper</emphasis>にすることができます。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Engine</control>：
+                            サーバーの実行に使用される<Links href="//server-engines" summary="ネットワークリクエストを処理するエンジンについて学びます。">エンジン</Links>を選択します。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Configuration</control>：
+                            サーバーパラメータを<Links href="//server-configuration-file" summary="構成ファイルでさまざまなサーバーパラメータを構成する方法を学びます。">YAMLまたはHOCONファイルで指定</Links>するか、<Links href="//server-configuration-code" summary="コード内でさまざまなサーバーパラメータを構成する方法を学びます。">コード内で指定</Links>するかを選択します。
+                        </p>
+                        <warning>
+                            現在、MavenベースのKtorプロジェクトではYAML構成はサポートされていません。
+                        </warning>
+                    </li>
+                </list>
+                <p>このチュートリアルでは、これらの設定はデフォルト値のままで構いません。</p>
+            </step>
+            <step>
+                <p>
+                    <control>Done</control>をクリックして構成を保存し、メニューを閉じます。
+                </p>
+            </step>
+            <step>
+                <p>
+                    その下には、プロジェクトに追加できる一連の<Links href="//server-plugins" summary="プラグインは、シリアル化、コンテンツエンコーディング、圧縮などの一般的な機能を提供します。">プラグイン</Links>が表示されます。プラグインは、認証、シリアル化とコンテンツエンコーディング、圧縮、Cookieのサポートなど、Ktorアプリケーションで一般的な機能を提供する構成要素です。
+                </p>
+                <p>このチュートリアルでは、現段階でプラグインを追加する必要はありません。</p>
+            </step>
+            <step>
+                <p>
+                    <control>Download</control>ボタンをクリックして、Ktorプロジェクトを生成してダウンロードします。
+                    <img src="ktor_343_project_generator_new_project_download.png"
+                         alt="Ktorプロジェクトジェネレーターのダウンロードボタン"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                </p>
+            </step>
+            <p>ダウンロードが自動的に開始されます。</p>
+        </procedure>
+        <p>新しいプロジェクトが生成されたので、続けて<a href="#unpacking">Ktorプロジェクトの展開と実行</a>に進んでください。</p>
+    </chapter>
+    <chapter title="IntelliJ IDEA Ultimate用のKtorプラグインの使用" id="create_project_with_intellij"
+             collapsible="true">
+        <p>
+            このセクションでは、IntelliJ IDEA Ultimate用の<a href="https://plugins.jetbrains.com/plugin/16008-ktor">Ktorプラグイン</a>を使用したプロジェクトのセットアップについて説明します。
+        </p>
+        <p>
+            新しいKtorプロジェクトを作成するには、<a href="https://www.jetbrains.com/help/idea/run-for-the-first-time.html">IntelliJ IDEAを開き</a>、以下の手順に従ってください。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    ウェルカム画面で、<control>New Project</control>をクリックします。
+                </p>
+                <p>
+                    または、メインメニューから<ui-path>File | New | Project</ui-path>を選択します。
+                </p>
+            </step>
+            <step>
+                <p>
+                    <control>New Project</control>ウィザードで、左側のリストから<control>Ktor</control>を選択します。
+                </p>
+            </step>
+            <step>
+                <p>
+                    右側のペインで、以下の設定を指定できます。
+                </p>
+                <img src="ktor_idea_new_project_settings.png" alt="Ktorプロジェクト設定" width="706"
+                     border-effect="rounded"/>
+                <list>
+                    <li>
+                        <p>
+                            <control>Name</control>：プロジェクト名を指定します。プロジェクトの名前として<Path>ktor-sample</Path>と入力します。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Location</control>：プロジェクトのディレクトリを指定します。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Website</control>：パッケージ名の生成に使用されるドメインを指定します。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Artifact</control>：このフィールドには生成されたアーティファクト名が表示されます。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Engine</control>：サーバーの実行に使用される<Links href="//server-engines" summary="ネットワークリクエストを処理するエンジンについて学びます。">エンジン</Links>を選択します。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Include samples</control>：プラグインのサンプルコードを追加するには、このオプションを有効にしたままにします。
+                        </p>
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    <control>Advanced Settings</control>をクリックして、追加設定メニューを展開します。
+                </p>
+                <img src="ktor_idea_new_project_advanced_settings.png" alt="Ktorプロジェクト詳細設定"
+                     width="706" border-effect="rounded"/>
+                <p>
+                    以下の設定が利用可能です：
+                </p>
+                <list>
+                    <li>
+                        <p>
+                            <control>Build System</control>：
+                            希望する<Links href="//server-dependencies" summary="既存のGradle/MavenプロジェクトにKtorサーバーの依存関係を追加する方法を学びます。">ビルドシステム</Links>を選択します。
+                            これは<emphasis>Gradle Kotlin</emphasis>、<emphasis>Gradle Groovy</emphasis>、<emphasis>Maven</emphasis>、または<emphasis>Amper</emphasis>にすることができます。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Ktor version</control>：
+                            必要なKtorバージョンを選択します。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Configuration</control>：
+                            サーバーパラメータを<Links href="//server-configuration-file" summary="構成ファイルでさまざまなサーバーパラメータを構成する方法を学びます。">YAMLまたはHOCONファイルで指定</Links>するか、<Links href="//server-configuration-code" summary="コード内でさまざまなサーバーパラメータを構成する方法を学びます。">コード内で指定</Links>するかを選択します。
+                        </p>
+                        <warning>
+                            現在、Mavenベース의 KtorプロジェクトではYAML構成はサポートされていません。
+                        </warning>
+                    </li>
+                </list>
+                <p>このチュートリアルでは、これらの設定はデフォルト値のままで構いません。</p>
+            </step>
+            <step>
+                <p>
+                    <control>Next</control>をクリックして次のページに進みます。
+                </p>
+                <img src="ktor_idea_new_project_plugins_list.png" alt="Ktorプラグイン" width="706"
+                     border-effect="rounded"/>
+                <p>
+                    このページでは、一連の<Links href="//server-plugins" summary="プラグインは、シリアル化、コンテンツエンコーディング、圧縮などの一般的な機能を提供します。">プラグイン</Links>（認証、シリアル化とコンテンツエンコーディング、圧縮、Cookieのサポートなど、Ktorアプリケーションの一般的な機能を提供する構成要素）を選択できます。
+                </p>
+                <p>このチュートリアルでは、現段階でプラグインを追加する必要はありません。</p>
+            </step>
+            <step>
+                <p>
+                    <control>Create</control>をクリックし、IntelliJ IDEAがプロジェクトを生成して依存関係をインストールするまで待ちます。
+                </p>
+            </step>
+        </procedure>
+        <p>
+            新しいプロジェクトを作成したので、続けてアプリケーションの<a href="#open-explore-run">オープン、探索、および実行</a>方法を学習してください。
+        </p>
+    </chapter>
+    <chapter title="Ktor CLIツールの使用" id="create_project_with_ktor_cli_tool"
+             collapsible="true">
+        <p>
+            このセクションでは、<a href="https://github.com/ktorio/ktor-cli">Ktor CLIツール</a>を使用したプロジェクトのセットアップについて説明します。
+        </p>
+        <p>
+            新しいKtorプロジェクトを作成するには、お好みのターミナルを開き、以下の手順に従ってください。
+        </p>
+        <procedure>
+            <step>
+                以下のいずれかのコマンドを使用して、Ktor CLIツールをインストールします。
+                <Tabs>
+                    <TabItem title="macOS/Linux" id="macos-linux">
+                        <code-block lang="console" code="                                brew install ktor"/>
+                    </TabItem>
+                    <TabItem title="Windows" id="windows">
+                        <code-block lang="console" code="                                winget install JetBrains.KtorCLI"/>
+                    </TabItem>
+                </Tabs>
+            </step>
+            <step>
+                対話モードで新しいプロジェクトを生成するには、次のコマンドを使用します。
+                <code-block lang="console" code="                      ktor new"/>
+            </step>
+            <step>
+                プロジェクト名として<Path>ktor-sample</Path>と入力します。
+                <img src="server_create_cli_tool_name_dark.png"
+                     alt="対話モードでのKtor CLIツールの使用"
+                     border-effect="rounded"
+                     style="block"
+                     width="706"/>
+                <p>
+                    （オプション）プロジェクト名の下の<ui-path>Location</ui-path>パスを編集することで、プロジェクトが保存される場所を変更することもできます。
+                </p>
+            </step>
+            <step>
+                <shortcut>Enter</shortcut>を押して続行します。
+            </step>
+            <step>
+                次のステップでは、プロジェクトに<Links href="//server-plugins" summary="プラグインは、シリアル化、コンテンツエンコーディング、圧縮などの一般的な機能を提供します。">プラグイン</Links>を検索して追加できます。プラグインは、認証、シリアル化とコンテンツエンコーディング、圧縮、Cookieのサポートなど、Ktorアプリケーションで一般的な機能を提供する構成要素です。
+                <img src="server_create_cli_tool_add_plugins_dark.png"
+                     alt="Ktor CLIツールを使用したプロジェクトへのプラグインの追加"
+                     border-effect="rounded"
+                     style="block"
+                     width="706"/>
+                <p>このチュートリアルでは、現段階でプラグインを追加する必要はありません。</p>
+            </step>
+            <step>
+                <shortcut>CTRL+G</shortcut>を押してプロジェクトを生成します。
+                <p>
+                    あるいは、<control>CREATE PROJECT (CTRL+G)</control>を選択して<shortcut>Enter</shortcut>を押すことでもプロジェクトを生成できます。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+</chapter>
+<chapter title="Ktorプロジェクトの展開と実行" id="unpacking">
+    <p>
+        このセクションでは、コマンドラインからプロジェクトを展開、ビルド、および実行する方法を学びます。以下の手順は、次のような状況を想定しています。
+    </p>
+    <list type="bullet">
+        <li><Path>ktor-sample</Path>という名前のGradleプロジェクトを作成し、ダウンロードした。</li>
+        <li>このプロジェクトは、ホームディレクトリの<Path>myprojects</Path>というフォルダに配置されている。</li>
+    </list>
+    <p>必要に応じて、自身のセットアップに合わせて名前とパスを変更してください。</p>
+    <p>お好みのコマンドラインツールを開き、以下の手順に従います。</p>
+    <procedure>
+        <step>
+            <p>ターミナルウィンドウで、プロジェクトをダウンロードしたフォルダに移動します。</p>
+            <code-block lang="console" code="                    cd ~/myprojects"/>
+        </step>
+        <step>
+            <p>ZIPアーカイブを同名のフォルダに展開します。</p>
+            <Tabs>
+                <TabItem title="macOS" group-key="macOS">
+                    <code-block lang="console" code="                            unzip ktor-sample.zip -d ktor-sample"/>
+                </TabItem>
+                <TabItem title="Windows" group-key="windows">
+                    <code-block lang="console" code="                            tar -xf ktor-sample.zip"/>
+                </TabItem>
+            </Tabs>
+            <p>ディレクトリには、ZIPアーカイブと展開されたフォルダが含まれるようになります。</p>
+        </step>
+        <step>
+            <p>ディレクトリから、新しく作成されたフォルダに移動します。</p>
+            <code-block lang="console" code="                    cd ktor-sample"/>
+        </step>
+        <step>
+            <p>macOSおよびUNIXシステムでは、システムが実行可能なコマンドとして認識できるように、Gradleヘルパースクリプトを実行可能にする必要があります。これを行うには、<code>chmod</code>コマンドを使用します。</p>
+            <Tabs>
+                <TabItem title="macOS" group-key="macOS">
+                    <code-block lang="console" code="                            chmod +x ./gradlew"/>
+                </TabItem>
+            </Tabs>
+        </step>
+        <step>
+            <p>プロジェクトをビルドするには、次のコマンドを使用します。</p>
+            <Tabs>
+                <TabItem title="macOS" group-key="macOS">
+                    <code-block lang="console" code="                            ./gradlew build"/>
+                </TabItem>
+                <TabItem title="Windows" group-key="windows">
+                    <code-block lang="console" code="                            gradlew build"/>
+                </TabItem>
+            </Tabs>
+            <p>ビルドが成功したら、次のステップに進んでプロジェクトを実行します。</p>
+        </step>
+        <step>
+            <p>プロジェクトを実行するには、次のコマンドを使用します。</p>
+            <Tabs>
+                <TabItem title="macOS" group-key="macOS">
+                    <code-block lang="console" code="                            ./gradlew run"/>
+                </TabItem>
+                <TabItem title="Windows" group-key="windows">
+                    <code-block lang="console" code="                            gradlew run"/>
+                </TabItem>
+            </Tabs>
+        </step>
+        <step>
+            <p>プロジェクトが実行されていることを確認するには、ターミナル出力に表示されているURL（<a href="http://0.0.0.0:8080">http://0.0.0.0:8080</a>）をブラウザで開きます。
+                ブラウザに「Hello World!」というメッセージが表示されるはずです。</p>
+            <img src="server_get_started_ktor_sample_app_output.png" alt="生成されたKtorプロジェクトの出力"
+                 border-effect="line" width="706"/>
+        </step>
+    </procedure>
+    <p>おめでとうございます！Ktorプロジェクトの起動に成功しました。</p>
+    <note>
+        基盤となるプロセスがKtorアプリケーションの実行でビジー状態であるため、コマンドラインが応答しなくなることに注意してください。<shortcut>CTRL+C</shortcut>を押すとアプリケーションを終了できます。
+    </note>
+</chapter>
+<chapter title="IntelliJ IDEAでのKtorプロジェクトのオープン、探索、および実行" id="open-explore-run">
+    <chapter title="プロジェクトをオープンする" id="open">
+        <p><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a>がインストールされている場合は、コマンドラインから簡単にプロジェクトを開くことができます。
+        </p>
+        <p>
+            プロジェクトフォルダ内にいることを確認し、<code>idea</code>コマンドに続けて、現在のフォルダを表すピリオドを入力します。
+        </p>
+        <code-block lang="Bash" code="                idea ."/>
+        <p>
+            または、手動でプロジェクトを開くには、IntelliJ IDEAを起動します。
+        </p>
+        <p>
+            ウェルカム画面が開いた場合は、<control>Open</control>をクリックします。そうでない場合は、メインメニューの<ui-path>File | Open</ui-path>に移動し、<Path>ktor-sample</Path>フォルダを選択して開きます。
+        </p>
+        <tip>
+            プロジェクトの管理に関する詳細は、<a href="https://www.jetbrains.com/help/idea/creating-and-managing-projects.html">IntelliJ IDEAのドキュメント</a>を参照してください。
+        </tip>
+    </chapter>
+    <chapter title="プロジェクトを探索する" id="explore">
+        <p>プロジェクトを開くと、次のような構造が表示されます。</p>
+        <img src="tutorial_server_get_started_idea_project_view.png" alt="IDEでの生成されたKtorプロジェクトビュー" width="706"/>
+        <p>
+            完全なレイアウトを表示するには、各フォルダの横にある展開矢印をクリックして、<control>Project</control>ビューのフォルダを展開します。
+        </p>
+        <p>
+            アプリケーションのソースコードは、<Path>src/main/kotlin</Path>の下にあります。デフォルトで、<Path>Application.kt</Path>と<Path>Routing.kt</Path>という2つのファイルが作成されます。
+        </p>
+        <img src="tutorial_server_get_started_idea_main_folder.png" alt="Ktorプロジェクトのsrcフォルダ構造" width="400"/>
+        <p>プロジェクト名は<Path>settings.gradle.kts</Path>ファイルで構成されています。
+        </p>
+        <code-block lang="kotlin" code="rootProject.name = &quot;ktor-sample&quot;"/>
+        <p>
+            構成ファイルやその他の種類のコンテンツは、<Path>src/main/resources</Path>フォルダ内に配置されます。
+        </p>
+        <img src="tutorial_server_get_started_idea_resources_folder.png" alt="Ktorプロジェクトのresourcesフォルダ構造"
+             width="400"/>
+    </chapter>
+    <chapter title="プロジェクトを実行する" id="run">
+        <procedure>
+            <p>IntelliJ IDEA内からプロジェクトを実行するには：</p>
+            <step>
+                <p>右側のサイドバーにあるGradleアイコン（<img alt="IntelliJ IDEA Gradleアイコン"
+                                                  src="intellij_idea_gradle_icon.svg" width="16" height="26"/>）をクリックして、<a href="https://www.jetbrains.com/help/idea/jetgradle-tool-window.html">Gradleツールウィンドウ</a>を開きます。</p>
+            </step>
+            <step>
+                <p>このツールウィンドウ内で、<ui-path>Tasks | application</ui-path>に移動し、<control>run</control>タスクをダブルクリックします。
+                </p>
+                <img src="tutorial_server_get_started_idea_gradle_run.png" alt="IntelliJ IDEAのGradleタブ"
+                     border-effect="line" width="450"/>
+            </step>
+            <step>
+                <p>KtorアプリケーションがIDEの下部にある<a href="https://www.jetbrains.com/help/idea/run-tool-window.html">実行（Run）ツールウィンドウ</a>で起動します。</p>
+                <img src="tutorial_server_get_started_idea_run_terminal.png" alt="ターミナルで実行中のプロジェクト" width="706"/>
+                <p>以前にコマンドラインに表示されていたものと同じメッセージが、<ui-path>Run</ui-path>ツールウィンドウに表示されます。
+                </p>
+            </step>
+            <step>
+                <p>プロジェクトが実行されていることを確認するには、指定されたURL（<a href="http://0.0.0.0:8080">http://0.0.0.0:8080</a>）をブラウザで開きます。</p>
+                <p>画面に「Hello World!」というメッセージが再び表示されるはずです。</p>
+                <img src="server_get_started_ktor_sample_app_output.png" alt="ブラウザ画面のHello World"
+                     width="706"/>
+            </step>
+        </procedure>
+        <p>
+            <ui-path>Run</ui-path>ツールウィンドウを介してアプリケーションを管理できます。
+        </p>
+        <list type="bullet">
+            <li>
+                アプリケーションを終了するには、停止ボタン（<img src="intellij_idea_terminate_icon.svg"
+                                                     style="inline" height="16" width="16"
+                                                     alt="IntelliJ IDEA終了アイコン"/>）をクリックします。
+            </li>
+            <li>
+                プロセスを再起動するには、再実行ボタン（<img src="intellij_idea_rerun_icon.svg"
+                                                  style="inline" height="16" width="16"
+                                                  alt="IntelliJ IDEA再実行アイコン"/>）をクリックします。
+            </li>
+        </list>
+        <p>
+            これらのオプションの詳細については、<a href="https://www.jetbrains.com/help/idea/run-tool-window.html#run-toolbar">IntelliJ IDEA実行ツールウィンドウのドキュメント</a>を参照してください。
+        </p>
+    </chapter>
+</chapter>
+<chapter title="試してみるべき追加タスク" id="additional-tasks">
+    <p>試してみることをお勧めする追加タスクをいくつか紹介します：</p>
+    <list type="decimal">
+        <li><a href="#change-the-default-port">デフォルトポートの変更</a></li>
+        <li><a href="#add-a-new-http-endpoint">新しいHTTPエンドポイントの追加</a></li>
+        <li><a href="#configure-static-content">静的コンテンツの構成</a></li>
+        <li><a href="#write-an-integration-test">統合テストの作成</a></li>
+        <li><a href="#register-error-handlers">エラーハンドラーの登録</a></li>
+    </list>
+    <p>
+        これらのタスクは互いに依存していませんが、徐々に難易度が上がっていきます。宣言された順序で試すことが、段階的に学習するための最も簡単な方法です。簡単にするため、また重複を避けるため、以下の説明はタスクを順番に試していることを前提としています。
+    </p>
+    <p>
+        コーディングが必要な箇所については、コードと対応するインポートの両方を指定しています。IDEがこれらのインポートを自動的に追加してくれる場合もあります。
+    </p>
+    <chapter title="デフォルトポートの変更" id="change-the-default-port">
+        <chapter title="構成ファイルでのポート変更" id="change-the-port-in-config">
+            <p>
+                構成を外部のYAMLまたはHOCONファイルに保存することを選択した場合、<ui-path>Project</ui-path>ビューで<Path>src/main/resources</Path>フォルダに移動し、以下の手順に従います。
+            </p>
+            <procedure id="change-default-port-yaml-procedure">
+                <step>
+                    構成ファイル（<Path>application.yaml</Path>または<Path>application.conf</Path>）を開きます。次のようになっているはずです：
+                    <Tabs>
+                        <TabItem title="application.yaml (YAML)" group-key="yaml">
+                            <code-block lang="yaml" code="ktor:&#10;  deployment:&#10;    port: 8080&#10;  application:&#10;    modules:&#10;      - com.example.RoutingKt.configureRouting"/>
+                        </TabItem>
+                        <TabItem title="application.conf (HOCON)" group-key="hocon">
+                            <code-block lang="generic" code="ktor {&#10;  deployment {&#10;    port = 8080&#10;    port = ${?PORT}&#10;  }&#10;  application {&#10;    modules = [&#10;      com.example.RoutingKt.configureRouting&#10;    ]&#10;  }&#10;}"/>
+                        </TabItem>
+                    </Tabs>
+                </step>
+                <step>
+                    ファイル内の<code>port</code>の値を、<code>9292</code>など、任意の見慣れない番号に変更します。
+                </step>
+                <step>
+                    <p>再実行ボタン（<img alt="IntelliJ IDEA再実行ボタンアイコン"
+                                       src="intellij_idea_rerun_icon.svg" height="16" width="16"/>）をクリックして、アプリケーションを再起動します。</p>
+                </step>
+                <step>
+                    <p>アプリケーションが新しいポート番号で実行されていることを確認するには、新しいURL（<a href="http://0.0.0.0:9292">http://0.0.0.0:9292</a>）をブラウザで開くか、<a href="https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html#creating-http-request-files">IntelliJ IDEAで新しいHTTPリクエストファイルを作成</a>します。</p>
+                    <img src="tutorial_server_get_started_port_change.png"
+                         alt="IntelliJ IDEAのHTTPリクエストファイルを使用したポート変更のテスト" width="706"/>
+                </step>
+            </procedure>
+        </chapter>
+        <chapter title="コード内でのポート変更" id="change-the-port-in-code">
+            <p>
+                <a href="#configure-project-step">新しいKtorプロジェクトを作成する際</a>、構成をコード内に保存するか、外部のYAMLまたはHOCONファイルに保存するかを選択できます。
+            </p>
+            <p>
+                構成をコード内に保存することを選択した場合、<ui-path>Project</ui-path>ビューで<Path>src/main/kotlin</Path>フォルダに移動し、以下の手順に従います。
+            </p>
+            <procedure id="change-the-default-port-code-procedure">
+                <step>
+                    <p><Path>main.kt</Path>ファイルを開きます。次のようなコードが見つかるはずです。
+                    </p>
+                    <code-block lang="kotlin" code="                            fun main(args: Array&lt;String&gt;) {&#10;                                embeddedServer(&#10;                                    factory = io.ktor.server.netty.Netty,&#10;                                    port = 8080,&#10;                                    host = &quot;0.0.0.0&quot;,&#10;                                    module = Application::rootModule&#10;                                ).start(wait = true)&#10;                            }"/>
+                </step>
+                <step>
+                    <p><code>embeddedServer()</code>関数内で、<code>port</code>パラメータを<code>9292</code>など、任意の別の番号に変更します。</p>
+                    <code-block lang="kotlin" code="                            fun main(args: Array&lt;String&gt;) {&#10;                                embeddedServer(&#10;                                    factory = io.ktor.server.netty.Netty,&#10;                                    port = 9292,&#10;                                    host = &quot;0.0.0.0&quot;,&#10;                                    module = Application::rootModule&#10;                                ).start(wait = true)&#10;                            }"/>
+                </step>
+                <step>
+                    <p>再実行ボタン（<img alt="IntelliJ IDEA再実行ボタンアイコン"
+                                       src="intellij_idea_rerun_icon.svg" height="16" width="16"/>）をクリックして、アプリケーションを再起動します。</p>
+                </step>
+                <step>
+                    <p>アプリケーションが新しいポート番号で実行されていることを確認するには、新しいURL（<a href="http://0.0.0.0:9292">http://0.0.0.0:9292</a>）をブラウザで開くか、<a href="https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html#creating-http-request-files">IntelliJ IDEAで新しいHTTPリクエストファイルを作成</a>します。</p>
+                    <img src="tutorial_server_get_started_port_change.png"
+                         alt="IntelliJ IDEAのHTTPリクエストファイルを使用したポート変更のテスト" width="706"/>
+                </step>
+            </procedure>
+        </chapter>
+    </chapter>
+    <chapter title="新しいHTTPエンドポイントの追加" id="add-a-new-http-endpoint">
+        <p>
+            <ui-path>Project</ui-path>ツールウィンドウで、<Path>src/main/kotlin</Path>フォルダに移動し、以下の手順に従います。
+        </p>
+        <procedure>
+            <step>
+                <p><Path>Routing.kt</Path>ファイルを開きます。次のようなコードが表示されるはずです：
+                </p>
+                <code-block lang="Kotlin" validate="true" code="                        fun Application.configureRouting() {&#10;                            routing {&#10;                                get(&quot;/&quot;) {&#10;                                    call.respondText(&quot;Hello World!&quot;)&#10;                                }&#10;                            }&#10;                        }"/>
+            </step>
+            <step>
+                <p>新しいエンドポイントを作成するには、次のように追加のルートを挿入します。</p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        // ...&#10;&#10;        get(&quot;/test1&quot;) {&#10;            val text = &quot;&lt;h1&gt;Hello From Ktor&lt;/h1&gt;&quot;&#10;            val type = ContentType.parse(&quot;text/html&quot;)&#10;            call.respondText(text, type)&#10;        }&#10;    }&#10;}"/>
+                <note><code>/test1</code>というURLは、好きなものに変更できることに注意してください。</note>
+            </step>
+            <step>
+                <p>IDEは自動的に<code>ContentType</code>のインポートを追加します。</p>
+                <code-block lang="kotlin" code="                        import io.ktor.http.ContentType"/>
+            </step>
+            <step>
+                <p>再実行ボタン（<img alt="IntelliJ IDEA再実行ボタンアイコン"
+                                   src="intellij_idea_rerun_icon.svg" height="16" width="16"/>）をクリックして、アプリケーションを再起動します。</p>
+            </step>
+            <step>
+                <p>ブラウザで新しいURL（<a href="http://0.0.0.0:9292/test1">http://0.0.0.0:9292/test1</a>）をリクエストします。ポート番号は、<a href="#change-the-default-port">デフォルトポートの変更</a>タスクを完了したかどうかによって異なります。以下のような出力が表示されるはずです。</p>
+                <img src="server_get_started_add_new_http_endpoint_output.png"
+                     alt="ブラウザ画面にHello from Ktorが表示されている様子" width="706"/>
+                <p>HTTPリクエストファイルを作成した場合は、そこでも新しいエンドポイントを確認できます。</p>
+                <code-block lang="http" code="                    GET http://0.0.0.0:9292&#10;&#10;                    ###&#10;&#10;                    GET http://0.0.0.0:9292/test1"/>
+                <note>異なるリクエストを区切るには、3つのハッシュ（<code>###</code>）を含む行が必要であることに注意してください。</note>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="静的コンテンツの構成" id="configure-static-content">
+        <p><ui-path>Project</ui-path>ツールウィンドウで、<Path>src/main/kotlin</Path>フォルダに移動し、以下の手順に従います。
+        </p>
+        <procedure>
+            <step>
+                <p><Path>Routing.kt</Path>ファイルを開き、ルーティングセクションに次のルートを追加します。</p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        staticResources(&quot;/content&quot;, &quot;mycontent&quot;)&#10;        // ...&#10;    }&#10;}"/>
+                <p>この行の意味は次のとおりです：</p>
+                <list type="bullet">
+                    <li><code>staticResources()</code>を呼び出すことで、アプリケーションがHTMLやJavaScriptファイルなどの標準的なウェブサイトコンテンツを提供できるようになります。このコンテンツはブラウザ内で実行できますが、サーバーの観点からは静的であると見なされます。
+                    </li>
+                    <li>URL <code>/content</code>は、このコンテンツを取得するために使用されるパスを指定します。
+                    </li>
+                    <li>パス <code>mycontent</code>は、静的コンテンツを配置するフォルダの名前です。Ktorは、このフォルダを<code>resources</code>ディレクトリ内で探します。
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>IDEが自動的に追加しない場合は、次のインポートを追加してください。</p>
+                <code-block lang="kotlin" code="                        import io.ktor.server.http.content.staticResources"/>
+            </step>
+            <step>
+                <p><control>Project</control>ツールウィンドウで、<Path>src/main/resources</Path>フォルダを右クリックし、<control>New | Directory</control>を選択します。
+                </p>
+                <p>または、<Path>src/main/resources</Path>フォルダを選択し、<shortcut>⌘Cmd+N</shortcut>（macOS）または<shortcut>Ctrl+N</shortcut>（Windows/Linux）を押し、<control>Directory</control>をクリックします。
+                </p>
+            </step>
+            <step>
+                <p>新しいディレクトリに<code>mycontent</code>という名前を付け、<shortcut>↩Enter</shortcut>を押します。
+                </p>
+            </step>
+            <step>
+                <p>新しく作成したフォルダを右クリックし、<control>New | File</control>をクリックします。
+                </p>
+            </step>
+            <step>
+                <p>新しいファイルに<Path>sample.html</Path>という名前を付け、<shortcut>↩Enter</shortcut>を押します。
+                </p>
+            </step>
+            <step>
+                <p>新しく作成したファイルページに、有効なHTMLを入力します（例）：</p>
+                <code-block lang="html" code="&lt;html lang=&quot;en&quot;&gt;&#10;    &lt;head&gt;&#10;        &lt;meta charset=&quot;UTF-8&quot; /&gt;&#10;        &lt;title&gt;My sample&lt;/title&gt;&#10;    &lt;/head&gt;&#10;    &lt;body&gt;&#10;        &lt;h1&gt;This page is built with:&lt;/h1&gt;&#10;        &lt;ol&gt;&#10;            &lt;li&gt;Ktor&lt;/li&gt;&#10;            &lt;li&gt;Kotlin&lt;/li&gt;&#10;            &lt;li&gt;HTML&lt;/li&gt;&#10;        &lt;/ol&gt;&#10;    &lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>再実行ボタン（<img alt="IntelliJ IDEA再実行ボタンアイコン"
+                                   src="intellij_idea_rerun_icon.svg" height="16" width="16"/>）をクリックして、アプリケーションを再起動します。</p>
+            </step>
+            <step>
+                <p>ブラウザで<a href="http://0.0.0.0:9292/content/sample.html">http://0.0.0.0:9292/content/sample.html</a>を開くと、サンプルページの内容が表示されるはずです。</p>
+                <img src="server_get_started_configure_static_content_output.png"
+                     alt="ブラウザでの静的ページの出力" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="統合テストの作成" id="write-an-integration-test">
+        <p>
+            Ktorは<Links href="//server-testing" summary="特別なテストエンジンを使用してサーバーアプリケーションをテストする方法を学びます。">統合テストの作成</Links>をサポートしており、生成されたプロジェクトにはこの機能がバンドルされています。
+        </p>
+        <p>これを利用するには、以下の手順に従ってください。</p>
+        <procedure>
+            <step>
+                <p>
+                    <Path>src/test/kotlin</Path>フォルダに移動します。
+                </p>
+            </step>
+            <step>
+                <p><Path>ServerTest.kt</Path>ファイルを開きます。次のコードが表示されるはずです：</p>
+                <code-block lang="kotlin" code="class ServerTest {&#10;&#10;    @Test&#10;    fun `test root endpoint`() = testApplication {&#10;        // デフォルト構成をロードします&#10;        configure()&#10;        // サーバーのルートが200を返すことを確認します&#10;        assertEquals(HttpStatusCode.OK, client.get(&quot;/&quot;).status)&#10;    }&#10;&#10;}"/>
+                <p><code>testApplication()</code>関数は、Ktorの新しいインスタンスを作成します。このインスタンスは、Nettyなどのサーバーではなく、テスト環境内で実行されます。</p>
+                <p>次に、<code>configure()</code>関数を使用して、<code>embeddedServer()</code>から呼び出されるのと同じセットアップを呼び出すことができます。</p>
+                <p>最後に、組み込みの<code>client</code>オブジェクトとJUnitアサーションを使用して、サンプルリクエストを送信し、レスポンスを確認できます。</p>
+            </step>
+        </procedure>
+        <p>
+            IntelliJ IDEAでテストを実行する標準的な方法のいずれかでテストを実行できます。Ktorの新しいインスタンスを実行しているため、テストの成否はアプリケーションが<code>0.0.0.0</code>で実行されているかどうかには依存しないことに注意してください。
+        </p>
+        <p>
+            <a href="#add-a-new-http-endpoint">新しいHTTPエンドポイントの追加</a>に成功した場合は、この追加のテストを追加してください：
+        </p>
+        <code-block lang="kotlin" code="    @Test&#10;    fun `test new endpoint`() = testApplication {&#10;        configure()&#10;&#10;        val response = client.get(&quot;/test1&quot;)&#10;&#10;        assertEquals(HttpStatusCode.OK, response.status)&#10;        assertEquals(&quot;html&quot;, response.contentType()?.contentSubtype)&#10;        assertContains(response.bodyAsText(), &quot;Hello From Ktor&quot;)&#10;    }"/>
+        <p>以下の追加のインポートを追加します：</p>
+        <code-block lang="Kotlin" code="                import io.ktor.http.contentType&#10;                import io.ktor.client.statement.bodyAsText"/>
+    </chapter>
+    <chapter title="エラーハンドラーの登録" id="register-error-handlers">
+        <p>
+            <Links href="//server-status-pages" summary="%plugin_name%を使用すると、Ktorアプリケーションは、スローされた例外やステータスコードに基づいて、あらゆる失敗状態に適切に応答できるようになります。">StatusPagesプラグイン</Links>を使用して、Ktorアプリケーションのエラーを処理できます。
+        </p>
+        <tip>
+            このプラグインは、デフォルトではプロジェクトに含まれていません。Ktorプロジェクトジェネレーター、またはIntelliJ IDEAのプロジェクトウィザードでプロジェクトを作成する際に、<ui-path>Plugins</ui-path>セクションから追加できます。
+        </tip>
+        <p>
+            次のステップでは、プラグインを手動で追加および構成する方法を学びます。これを達成するための4つのステップがあります：
+        </p>
+        <list type="decimal">
+            <li><a href="#add-dependency">Gradleビルドファイルに新しい依存関係を追加する。</a></li>
+            <li><a href="#install-plugin-and-specify-handler">プラグインをインストールし、例外ハンドラーを指定する。</a></li>
+            <li><a href="#write-sample-code">ハンドラーをトリガーするためのサンプルコードを作成する。</a></li>
+            <li><a href="#restart-and-invoke">サンプルコードを再起動して呼び出す。</a></li>
+        </list>
+        <procedure title="新しい依存関係の追加" id="add-dependency">
+            <p><control>Project</control>ツールウィンドウで、プロジェクトのルートフォルダに移動し、以下の手順に従います。
+            </p>
+            <step>
+                <p><Path>build.gradle.kts</Path>ファイルを開き、次のように新しい依存関係を追加します：</p>
+                <code-block lang="kotlin" code="dependencies {&#10;    implementation(ktorLibs.server.config.yaml)&#10;    implementation(ktorLibs.server.core)&#10;    implementation(ktorLibs.server.netty)&#10;    // 新しい依存関係を追加&#10;    implementation(ktorLibs.server.statusPages)&#10;    implementation(libs.logback.classic)&#10;&#10;    testImplementation(kotlin(&quot;test&quot;))&#10;    testImplementation(ktorLibs.server.testHost)&#10;}"/>
+            </step>
+            <step>
+                <p><shortcut>Shift+⌘Cmd+I</shortcut>（macOS）または<shortcut>Ctrl+Shift+O</shortcut>（Windows/Linux）を押して、プロジェクトをリロードします。
+                </p>
+            </step>
+        </procedure>
+        <procedure title="プラグインのインストールと例外ハンドラーの指定"
+                   id="install-plugin-and-specify-handler">
+            <step>
+                <p><Path>Routing.kt</Path>の<code>.configureRouting()</code>メソッドに移動し、次のコード行を追加します：</p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    install(StatusPages) {&#10;        exception&lt;IllegalStateException&gt; { call, cause -&gt;&#10;            call.respondText(&quot;App in illegal state as ${cause.message}&quot;)&#10;        }&#10;    }&#10;    routing {&#10;        // ...&#10;    }&#10;}"/>
+                <p>これらの行は、<code>StatusPages</code>プラグインをインストールし、<code>IllegalStateException</code>型の例外がスローされたときにどのようなアクションを実行するかを指定します。</p>
+            </step>
+            <step>
+                <p>以下のインポートを追加します：</p>
+                <code-block lang="kotlin" code="                        import io.ktor.server.plugins.statuspages.StatusPages"/>
+            </step>
+        </procedure>
+        <p>
+            通常、レスポンスにはHTTPエラーコードが設定されますが、このタスクの目的上、出力はブラウザに直接表示されます。
+        </p>
+        <procedure title="ハンドラーをトリガーするためのサンプルコードの作成" id="write-sample-code">
+            <step>
+                <p><code>.configureRouting()</code>メソッド内にとどまり、次のように追加のルートを追加します：</p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    install(StatusPages) {&#10;        exception&lt;IllegalStateException&gt; { call, cause -&gt;&#10;            call.respondText(&quot;App in illegal state as ${cause.message}&quot;)&#10;        }&#10;    }&#10;    routing {&#10;        // ...&#10;&#10;        get(&quot;/error-test&quot;) {&#10;            throw IllegalStateException(&quot;Too Busy&quot;)&#10;        }&#10;    }&#10;}"/>
+                <p>これで、URL <code>/error-test</code>を持つエンドポイントが追加されました。このエンドポイントがトリガーされると、ハンドラーで使用されている型の例外がスローされます。</p>
+            </step>
+        </procedure>
+        <procedure title="サンプルコードの再起動と呼び出し" id="restart-and-invoke">
+            <step>
+                <p>再実行ボタン（<img alt="IntelliJ IDEA再実行ボタンアイコン"
+                                   src="intellij_idea_rerun_icon.svg" height="16" width="16"/>）をクリックして、アプリケーションを再起動します。</p></step>
+            <step>
+                <p>ブラウザで、URL <a href="http://0.0.0.0:9292/error-test">http://0.0.0.0:9292/error-test</a>にアクセスします。次のようにエラーメッセージが表示されるはずです：</p>
+                <img src="server_get_started_register_error_handler_output.png"
+                     alt="`App in illegal state as Too Busy`というメッセージが表示されたブラウザ画面" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+</chapter>
+<chapter title="次のステップ" id="next_steps">
+    <p>
+        追加タスクの最後まで到達したなら、Ktorサーバーの構成、Ktorプラグインの統合、および新しいルートの実装について理解できたはずです。しかし、これはほんの始まりに過ぎません。Ktorの基礎的な概念をさらに深く掘り下げるには、このガイドの次のチュートリアルに進んでください。
+    </p>
+    <p>
+        次は、<Links href="//server-requests-and-responses" summary="タスク管理アプリケーションを構築することで、Ktorを使用したKotlinでのルーティング、リクエスト処理、およびパラメータの基本を学びます。">タスク管理アプリケーションを作成して、リクエストを処理しレスポンスを生成する方法</Links>を学びます。
+    </p>
+</chapter>
+</topic>

--- a/docs/ja/ktor/server-create-and-configure.md
+++ b/docs/ja/ktor/server-create-and-configure.md
@@ -1,0 +1,130 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   title="サーバーの作成"
+   id="server-create-and-configure" help-id="start_server;create_server">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <p>
+        <b>コード例</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">embedded-server</a>,
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">engine-main</a>,
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-yaml">engine-main-yaml</a>
+    </p>
+</tldr>
+<link-summary>
+    アプリケーションのデプロイのニーズに応じてサーバーを作成する方法を学びます。
+</link-summary>
+<p>
+    Ktorアプリケーションを作成する前に、アプリケーションをどのように
+    <Links href="//server-deployment" summary="">
+        デプロイ
+    </Links>
+    するかを考慮する必要があります。
+</p>
+<list>
+    <li>
+        <p>
+            <control><a href="#embedded">自己完結型パッケージ</a></control>として
+        </p>
+        <p>
+            この場合、ネットワークリクエストを処理するために使用されるアプリケーション<Links href="//server-engines" summary="ネットワークリクエストを処理するエンジンについて学びます。">エンジン</Links>をアプリケーションの一部にする必要があります。
+            アプリケーションはエンジンの設定、接続、およびSSLオプションを制御できます。
+        </p>
+    </li>
+    <li>
+        <p>
+            <control>
+                <a href="#servlet">サーブレット</a>
+            </control>として
+        </p>
+        <p>
+            この場合、Ktorアプリケーションはサーブレットコンテナ（TomcatやJettyなど）内にデプロイできます。サーブレットコンテナがアプリケーションのライフサイクルと接続設定を制御します。
+        </p>
+    </li>
+</list>
+<chapter title="自己完結型パッケージ" id="embedded">
+    <p>
+        Ktorサーバーアプリケーションを自己完結型パッケージとして提供するには、まずサーバーを作成する必要があります。
+        サーバーの設定には、サーバー<Links href="//server-engines" summary="ネットワークリクエストを処理するエンジンについて学びます。">エンジン</Links>（Netty、Jettyなど）、さまざまなエンジン固有のオプション、ホストとポートの値など、さまざまな設定を含めることができます。
+        Ktorでサーバーを作成して実行するには、主に2つのアプローチがあります。
+    </p>
+    <list>
+        <li>
+            <p>
+                <code>embeddedServer</code>関数は、
+                <a href="#embedded-server">
+                    コード内でサーバーパラメータを設定
+                </a>
+                し、アプリケーションを素早く実行するためのシンプルな方法です。
+            </p>
+        </li>
+        <li>
+            <p>
+                <code>EngineMain</code>は、サーバーを設定するためのより高い柔軟性を提供します。
+                <a href="#engine-main">
+                    ファイル内でサーバーパラメータを指定
+                </a>
+                できるため、アプリケーションを再コンパイルせずに設定を変更できます。さらに、コマンドラインからアプリケーションを実行し、対応するコマンドライン引数を渡すことで必要なサーバーパラメータを上書きすることも可能です。
+            </p>
+        </li>
+    </list>
+    <chapter title="コード内での設定" id="embedded-server">
+        <p>
+            <code>embeddedServer</code>関数は、
+            <Links href="//server-configuration-code" summary="コード内でさまざまなサーバーパラメータを設定する方法を学びます。">コード内</Links>
+            でサーバーパラメータを設定し、アプリケーションを素早く実行するためのシンプルな方法です。以下のコードスニペットでは、サーバーを起動するためのパラメータとして
+            <Links href="//server-engines" summary="ネットワークリクエストを処理するエンジンについて学びます。">エンジン</Links>
+            とポートを受け取ります。以下の例では、<code>Netty</code>エンジンを使用してサーバーを実行し、<code>8080</code>ポートでリスンします。
+        </p>
+        <code-block lang="kotlin" code="package com.example&#10;&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    if (args.isEmpty()) {&#10;        println(&quot;Running basic server...&quot;)&#10;        println(&quot;Provide the 'configured' argument to run a configured server.&quot;)&#10;        runBasicServer()&#10;    }&#10;&#10;    when (args[0]) {&#10;        &quot;basic&quot; -&gt; runBasicServer()&#10;        &quot;configured&quot; -&gt; runConfiguredServer()&#10;        else -&gt; runServerWithCommandLineConfig(args)&#10;    }&#10;}&#10;&#10;fun runBasicServer() {&#10;    embeddedServer(Netty, port = 8080) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}&#10;&#10;fun runConfiguredServer() {&#10;    embeddedServer(Netty, configure = {&#10;        connectors.add(EngineConnectorBuilder().apply {&#10;            host = &quot;127.0.0.1&quot;&#10;            port = 8080&#10;        })&#10;        connectionGroupSize = 2&#10;        workerGroupSize = 5&#10;        callGroupSize = 10&#10;        shutdownGracePeriod = 2000&#10;        shutdownTimeout = 3000&#10;    }) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}&#10;&#10;fun runServerWithCommandLineConfig(args: Array&lt;String&gt;) {&#10;    embeddedServer(&#10;        factory = Netty,&#10;        configure = {&#10;            val cliConfig = CommandLineConfig(args)&#10;            takeFrom(cliConfig.engineConfig)&#10;            loadCommonConfiguration(cliConfig.rootConfig.environment.config)&#10;        }&#10;    ) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+        <p>
+            完全な例については、
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">
+                embedded-server
+            </a>
+            を参照してください。
+        </p>
+    </chapter>
+    <chapter title="ファイル内での設定" id="engine-main">
+        <p>
+            <code>EngineMain</code>は、選択したエンジンでサーバーを起動し、外部の<Links href="//server-configuration-file" summary="設定ファイルでさまざまなサーバーパラメータを設定する方法を学びます。">設定ファイル</Links>（通常は<Path>resource</Path>ディレクトリにある<Path>application.conf</Path>または<Path>application.yaml</Path>）から<Links href="//server-modules" summary="モジュールを使用すると、ルートをグループ化してアプリケーションを構造化できます。">アプリケーションモジュール</Links>を読み込みます。
+        </p>
+        <p>
+            どのモジュールを読み込むかの指定に加えて、設定ファイルにはポート、ホスト、SSL設定などのさまざまなサーバーパラメータを含めることができます。例えば、以下の設定ではサーバーポートを<code>8080</code>に設定しています。
+        </p>
+        <Tabs>
+            <TabItem title="Application.kt" id="application-kt">
+                <code-block lang="kotlin" code="package com.example&#10;&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit = io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, world!&quot;)&#10;        }&#10;    }&#10;}"/>
+            </TabItem>
+            <TabItem title="application.conf" id="application-conf">
+                <code-block code="ktor {&#10;    deployment {&#10;        port = 8080&#10;    }&#10;    application {&#10;        modules = [ com.example.ApplicationKt.module ]&#10;    }&#10;}"/>
+            </TabItem>
+            <TabItem title="application.yaml" id="application-yaml">
+                <code-block lang="yaml" code="ktor:&#10;    deployment:&#10;        port: 8080&#10;    application:&#10;        modules:&#10;            - com.example.ApplicationKt.module"/>
+            </TabItem>
+        </Tabs>
+        <note>
+            <code>EngineMain.main()</code>でサーバーを即座に起動する代わりに、<code>EngineMain.createServer()</code>を使用して手動でサーバーインスタンスを作成することもできます。詳細については、<a href="#createServer"></a>を参照してください。
+        </note>
+        <p>
+            完全な例については、
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">
+                engine-main
+            </a>
+            および
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-yaml">
+                engine-main-yaml
+            </a>
+            を参照してください。
+        </p>
+    </chapter>
+</chapter>
+<chapter title="サーブレット" id="servlet">
+    <p>
+        Ktorアプリケーションは、TomcatやJettyを含むサーブレットコンテナ内で実行およびデプロイできます。
+        サーブレットコンテナ内にデプロイするには、
+        <Links href="//server-war" summary="WARアーカイブを使用してサーブレットコンテナ内でKtorアプリケーションを実行およびデプロイする方法を学びます。">WAR</Links>
+        アーカイブを生成し、それをサーバーまたはWARをサポートするクラウドサービスにデプロイする必要があります。
+    </p>
+</chapter>
+</topic>

--- a/docs/ja/ktor/server-create-restful-apis.md
+++ b/docs/ja/ktor/server-create-restful-apis.md
@@ -1,0 +1,515 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Ktorを使用したKotlinでのRESTful APIの作成方法" id="server-create-restful-apis"
+       help-id="create-restful-apis">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <var name="example_name" value="tutorial-server-restful-api"/>
+    <p>
+        <b>コード例</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+    <p>
+        <b>使用されているプラグイン</b>: <Links href="//server-routing" summary="Routingは、サーバーアプリケーションで受信リクエストを処理するためのコアプラグインです。">Routing</Links>,<Links href="//server-static-content" summary="スタイルシート、スクリプト、画像などの静的コンテンツを提供する方法を学びます。">Static Content</Links>,
+        <Links href="//server-serialization" summary="ContentNegotiationプラグインは、クライアントとサーバー間のメディアタイプのネゴシエーションと、特定のフォーマットでのコンテンツのシリアライズ/デシリアライズという2つの主要な目的を果たします。">Content Negotiation</Links>, <a
+            href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>
+    </p>
+</tldr>
+<card-summary>
+    Ktorを使用してRESTful APIを構築する方法を学びます。このチュートリアルでは、セットアップ、ルーティング、および実例に基づいたテストについて説明します。
+</card-summary>
+<web-summary>
+    Ktorを使用してKotlin RESTful APIを構築する方法を学びます。このチュートリアルでは、セットアップ、ルーティング、および実例に基づいたテストについて説明します。Kotlinバックエンド開発者にとって理想的な入門レベルのチュートリアルです。
+</web-summary>
+<link-summary>
+    KotlinとKtorを使用してバックエンドサービスを構築する方法を学びます。JSONファイルを生成するRESTful APIの例を紹介します。
+</link-summary>
+<p>
+    このチュートリアルでは、KotlinとKtorを使用してバックエンドサービスを構築する方法を説明し、JSONデータを生成するRESTful APIの例を紹介します。
+</p>
+<p>
+    <Links href="//server-requests-and-responses" summary="タスクマネージャーアプリケーションの構築を通じて、KotlinとKtorでのルーティング、リクエストの処理、およびパラメータの基本を学びます。">前のチュートリアル</Links>では、バリデーション、エラー処理、およびユニットテストの基礎を紹介しました。このチュートリアルでは、これらのトピックを拡張し、タスクを管理するためのRESTfulサービスを作成します。
+</p>
+<p>
+    以下の内容を学習します：
+</p>
+<list>
+    <li>JSONシリアライズを使用するRESTfulサービスを作成する。</li>
+    <li><Links href="//server-serialization" summary="ContentNegotiationプラグインは、クライアントとサーバー間のメディアタイプのネゴシエーションと、特定のフォーマットでのコンテンツのシリアライズ/デシリアライズという2つの主要な目的を果たします。">Content Negotiation</Links>のプロセスを理解する。</li>
+    <li>Ktor内でREST APIのルートを定義する。</li>
+</list>
+<chapter title="前提条件" id="prerequisites">
+    <p>このチュートリアルは単独で行うこともできますが、<Links href="//server-requests-and-responses" summary="タスクマネージャーアプリケーションの構築を通じて、KotlinとKtorでのルーティング、リクエストの処理、およびパラメータの基本を学びます。">リクエストの処理とレスポンスの生成方法</Links>を学ぶために、前のチュートリアルを完了することを強くお勧めします。
+    </p>
+    <p><a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA</a>のインストールをお勧めしますが、お好みの他のIDEを使用することもできます。
+    </p>
+</chapter>
+<chapter title="RESTfulタスクマネージャーの作成" id="hello-restful-task-manager">
+    <p>このチュートリアルでは、既存のタスクマネージャーをRESTfulサービスとして書き直します。これを行うために、いくつかのKtor <Links href="//server-plugins" summary="プラグインは、シリアライズ、コンテンツエンコーディング、圧縮などの共通機能を提供します。">プラグイン</Links>を使用します。</p>
+    <p>
+        既存のプロジェクトに手動で追加することもできますが、新しいプロジェクトを生成してから、前のチュートリアルのコードを段階的に追加していく方が簡単です。進めながらすべてのコードを反復するため、前のプロジェクトを手元に用意しておく必要はありません。
+    </p>
+    <procedure title="プラグインを使用して新しいプロジェクトを作成する">
+        <step>
+            <p>
+                <a href="https://start.ktor.io/">Ktor Project Generator</a>にアクセスします。
+            </p>
+        </step>
+        <step>
+            <p><control>Project artifact</control>フィールドに、プロジェクト名として
+                <Path>com.example.ktor-rest-task-app</Path>
+                と入力します。
+                <img src="tutorial_creating_restful_apis_project_artifact.png"
+                     alt="Ktor Project Generatorでプロジェクトのアーティファクトを指定する"
+                     style="block"
+                     border-effect="line"
+                     width="706"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                プラグインセクションで、以下のプラグインを検索し、<control>Add</control>ボタンをクリックして追加します：
+            </p>
+            <list type="bullet">
+                <li>Content Negotiation</li>
+                <li>kotlinx.serialization</li>
+                <li>Static Content</li>
+            </list>
+            <p>
+                <img src="ktor_project_generator_add_plugins.gif" alt="Ktor Project Generatorでプラグインを追加する"
+                     border-effect="line"
+                     style="block"
+                     width="706"/>
+                プラグインを追加すると、プロジェクト設定の下にすべてのプラグインがリストされます。
+                <img src="tutorial_creating_restful_apis_plugins_list.png"
+                     alt="Ktor Project Generatorのプラグインリスト"
+                     border-effect="line"
+                     style="block"
+                     width="706"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                <control>Download</control>ボタンをクリックして、Ktorプロジェクトを生成しダウンロードします。
+            </p>
+        </step>
+    </procedure>
+    <procedure title="スターターコードの追加" id="add-starter-code">
+        <step>
+            <p><a href="server-create-a-new-project.topic#open-explore-run">IntelliJ IDEAでKtorプロジェクトを開き、探索し、実行する</a>チュートリアルで説明したように、IntelliJ IDEAでプロジェクトを開きます。</p>
+        </step>
+        <step>
+            <p>
+                <Path>src/main/kotlin</Path>に移動し、
+                <Path>model</Path>というサブパッケージを作成します。
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>model</Path>パッケージの中に、新しい
+                <Path>Task.kt</Path>ファイルを作成します。
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>Task.kt</Path>ファイルを開き、優先度を表す<code>enum</code>とタスクを表す<code>class</code>を追加します：
+            </p>
+            <code-block lang="kotlin" code="package com.example.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+            <p>
+                前のチュートリアルでは、拡張関数を使用して<code>Task</code>をHTMLに変換しました。今回は、<code>Task</code>クラスに<code>kotlinx.serialization</code>ライブラリの<a
+                    href="https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-serializable/"><code>Serializable</code></a>型のアノテーションを付けています。
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>Routing.kt</Path>ファイルを開き、既存のコードを以下の実装に置き換えます：
+            </p>
+            <code-block lang="kotlin" code="                    package com.example&#10;&#10;                    import com.example.model.*&#10;                    import io.ktor.server.application.*&#10;                    import io.ktor.server.http.content.*&#10;                    import io.ktor.server.response.*&#10;                    import io.ktor.server.routing.*&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            staticResources(&quot;static&quot;, &quot;static&quot;)&#10;&#10;                            get(&quot;/tasks&quot;) {&#10;                                call.respond(&#10;                                    listOf(&#10;                                        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                                        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                                        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                                        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;                                    )&#10;                                )&#10;                            }&#10;                        }&#10;                    }"/>
+            <p>
+                前のチュートリアルと同様に、URL <code>/tasks</code> へのGETリクエストのルートを作成しました。今回は、タスクのリストを手動で変換する代わりに、リストをそのまま返しています。
+            </p>
+        </step>
+        <step>
+            <p>IntelliJ IDEAで、実行ボタン(<img src="intellij_idea_gutter_icon.svg"
+                      style="inline" height="16" width="16"
+                      alt="IntelliJ IDEAの実行アイコン"/>)をクリックしてアプリケーションを起動します。</p>
+        </step>
+        <step>
+            <p>
+                ブラウザで <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a> にアクセスします。以下のように、タスクリストのJSON版が表示されるはずです：
+            </p>
+        </step>
+        <img src="tutorial_creating_restful_apis_starter_code_preview.png"
+             alt="ブラウザ画面に表示されたJSONデータ"
+             border-effect="rounded"
+             width="706"/>
+        <p>明らかに、私たちの代わりに多くの処理が行われています。具体的には何が起きているのでしょうか？</p>
+    </procedure>
+</chapter>
+<chapter title="コンテンツネゴシエーションを理解する" id="content-negotiation">
+    <chapter title="ブラウザ経由のコンテンツネゴシエーション" id="via-browser">
+        <p>
+            プロジェクトを作成した際、<Links href="//server-serialization" summary="ContentNegotiationプラグインは、クライアントとサーバー間のメディアタイプのネゴシエーションと、特定のフォーマットでのコンテンツのシリアライズ/デシリアライズという2つの主要な目的を果たします。">Content Negotiation</Links>プラグインを含めました。このプラグインは、クライアントがレンダリングできるコンテンツの種類を確認し、現在のサービスが提供できるコンテンツタイプと照合します。そのため、<format style="italic">Content Negotiation</format>（コンテンツネゴシエーション）という用語が使われます。
+        </p>
+        <p>
+            HTTPでは、クライアントは <code>Accept</code> ヘッダーを通じてレンダリング可能なコンテンツタイプを通知します。このヘッダーの値は1つ以上のコンテンツタイプです。上記の場合、ブラウザに組み込まれている開発ツールを使用して、このヘッダーの値を確認できます。
+        </p>
+        <p>
+            以下の例を考えてみましょう：
+        </p>
+        <code-block code="                text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"/>
+        <p><code>&#42;/&#42;</code> が含まれていることに注目してください。このヘッダーは、HTML、XML、または画像を受け入れることを示していますが、他のあらゆるコンテンツタイプも受け入れることを意味します。</p>
+        <p>Content Negotiationプラグインは、データをブラウザに送り返すためのフォーマットを見つける必要があります。プロジェクト内の生成されたコードを見ると、<Path>src/main/kotlin</Path> 内に <Path>Serialization.kt</Path> というファイルがあり、以下の内容が含まれています：
+        </p>
+        <code-block lang="kotlin" code="fun Application.configureSerialization() {&#10;    install(ContentNegotiation) {&#10;        json()&#10;    }&#10;}"/>
+        <p>
+            このコードは <code>ContentNegotiation</code> プラグインをインストールし、<code>kotlinx.serialization</code> プラグインも構成します。これにより、クライアントがリクエストを送信すると、サーバーはJSONとしてシリアライズされたオブジェクトを返送できます。
+        </p>
+        <p>
+            ブラウザからのリクエストの場合、<code>ContentNegotiation</code> プラグインはJSONしか返せないことを認識しており、ブラウザは送られてきたものを何でも表示しようとします。そのため、リクエストは成功します。
+        </p>
+    </chapter>
+    <procedure title="JavaScript経由のコンテンツネゴシエーション" id="via-javascript">
+        <p>
+            本番環境では、通常JSONをブラウザに直接表示することはありません。代わりに、ブラウザで実行されているJavaScriptコードがリクエストを行い、返されたデータをシングルページアプリケーション（SPA）の一部として表示します。通常、この種のアプリケーションは <a href="https://react.dev/">React</a>、<a href="https://angular.io/">Angular</a>、または <a href="https://vuejs.org/">Vue.js</a> のようなフレームワークを使用して記述されます。
+        </p>
+        <step>
+            <p>
+                これをシミュレートするために、<Path>src/main/resources/static</Path> 内の <Path>index.html</Path> ページを開き、デフォルトのコンテンツを以下に置き換えます：
+            </p>
+            <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;A Simple SPA For Tasks&lt;/title&gt;&#10;    &lt;script type=&quot;application/javascript&quot;&gt;&#10;        function fetchAndDisplayTasks() {&#10;            fetchTasks()&#10;                .then(tasks =&gt; displayTasks(tasks))&#10;        }&#10;&#10;        function fetchTasks() {&#10;            return fetch(&#10;                &quot;/tasks&quot;,&#10;                {&#10;                    headers: { 'Accept': 'application/json' }&#10;                }&#10;            ).then(resp =&gt; resp.json());&#10;        }&#10;&#10;        function displayTasks(tasks) {&#10;            const tasksTableBody = document.getElementById(&quot;tasksTableBody&quot;)&#10;            tasks.forEach(task =&gt; {&#10;                const newRow = taskRow(task);&#10;                tasksTableBody.appendChild(newRow);&#10;            });&#10;        }&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Viewing Tasks Via JS&lt;/h1&gt;&#10;&lt;form action=&quot;javascript:fetchAndDisplayTasks()&quot;&gt;&#10;    &lt;input type=&quot;submit&quot; value=&quot;View The Tasks&quot;&gt;&#10;&lt;/form&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            <p>
+                このページにはHTMLフォームと空のテーブルが含まれています。フォームを送信すると、JavaScriptイベントハンドラーが <code>Accept</code> ヘッダーを <code>application/json</code> に設定して <code>/tasks</code> エンドポイントにリクエストを送信します。返されたデータはデシリアライズされ、HTMLテーブルに追加されます。
+            </p>
+        </step>
+        <step>
+            <p>
+                IntelliJ IDEAで、再実行ボタン(<img src="intellij_idea_rerun_icon.svg"
+                                               style="inline" height="16" width="16"
+                                               alt="IntelliJ IDEAの再実行アイコン"/>)をクリックしてアプリケーションを再起動します。
+            </p>
+        </step>
+        <step>
+            <p>
+                URL <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a> にアクセスします。<control>View The Tasks</control> ボタンをクリックしてデータを取得できるはずです：
+            </p>
+            <img src="tutorial_creating_restful_apis_tasks_via_js.png"
+                 alt="ボタンとHTMLテーブルとして表示されたタスクが表示されているブラウザウィンドウ"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="GETルートの追加" id="porting-get-routes">
+    <p>
+        コンテンツネゴシエーションのプロセスに慣れたところで、<Links href="//server-requests-and-responses" summary="タスクマネージャーアプリケーションの構築を通じて、KotlinとKtorでのルーティング、リクエストの処理、およびパラメータの基本を学びます。">前のチュートリアル</Links>の機能をこちらに移植していきましょう。
+    </p>
+    <chapter title="タスクリポジトリの再利用" id="task-repository">
+        <p>
+            タスクのリポジトリは変更なしで再利用できるので、まずそれを行いましょう。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    <Path>model</Path>パッケージ内に、新しい <Path>TaskRepository.kt</Path> ファイルを作成します。
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>TaskRepository.kt</Path> を開き、以下のコードを追加します：
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&#10;        tasks.add(task)&#10;    }&#10;}"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="GETリクエスト用のルートを再利用する" id="get-requests">
+        <p>
+            リポジトリを作成したので、GETリクエスト用のルートを実装できます。タスクをHTMLに変換することを心配する必要がなくなったため、以前のコードを簡略化できます：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    <Path>src/main/kotlin</Path> 内の <Path>Routing.kt</Path> ファイルに移動します。
+                </p>
+            </step>
+            <step>
+                <p>
+                    <code>Application.configureRouting()</code> 関数内の <code>/tasks</code> ルートのコードを、以下の実装に更新します：
+                </p>
+                <code-block lang="kotlin" code="                    package com.example&#10;&#10;                    import com.example.model.Priority&#10;                    import com.example.model.TaskRepository&#10;                    import io.ktor.http.*&#10;                    import io.ktor.server.application.*&#10;                    import io.ktor.server.http.content.*&#10;                    import io.ktor.server.response.*&#10;                    import io.ktor.server.routing.*&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            staticResources(&quot;static&quot;, &quot;static&quot;)&#10;&#10;                            //更新された実装&#10;                            route(&quot;/tasks&quot;) {&#10;                                get {&#10;                                    val tasks = TaskRepository.allTasks()&#10;                                    call.respond(tasks)&#10;                                }&#10;&#10;                                get(&quot;/byName/{taskName}&quot;) {&#10;                                    val name = call.parameters[&quot;taskName&quot;]&#10;                                    if (name == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@get&#10;                                    }&#10;&#10;                                    val task = TaskRepository.taskByName(name)&#10;                                    if (task == null) {&#10;                                        call.respond(HttpStatusCode.NotFound)&#10;                                        return@get&#10;                                    }&#10;                                    call.respond(task)&#10;                                }&#10;                                get(&quot;/byPriority/{priority}&quot;) {&#10;                                    val priorityAsText = call.parameters[&quot;priority&quot;]&#10;                                    if (priorityAsText == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@get&#10;                                    }&#10;                                    try {&#10;                                        val priority = Priority.valueOf(priorityAsText)&#10;                                        val tasks = TaskRepository.tasksByPriority(priority)&#10;&#10;                                        if (tasks.isEmpty()) {&#10;                                            call.respond(HttpStatusCode.NotFound)&#10;                                            return@get&#10;                                        }&#10;                                        call.respond(tasks)&#10;                                    } catch (ex: IllegalArgumentException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+                <p>
+                    これにより、サーバーは以下のGETリクエストに応答できるようになります：</p>
+                <list>
+                    <li><code>/tasks</code> はリポジトリ内のすべてのタスクを返します。</li>
+                    <li><code>/tasks/byName/{taskName}</code> は指定された <code>taskName</code> でフィルタリングされたタスクを返します。
+                    </li>
+                    <li><code>/tasks/byPriority/{priority}</code> は指定された <code>priority</code> でフィルタリングされたタスクを返します。
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEAで、再実行ボタン(<img src="intellij_idea_rerun_icon.svg"
+                                                   style="inline" height="16" width="16"
+                                                   alt="IntelliJ IDEAの再実行アイコン"/>)をクリックしてアプリケーションを再起動します。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="機能のテスト" id="test-tasks-routes">
+        <procedure title="ブラウザを使用する">
+            <p>ブラウザでこれらのルートをテストできます。例えば、<a
+                    href="http://0.0.0.0:8080/tasks/byPriority/Medium">http://0.0.0.0:8080/tasks/byPriority/Medium</a> にアクセスすると、<code>Medium</code> 優先度のすべてのタスクがJSON形式で表示されます：</p>
+            <img src="tutorial_creating_restful_apis_tasks_medium_priority.png"
+                 alt="Medium優先度のタスクがJSON形式で表示されているブラウザウィンドウ"
+                 border-effect="rounded"
+                 width="706"/>
+            <p>
+                この種のリクエストは通常JavaScriptから行われるため、より詳細なテストが好ましいです。このために、<a
+                    href="https://learning.postman.com/docs/sending-requests/requests/">Postman</a>のような専門的なツールを使用できます。
+            </p>
+        </procedure>
+        <procedure title="Postmanを使用する">
+            <step>
+                <p>Postmanで、URL <code>http://0.0.0.0:8080/tasks/byPriority/Medium</code> を使用して新しいGETリクエストを作成します。</p>
+            </step>
+            <step>
+                <p>
+                    <ui-path>Headers</ui-path>ペインで、<ui-path>Accept</ui-path>ヘッダーの値を <code>application/json</code> に設定します。
+                </p>
+            </step>
+            <step>
+                <p><control>Send</control>をクリックしてリクエストを送信し、レスポンスビューアーでレスポンスを確認します。
+                </p>
+                <img src="tutorial_creating_restful_apis_tasks_medium_priority_postman.png"
+                     alt="Medium優先度のタスクをJSON形式で表示しているPostmanのGETリクエスト"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+        <procedure title="HTTPリクエストファイルを使用する">
+            <p>IntelliJ IDEA Ultimateでは、HTTPリクエストファイルで同じ手順を実行できます。</p>
+            <step>
+                <p>
+                    プロジェクトのルートディレクトリに、新しい <Path>REST Task Manager.http</Path> ファイルを作成します。
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>REST Task Manager.http</Path> ファイルを開き、以下のGETリクエストを追加します：
+                </p>
+                <code-block lang="http" code="GET http://0.0.0.0:8080/tasks/byPriority/Medium&#10;Accept: application/json"/>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA内でリクエストを送信するには、その横にあるガターアイコン(<img
+                        alt="IntelliJ IDEAのガターアイコン"
+                        src="intellij_idea_gutter_icon.svg"
+                        width="16" height="26"/>)をクリックします。
+                </p>
+            </step>
+            <step>
+                <p>これにより、<Path>Services</Path>ツールウィンドウで実行されます：
+                </p>
+                <img src="tutorial_creating_restful_apis_tasks_medium_priority_http_file.png"
+                     alt="Medium優先度のタスクをJSON形式で表示しているHTTPファイル内のGETリクエスト"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+        <note>
+            ルートをテストする別の方法として、Kotlin Notebook内から <a
+                href="https://khttp.readthedocs.io/en/latest/">khttp</a> ライブラリを使用することもできます。
+        </note>
+    </chapter>
+</chapter>
+<chapter title="POSTリクエスト用のルートを追加する" id="add-a-route-for-post-requests">
+    <p>
+        前のチュートリアルでは、タスクはHTMLフォームを通じて作成されました。しかし、現在はRESTfulサービスを構築しているため、その必要はありません。代わりに、主要な処理を肩代わりしてくれる <code>kotlinx.serialization</code> フレームワークを活用します。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                <Path>src/main/kotlin</Path> 内の <Path>Routing.kt</Path> ファイルを開きます。
+            </p>
+        </step>
+        <step>
+            <p>
+                以下のように、新しいPOSTルートを <code>Application.configureRouting()</code> 関数に追加します：
+            </p>
+            <code-block lang="kotlin" code="                    //...&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            //...&#10;&#10;                            route(&quot;/tasks&quot;) {&#10;                                //...&#10;&#10;                                //以下の新しいルートを追加&#10;                                post {&#10;                                    try {&#10;                                        val task = call.receive&lt;Task&gt;()&#10;                                        TaskRepository.addTask(task)&#10;                                        call.respond(HttpStatusCode.Created)&#10;                                    } catch (ex: IllegalStateException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    } catch (ex: SerializationException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+            <p>
+                以下の新しいインポートを追加します：
+            </p>
+            <code-block lang="kotlin" code="                    //...&#10;                    import com.example.model.Task&#10;                    import io.ktor.server.request.receive&#10;                    import kotlinx.serialization.SerializationException"/>
+            <p>
+                POSTリクエストが <code>/tasks</code> に送信されると、<code>kotlinx.serialization</code> フレームワークがリクエストのボディを <code>Task</code> オブジェクトに変換します。これが成功すると、タスクがリポジトリに追加されます。デシリアライズプロセスが失敗した場合、サーバーは <code>SerializationException</code> を処理し、タスクが重複している場合は <code>IllegalStateException</code> を処理します。
+            </p>
+        </step>
+        <step>
+            <p>
+                アプリケーションを再起動します。
+            </p>
+        </step>
+        <step>
+            <p>
+                Postmanでこの機能をテストするには、URL <code>http://0.0.0.0:8080/tasks</code> に対して新しいPOSTリクエストを作成します。
+            </p>
+        </step>
+        <step>
+            <p>
+                <ui-path>Body</ui-path>パネルで、新しいタスクを表す以下のJSONドキュメントを追加します：
+            </p>
+            <code-block lang="json" code="{&#10;    &quot;name&quot;: &quot;cooking&quot;,&#10;    &quot;description&quot;: &quot;Cook the dinner&quot;,&#10;    &quot;priority&quot;: &quot;High&quot;&#10;}"/>
+            <img src="tutorial_creating_restful_apis_add_task.png"
+                 alt="新しいタスクを追加するためのPostmanのPOSTリクエスト"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+        <step>
+            <p><control>Send</control>をクリックしてリクエストを送信します。
+            </p>
+        </step>
+        <step>
+            <p>
+                <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a> にGETリクエストを送信することで、タスクが追加されたことを確認できます。
+            </p>
+        </step>
+        <step>
+            <p>
+                IntelliJ IDEA Ultimate内では、HTTPリクエストファイルに以下を追加することで同じ手順を実行できます：
+            </p>
+            <code-block lang="http" code="###&#10;&#10;POST http://0.0.0.0:8080/tasks&#10;Content-Type: application/json&#10;&#10;{&#10;    &quot;name&quot;: &quot;cooking&quot;,&#10;    &quot;description&quot;: &quot;Cook the dinner&quot;,&#10;    &quot;priority&quot;: &quot;High&quot;&#10;}"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="削除機能のサポート追加" id="remove-tasks">
+    <p>
+        サービスの基本操作の追加はほぼ完了しました。これらはCRUD（Create, Read, Update, and Delete）操作としてよくまとめられます。ここでは削除操作を実装します。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                <Path>TaskRepository.kt</Path> ファイルの <code>TaskRepository</code> オブジェクト内に、名前を基にタスクを削除する以下のメソッドを追加します：
+            </p>
+            <code-block lang="kotlin" code="    fun removeTask(name: String): Boolean {&#10;        return tasks.removeIf { it.name == name }&#10;    }"/>
+        </step>
+        <step>
+            <p>
+                <Path>Routing.kt</Path> ファイルを開き、DELETEリクエストを処理するエンドポイントを <code>routing()</code> 関数に追加します：
+            </p>
+            <code-block lang="kotlin" code="                    fun Application.configureRouting() {&#10;                        //...&#10;&#10;                        routing {&#10;                            route(&quot;/tasks&quot;) {&#10;                                //...&#10;                                //以下の関数を追加&#10;                                delete(&quot;/{taskName}&quot;) {&#10;                                    val name = call.parameters[&quot;taskName&quot;]&#10;                                    if (name == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@delete&#10;                                    }&#10;&#10;                                    if (TaskRepository.removeTask(name)) {&#10;                                        call.respond(HttpStatusCode.NoContent)&#10;                                    } else {&#10;                                        call.respond(HttpStatusCode.NotFound)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+        </step>
+        <step>
+            <p>
+                アプリケーションを再起動します。
+            </p>
+        </step>
+        <step>
+            <p>
+                HTTPリクエストファイルに以下のDELETEリクエストを追加します：
+            </p>
+            <code-block lang="http" code="###&#10;&#10;DELETE http://0.0.0.0:8080/tasks/gardening"/>
+        </step>
+        <step>
+            <p>
+                IntelliJ IDEA内でDELETEリクエストを送信するには、その横にあるガターアイコン(<img
+                    alt="IntelliJ IDEAのガターアイコン"
+                    src="intellij_idea_gutter_icon.svg"
+                    width="16" height="26"/>)をクリックします。
+            </p>
+        </step>
+        <step>
+            <p><Path>Services</Path>ツールウィンドウにレスポンスが表示されます：
+            </p>
+            <img src="tutorial_creating_restful_apis_delete_task.png"
+                 alt="HTTPリクエストファイル内のDELETEリクエスト"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="Ktor Clientを使用したユニットテストの作成" id="create-unit-tests">
+    <p>
+        これまでは手動でアプリケーションをテストしてきましたが、すでにお気づきの通り、このアプローチは時間がかかり、規模の拡大に対応できません。代わりに、組み込みの <code>client</code> オブジェクトを使用してJSONの取得とデシリアライズを行う <Links href="//server-testing" summary="特別なテスティングエンジンを使用してサーバーアプリケーションをテストする方法を学びます。">JUnitテスト</Links>を実装できます。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                <Path>src/test/kotlin</Path> 内の <Path>ServerTest.kt</Path> ファイルを開きます。
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>ServerTest.kt</Path> ファイルの内容を以下に置き換えます：
+            </p>
+            <code-block lang="kotlin" code="package com.example&#10;&#10;import com.example.model.Priority&#10;import com.example.model.Task&#10;import io.ktor.client.call.*&#10;import io.ktor.client.plugins.contentnegotiation.*&#10;import io.ktor.client.request.*&#10;import io.ktor.http.*&#10;import io.ktor.serialization.kotlinx.json.*&#10;import io.ktor.server.testing.*&#10;import kotlin.test.*&#10;&#10;class ApplicationTest {&#10;    @Test&#10;    fun tasksCanBeFoundByPriority() = testApplication {&#10;        configure()&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;        }&#10;&#10;        val response = client.get(&quot;/tasks/byPriority/Medium&quot;)&#10;        val results = response.body&lt;List&lt;Task&gt;&gt;()&#10;&#10;        assertEquals(HttpStatusCode.OK, response.status)&#10;&#10;        val expectedTaskNames = listOf(&quot;gardening&quot;, &quot;painting&quot;)&#10;        val actualTaskNames = results.map(Task::name)&#10;        assertContentEquals(expectedTaskNames, actualTaskNames)&#10;    }&#10;&#10;    @Test&#10;    fun invalidPriorityProduces400() = testApplication {&#10;        configure()&#10;        val response = client.get(&quot;/tasks/byPriority/Invalid&quot;)&#10;        assertEquals(HttpStatusCode.BadRequest, response.status)&#10;    }&#10;&#10;&#10;    @Test&#10;    fun unusedPriorityProduces404() = testApplication {&#10;        configure()&#10;        val response = client.get(&quot;/tasks/byPriority/Vital&quot;)&#10;        assertEquals(HttpStatusCode.NotFound, response.status)&#10;    }&#10;&#10;    @Test&#10;    fun newTasksCanBeAdded() = testApplication {&#10;        configure()&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;        }&#10;&#10;        val task = Task(&quot;swimming&quot;, &quot;Go to the beach&quot;, Priority.Low)&#10;        val response1 = client.post(&quot;/tasks&quot;) {&#10;            header(&#10;                HttpHeaders.ContentType,&#10;                ContentType.Application.Json&#10;            )&#10;&#10;            setBody(task)&#10;        }&#10;        assertEquals(HttpStatusCode.Created, response1.status)&#10;&#10;        val response2 = client.get(&quot;/tasks&quot;)&#10;        assertEquals(HttpStatusCode.OK, response2.status)&#10;&#10;        val taskNames = response2&#10;            .body&lt;List&lt;Task&gt;&gt;()&#10;            .map { it.name }&#10;&#10;        assertContains(taskNames, &quot;swimming&quot;)&#10;    }&#10;}"/>
+            <p>
+                サーバーで行ったのと同様に、<a href="client-create-and-configure.md#plugins">プラグイン</a>に <code>ContentNegotiation</code> と <code>kotlinx.serialization</code> プラグインをインストールする必要があることに注意してください。
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>build.gradle.kts</Path> ファイルに以下の依存関係を追加します：
+            </p>
+            <code-block lang="kotlin" code="                    testImplementation(ktorLibs.client.contentNegotiation)"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="JsonPathを使用したユニットテストの作成" id="unit-tests-via-jsonpath">
+    <p>
+        Ktor Clientや同様のライブラリを使用してサービスをテストするのは便利ですが、品質保証（QA）の観点からは欠点があります。サーバーがJSONを直接処理しない場合、JSONの構造に関する想定が正しいかどうか確信が持てないためです。
+    </p>
+    <p>
+        例えば、以下のような想定です：
+    </p>
+    <list>
+        <li>実際には <code>object</code> が使用されているのに、値が <code>array</code> に格納されている。</li>
+        <li>プロパティが <code>strings</code> なのに、<code>numbers</code> として格納されている。</li>
+        <li>メンバーが宣言順にシリアライズされるはずが、そうなっていない。</li>
+    </list>
+    <p>
+        サービスが複数のクライアントによって使用されることを目的としている場合、JSON構造に自信を持つことが不可欠です。これを実現するには、Ktor Clientを使用してサーバーからテキストを取得し、<a href="https://mvnrepository.com/artifact/com.jayway.jsonpath/json-path">JSONPath</a> ライブラリを使用してこのコンテンツを分析します。</p>
+    <procedure>
+        <step>
+            <p><Path>build.gradle.kts</Path> ファイルの <code>dependencies</code> ブロックに JSONPath ライブラリを追加します：
+            </p>
+            <code-block lang="kotlin" code="    testImplementation(&quot;com.jayway.jsonpath:json-path:2.9.0&quot;)"/>
+        </step>
+        <step>
+            <p>
+                <Path>src/test/kotlin</Path> フォルダに移動し、新しい <Path>ApplicationJsonPathTest.kt</Path> ファイルを作成します。
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>ApplicationJsonPathTest.kt</Path> ファイルを開き、以下の内容を追加します：
+            </p>
+            <code-block lang="kotlin" code="package com.example&#10;&#10;import com.jayway.jsonpath.DocumentContext&#10;import com.jayway.jsonpath.JsonPath&#10;import io.ktor.client.*&#10;import com.example.model.Priority&#10;import io.ktor.client.request.*&#10;import io.ktor.client.statement.*&#10;import io.ktor.http.*&#10;import io.ktor.server.testing.*&#10;import kotlin.test.*&#10;&#10;&#10;class ApplicationJsonPathTest {&#10;    @Test&#10;    fun tasksCanBeFound() = testApplication {&#10;        configure()&#10;        val jsonDoc = client.getAsJsonPath(&quot;/tasks&quot;)&#10;&#10;        val result: List&lt;String&gt; = jsonDoc.read(&quot;$[*].name&quot;)&#10;        assertEquals(&quot;cleaning&quot;, result[0])&#10;        assertEquals(&quot;gardening&quot;, result[1])&#10;        assertEquals(&quot;shopping&quot;, result[2])&#10;    }&#10;&#10;    @Test&#10;    fun tasksCanBeFoundByPriority() = testApplication {&#10;        configure()&#10;        val priority = Priority.Medium&#10;        val jsonDoc = client.getAsJsonPath(&quot;/tasks/byPriority/$priority&quot;)&#10;&#10;        val result: List&lt;String&gt; =&#10;            jsonDoc.read(&quot;$[?(@.priority == '$priority')].name&quot;)&#10;        assertEquals(2, result.size)&#10;&#10;        assertEquals(&quot;gardening&quot;, result[0])&#10;        assertEquals(&quot;painting&quot;, result[1])&#10;    }&#10;&#10;    suspend fun HttpClient.getAsJsonPath(url: String): DocumentContext {&#10;        val response = this.get(url) {&#10;            accept(ContentType.Application.Json)&#10;        }&#10;        return JsonPath.parse(response.bodyAsText())&#10;    }&#10;}"/>
+            <p>
+                JsonPath クエリは以下のように機能します：
+            </p>
+            <list>
+                <li>
+                    <code>$[&#42;].name</code> は「ドキュメントを配列として扱い、各エントリの name プロパティの値を返す」ことを意味します。
+                </li>
+                <li>
+                    <code>$[?(@.priority == '$priority')].name</code> は「指定された値と等しい優先度を持つ配列内のすべてのエントリの name プロパティの値を返す」ことを意味します。
+                </li>
+            </list>
+            <p>
+                このようなクエリを使用して、返されたJSONに対する理解を確認できます。コードのリファクタリングやサービスの再デプロイを行う際、現在のフレームワークでのデシリアライズを妨げない変更であっても、シリアライズにおけるあらゆる修正が特定されます。これにより、自信を持って公開APIを再公開できます。
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="次のステップ" id="next-steps">
+    <p>
+        おめでとうございます！タスクマネージャーアプリケーションのRESTful APIサービスの作成を完了し、Ktor ClientとJsonPathを使用したユニットテストの要点を学びました。</p>
+    <p>
+        <Links href="//server-create-website" summary="KotlinとKtor、およびThymeleafテンプレートを使用してウェブサイトを構築する方法を学びます。">次のチュートリアル</Links>に進んで、APIサービスを再利用してウェブアプリケーションを構築する方法を学びましょう。
+    </p>
+</chapter>
+</topic>

--- a/docs/ja/ktor/server-create-website.md
+++ b/docs/ja/ktor/server-create-website.md
@@ -1,0 +1,408 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Ktor を使用して Kotlin で Web サイトを作成する" id="server-create-website">
+    <show-structure for="chapter,procedure" depth="3"/>
+    <tldr>
+        <var name="example_name" value="tutorial-server-web-application"/>
+        <p>
+            <b>コード例</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+        <p>
+            <b>使用されるプラグイン</b>: <Links href="//server-static-content" summary="スタイルシート、スクリプト、画像などの静的コンテンツを提供する方法を学びます。">Static Content</Links>、
+            <Links href="//server-thymeleaf" summary="必要な依存関係: io.ktor:%artifact_name%">Thymeleaf</Links>
+        </p>
+    </tldr>
+    <web-summary>
+        Ktor と Kotlin を使用して Web サイトを構築する方法を学びます。このチュートリアルでは、Thymeleaf テンプレートと Ktor ルートを組み合わせて、サーバー側で HTML ベースのユーザーインターフェースを生成する方法を説明します。
+    </web-summary>
+    <card-summary>
+        Kotlin、Ktor、Thymeleaf テンプレートを使用して Web サイトを構築する方法を学びます。
+    </card-summary>
+    <link-summary>
+        Kotlin、Ktor、Thymeleaf テンプレートを使用して Web サイトを構築する方法を学びます。
+    </link-summary>
+    <p>
+        このチュートリアルでは、Kotlin と Ktor、そして <a href="https://www.thymeleaf.org/">Thymeleaf</a> テンプレートを使用して、インタラクティブな Web サイトを構築する方法を学びます。
+    </p>
+    <p>
+        <Links href="//server-create-restful-apis" summary="Kotlin と Ktor を使用してバックエンドサービスを構築する方法を、JSON ファイルを生成する RESTful API の例を交えて学びます。">前回のチュートリアル</Links>では、JavaScript で記述されたシングルページアプリケーション（SPA）によって利用される RESTful サービスを作成する方法を学びました。これは非常に人気のあるアーキテクチャですが、すべてのプロジェクトに適しているわけではありません。
+    </p>
+    <p>
+        次のような理由から、すべての実装をサーバー側に保持し、クライアントにはマークアップのみを送信したい場合があります。
+    </p>
+    <list>
+        <li>シンプルさ – 単一のコードベースを維持するため。</li>
+        <li>セキュリティ – 攻撃者にヒントを与える可能性のあるデータやコードをブラウザに配置しないようにするため。
+        </li>
+        <li>
+            サポート性 – レガシーブラウザや JavaScript が無効なブラウザなど、可能な限り幅広いクライアントをサポートするため。
+        </li>
+    </list>
+    <p>
+        Ktor は、<Links href="//server-templating" summary="HTML/CSS または JVM テンプレートエンジンで構築されたビューを操作する方法を学びます。">いくつかのサーバーページテクノロジー</Links>と統合することで、このアプローチをサポートしています。
+    </p>
+    <chapter title="前提条件" id="prerequisites">
+        <p>
+            このチュートリアルは単独で行うことができますが、RESTful API の作成方法を学ぶために、<Links href="//server-create-restful-apis" summary="Kotlin と Ktor を使用してバックエンドサービスを構築する方法を、JSON ファイルを生成する RESTful API の例を交えて学びます。">前のチュートリアル</Links>を完了することを強くお勧めします。
+        </p>
+        <p><a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA</a> をインストールすることをお勧めしますが、お好みの他の IDE を使用することもできます。
+        </p>
+    </chapter>
+    <chapter title="Hello Task Manager Web アプリケーション" id="hello-task-manager">
+        <p>
+            このチュートリアルでは、<Links href="//server-create-restful-apis" summary="Kotlin と Ktor を使用してバックエンドサービスを構築する方法を、JSON ファイルを生成する RESTful API の例を交えて学びます。">前回のチュートリアル</Links>で作成したタスク管理アプリケーションを Web アプリケーションに変換します。これを行うために、いくつかの Ktor <Links href="//server-plugins" summary="プラグインは、シリアル化、コンテンツエンコーディング、圧縮などの一般的な機能を提供します。">プラグイン</Links>を使用します。
+        </p>
+        <p>
+            既存のプロジェクトにこれらのプラグインを手動で追加することもできますが、新しいプロジェクトを生成して、前のチュートリアルのコードを徐々に組み込んでいく方が簡単です。必要なコードはすべて途中で提供されるため、前のプロジェクトが手元になくても大丈夫です。
+        </p>
+        <procedure title="プラグインを使用して初期プロジェクトを作成する" id="create-project">
+            <step>
+                <p>
+                    <a href="https://start.ktor.io/">Ktor Project Generator</a>
+                    に移動します。
+                </p>
+            </step>
+            <step>
+                <p>
+                    <control>Project artifact</control>
+                    フィールドに、プロジェクトのアーティファクト名として
+                    <Path>com.example.ktor-task-web-app</Path>
+                    と入力します。
+                    <img src="server_create_web_app_generator_project_artifact.png"
+                         alt="Ktor Project Generator project artifact name"
+                         style="block"
+                         border-effect="line" width="706"/>
+                </p>
+            </step>
+            <step>
+                <p> 次の画面で、
+                    <control>Add</control>
+                    ボタンをクリックして、以下のプラグインを検索して追加します。
+                </p>
+                <list>
+                    <li>Static Content</li>
+                    <li>Thymeleaf</li>
+                </list>
+                <p>
+                    <img src="ktor_project_generator_add_plugins.gif"
+                         alt="Adding plugins in the Ktor Project Generator"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                    プラグインを追加すると、プロジェクト設定の下に 3 つのプラグインがすべて表示されます。
+                    <img src="server_create_web_app_generator_plugins.png"
+                         alt="Ktor Project Generator plugins list"
+                         style="block"
+                         border-effect="line" width="706"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    <control>Download</control>
+                    ボタンをクリックして、Ktor プロジェクトを生成してダウンロードします。
+                </p>
+            </step>
+        </procedure>
+        <procedure title="スターターコードを追加する" id="add-starter-code">
+            <step>
+                IntelliJ IDEA またはお好みの他の IDE でプロジェクトを開きます。
+            </step>
+            <step>
+                <Path>src/main/kotlin</Path>
+                に移動し、
+                <Path>model</Path>
+                という名前のサブパッケージを作成します。
+            </step>
+            <step>
+                <Path>model</Path>
+                パッケージ内に、新しい
+                <Path>Task.kt</Path>
+                ファイルを作成します。
+            </step>
+            <step>
+                <p>
+                    <Path>Task.kt</Path>
+                    ファイルに、優先度を表す <code>enum</code> と、タスクを表す <code>data class</code> を追加します。
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+                <p>
+                    ここでも、<code>Task</code> オブジェクトを作成し、表示可能な形式でクライアントに送信したいと考えています。
+                </p>
+                <p>
+                    次のことを覚えているかもしれません。
+                </p>
+                <list>
+                    <li>
+                        <Links href="//server-requests-and-responses" summary="タスクマネージャーアプリケーションを構築することで、Kotlin と Ktor でのルーティング、リクエストの処理、パラメータの基本を学びます。">リクエストの処理とレスポンスの生成</Links>
+                        のチュートリアルでは、タスクを HTML に変換するために手書きの拡張関数を追加しました。
+                    </li>
+                    <li>
+                        <Links href="//server-create-restful-apis" summary="Kotlin と Ktor を使用してバックエンドサービスを構築する方法を、JSON ファイルを生成する RESTful API の例を交えて学びます。">RESTful API の作成</Links> チュートリアルでは、<code>kotlinx.serialization</code> ライブラリの <code>Serializable</code> 型で <code>Task</code> クラスにアノテーションを付けました。
+                    </li>
+                </list>
+                <p>
+                    今回の目標は、タスクの内容をブラウザに書き込むサーバーページを作成することです。
+                </p>
+            </step>
+            <step>
+                <Path>src/main/kotlin</Path>
+                にある
+                <Path>Routing.kt</Path>
+                ファイルを開きます。
+            </step>
+            <step>
+                <p>
+                    <code>.configureRouting()</code> 関数に、以下に示すように <code>/tasks</code> のルートを追加します。
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, World!&quot;)&#10;        }&#10;        get(&quot;/html-thymeleaf&quot;) {&#10;            call.respond(ThymeleafContent(&quot;index&quot;, mapOf(&quot;user&quot; to ThymeleafUser(1, &quot;user1&quot;))))&#10;        }&#10;        // この追加ルートを追加します&#10;        get(&quot;/tasks&quot;) {&#10;            val tasks = listOf(&#10;                Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;            )&#10;            call.respond(ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks)))&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;    }&#10;}"/>
+                <p>
+                    サーバーが <code>/tasks</code> へのリクエストを受け取ると、タスクのリストを作成し、それを Thymeleaf テンプレートに渡します。<code>ThymeleafContent</code> 型は、トリガーされるテンプレートの名前と、ページ上でアクセス可能な値のテーブルを受け取ります。
+                </p>
+            </step>
+            <step>
+                <Path>src/main/kotlin</Path>
+                にある
+                <Path>Thymeleaf.kt</Path>
+                ファイルを開きます。
+            </step>
+            <step>
+                <p>次の <code>.configureThymeleaf</code> 関数が表示されるはずです。</p>
+                <code-block lang="kotlin" code="fun Application.configureThymeleaf() {&#10;    install(Thymeleaf) {&#10;        setTemplateResolver(ClassLoaderTemplateResolver().apply {&#10;            prefix = &quot;templates/thymeleaf/&quot;&#10;            suffix = &quot;.html&quot;&#10;            characterEncoding = &quot;utf-8&quot;&#10;        })&#10;    }&#10;}"/>
+                <p>
+                    Thymeleaf プラグインの初期化内で、Ktor は
+                    <Path>templates/thymeleaf</Path>
+                    フォルダ内のサーバーページを検索します。静的コンテンツと同様に、このフォルダが
+                    <Path>resources</Path>
+                    ディレクトリ内にあることを期待しています。また、
+                    <Path>.html</Path>
+                    サフィックスも期待されています。
+                </p>
+                <p>
+                    この場合、<code>all-tasks</code> という名前はパス
+                    <code>src/main/resources/templates/thymeleaf/all-tasks.html</code>
+                    にマッピングされます。
+                </p>
+            </step>
+            <step>
+                <Path>src/main/resources</Path>
+                に移動し、新しい
+                <Path>templates/thymeleaf</Path>
+                ディレクトリを作成します。
+            </step>
+            <step>
+                <Path>src/main/resources/templates/thymeleaf</Path>
+                内に、新しい
+                <Path>all-tasks.html</Path>
+                ファイルを作成します。
+            </step>
+            <step>
+                <p><Path>all-tasks.html</Path>
+                    ファイルを開き、以下の内容を追加します。
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html &gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;All Current Tasks&lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;All Current Tasks&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr th:each=&quot;task: ${tasks}&quot;&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>IntelliJ IDEA で、実行ボタン
+                    (<img src="intellij_idea_gutter_icon.svg"
+                          style="inline" height="16" width="16"
+                          alt="intelliJ IDEA run icon"/>)
+                    をクリックしてアプリケーションを開始します。</p>
+            </step>
+            <step>
+                <p>
+                    ブラウザで <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a> に移動します。以下に示すように、現在のすべてのタスクがテーブルに表示されるはずです。
+                </p>
+                <img src="server_create_web_app_all_tasks.png"
+                     alt="A web browser window displaying a list of tasks" border-effect="rounded" width="706"/>
+                <p>
+                    すべてのサーバーページフレームワークと同様に、Thymeleaf テンプレートは静的コンテンツ（ブラウザに送信されるもの）と動的コンテンツ（サーバーで実行されるもの）を混合します。もし <a href="https://freemarker.apache.org/">Freemarker</a> などの別のフレームワークを選択していた場合、少し異なる構文で同じ機能を提供できたでしょう。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="GET ルートを追加する" id="add-get-routes">
+        <p>サーバーページをリクエストするプロセスに慣れたので、前のチュートリアルの機能をこのチュートリアルに移行し続けましょう。</p>
+        <p>
+            <control>Static Content</control>
+            プラグインを含めたため、
+            <Path>Routing.kt</Path>
+            ファイルには次のコードが存在します。
+        </p>
+        <code-block lang="kotlin" code="            staticResources(&quot;/static&quot;, &quot;static&quot;)"/>
+        <p>
+            これは、例えば <code>/static/index.html</code> へのリクエストが、次のパスからのコンテンツを提供することを意味します。
+        </p>
+        <code>src/main/resources/static/index.html</code>
+        <p>
+            このファイルはすでに生成されたプロジェクトの一部であるため、追加したい機能のホームページとして使用できます。
+        </p>
+        <procedure title="インデックスページを再利用する">
+            <step>
+                <p>
+                    <Path>src/main/resources/static</Path>
+                    内の
+                    <Path>index.html</Path>
+                    ファイルを開き、その内容を以下の実装に置き換えます。
+                </p>
+                <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Task Manager Web Application&lt;/h1&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;&lt;a href=&quot;/tasks&quot;&gt;View all the tasks&lt;/a&gt;&lt;/h3&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;View tasks by priority&lt;/h3&gt;&#10;    &lt;form method=&quot;get&quot; action=&quot;/tasks/byPriority&quot;&gt;&#10;        &lt;select name=&quot;priority&quot;&gt;&#10;            &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;            &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;            &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;            &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;        &lt;/select&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;View a task by name&lt;/h3&gt;&#10;    &lt;form method=&quot;get&quot; action=&quot;/tasks/byName&quot;&gt;&#10;        &lt;input type=&quot;text&quot; name=&quot;name&quot; width=&quot;10&quot;&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;Create or edit a task&lt;/h3&gt;&#10;    &lt;form method=&quot;post&quot; action=&quot;/tasks&quot;&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;name&quot;&gt;Name: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;name&quot; name=&quot;name&quot; size=&quot;10&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;description&quot;&gt;Description: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;description&quot;&#10;                   name=&quot;description&quot; size=&quot;20&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;priority&quot;&gt;Priority: &lt;/label&gt;&#10;            &lt;select id=&quot;priority&quot; name=&quot;priority&quot;&gt;&#10;                &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;                &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;                &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;                &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;            &lt;/select&gt;&#10;        &lt;/div&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA で、再実行ボタン (<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="intelliJ IDEA rerun icon"/>) をクリックしてアプリケーションを再起動します。
+                </p>
+            </step>
+            <step>
+                <p>
+                    ブラウザで <a href="http://localhost:8080/static/index.html">http://localhost:8080/static/index.html</a> に移動します。タスクの表示、フィルタリング、作成を行うためのリンクボタンと 3 つの HTML フォームが表示されるはずです。
+                </p>
+                <img src="server_create_web_app_tasks_form.png"
+                     alt="A web browser displaying an HTML form" border-effect="rounded" width="706"/>
+                <p>
+                    タスクを <code>name</code> または <code>priority</code> でフィルタリングする場合、GET リクエストを通じて HTML フォームを送信していることに注意してください。これは、パラメータが URL の後のクエリ文字列に追加されることを意味します。
+                </p>
+                <p>
+                    例えば、<code>Medium</code> 優先度のタスクを検索する場合、サーバーに送信されるリクエストは次のようになります。
+                </p>
+                <code>http://localhost:8080/tasks/byPriority?priority=Medium</code>
+            </step>
+        </procedure>
+        <procedure title="タスクリポジトリを再利用する" id="task-repository">
+            <p>
+                タスクのリポジトリは、前のチュートリアルのものと同一のままで構いません。
+            </p>
+            <p>
+                <Path>model</Path>
+                パッケージ内に新しい
+                <Path>TaskRepository.kt</Path>
+                ファイルを作成し、以下のコードを追加します。
+            </p>
+            <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&#10;        tasks.add(task)&#10;    }&#10;}"/>
+        </procedure>
+        <procedure title="GET リクエストのルートを再利用する" id="reuse-routes">
+            <p>
+                リポジトリを作成したので、GET リクエストのルートを実装できます。
+            </p>
+            <step>
+                <Path>src/main/kotlin</Path>
+                にある
+                <Path>Routing.kt</Path>
+                ファイルに移動します。
+            </step>
+            <step>
+                <p>
+                    現在のバージョンの <code>.configureRouting()</code> を以下の実装に置き換えます。
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, World!&quot;)&#10;        }&#10;        get(&quot;/html-thymeleaf&quot;) {&#10;            call.respond(ThymeleafContent(&quot;index&quot;, mapOf(&quot;user&quot; to ThymeleafUser(1, &quot;user1&quot;))))&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;&#10;        route(&quot;/tasks&quot;) {&#10;            get {&#10;                val tasks = TaskRepository.allTasks()&#10;                call.respond(&#10;                    ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks))&#10;                )&#10;            }&#10;            get(&quot;/byName&quot;) {&#10;                val name = call.request.queryParameters[&quot;name&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                val task = TaskRepository.taskByName(name)&#10;                if (task == null) {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                    return@get&#10;                }&#10;                call.respond(&#10;                    ThymeleafContent(&quot;single-task&quot;, mapOf(&quot;task&quot; to task))&#10;                )&#10;            }&#10;            get(&quot;/byPriority&quot;) {&#10;                val priorityAsText = call.request.queryParameters[&quot;priority&quot;]&#10;                if (priorityAsText == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(priorityAsText)&#10;                    val tasks = TaskRepository.tasksByPriority(priority)&#10;&#10;&#10;                    if (tasks.isEmpty()) {&#10;                        call.respond(HttpStatusCode.NotFound)&#10;                        return@get&#10;                    }&#10;                    val data = mapOf(&#10;                        &quot;priority&quot; to priority,&#10;                        &quot;tasks&quot; to tasks&#10;                    )&#10;                    call.respond(ThymeleafContent(&quot;tasks-by-priority&quot;, data))&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    上記のコードは次のように要約できます。
+                </p>
+                <list>
+                    <li>
+                        <code>/tasks</code> への GET リクエストでは、サーバーはリポジトリからすべてのタスクを取得し、
+                        <Path>all-tasks</Path>
+                        テンプレートを使用してブラウザに送信される次のビューを生成します。
+                    </li>
+                    <li>
+                        <code>/tasks/byName</code> への GET リクエストでは、サーバーは <code>queryString</code> からパラメータ <code>name</code> を取得し、一致するタスクを見つけ、
+                        <Path>single-task</Path>
+                        テンプレートを使用してブラウザに送信される次のビューを生成します。
+                    </li>
+                    <li>
+                        <code>/tasks/byPriority</code> への GET リクエストでは、サーバーは <code>queryString</code> からパラメータ <code>priority</code> を取得し、一致するタスクを見つけ、
+                        <Path>tasks-by-priority</Path>
+                        テンプレートを使用してブラウザに送信される次のビューを生成します。
+                    </li>
+                </list>
+                <p>これらすべてを機能させるには、追加のテンプレートを追加する必要があります。</p>
+            </step>
+            <step>
+                <Path>src/main/resources/templates/thymeleaf</Path>
+                に移動し、新しい
+                <Path>single-task.html</Path>
+                ファイルを作成します。
+            </step>
+            <step>
+                <p>
+                    <Path>single-task.html</Path>
+                    ファイルを開き、以下の内容を追加します。
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html &gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;All Current Tasks&lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;The Selected Task&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Description&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Priority&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>同じフォルダに、<Path>tasks-by-priority.html</Path> という名前の新しいファイルを作成します。
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>tasks-by-priority.html</Path>
+                    ファイルを開き、以下の内容を追加します。
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html&gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;Tasks By Priority &lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Tasks With Priority &lt;span th:text=&quot;${priority}&quot;&gt;&lt;/span&gt;&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&#10;        &lt;th&gt;Description&lt;/th&gt;&#10;        &lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr th:each=&quot;task: ${tasks}&quot;&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="POST リクエストのサポートを追加する" id="add-post-requests">
+        <p>
+            次に、<code>/tasks</code> への POST リクエストハンドラーを追加して、以下を実行します。
+        </p>
+        <list>
+            <li>フォームパラメータから情報を抽出します。</li>
+            <li>リポジトリを使用して新しいタスクを追加します。</li>
+            <li>
+                <control>all-tasks</control>
+                テンプレートを再利用してタスクを表示します。
+            </li>
+        </list>
+        <procedure>
+            <step>
+                <Path>src/main/kotlin</Path>
+                にある
+                <Path>Routing.kt</Path>
+                ファイルに移動します。
+            </step>
+            <step>
+                <p>
+                    <code>.configureRouting()</code> メソッド内に次の <code>post</code> リクエストルートを追加します。
+                </p>
+                <code-block lang="kotlin" code="            post {&#10;                val formContent = call.receiveParameters()&#10;                val params = Triple(&#10;                    formContent[&quot;name&quot;] ?: &quot;&quot;,&#10;                    formContent[&quot;description&quot;] ?: &quot;&quot;,&#10;                    formContent[&quot;priority&quot;] ?: &quot;&quot;&#10;                )&#10;                if (params.toList().any { it.isEmpty() }) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@post&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(params.third)&#10;                    TaskRepository.addTask(&#10;                        Task(&#10;                            params.first,&#10;                            params.second,&#10;                            priority&#10;                        )&#10;                    )&#10;                    val tasks = TaskRepository.allTasks()&#10;                    call.respond(&#10;                        ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks))&#10;                    )&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                } catch (ex: IllegalStateException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }"/>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA で、再実行ボタン (<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="intelliJ IDEA rerun icon"/>) をクリックしてアプリケーションを再起動します。
+                </p>
+            </step>
+            <step>
+                ブラウザで <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a> に移動します。
+            </step>
+            <step>
+                <p>
+                    <control>Create or edit a task</control>
+                    フォームに新しいタスクの詳細を入力します。
+                </p>
+                <img src="server_create_web_app_new_task.png"
+                     alt="A web browser displaying HTML forms" border-effect="rounded" width="706"/>
+            </step>
+            <step>
+                <p><control>Submit</control> ボタンをクリックしてフォームを送信します。
+                    すべてのタスクのリストに新しいタスクが表示されます。
+                </p>
+                <img src="server_create_web_app_new_task_added.png"
+                     alt="A web browser displaying a list of tasks" border-effect="rounded" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="次のステップ" id="next-steps">
+        <p>
+            おめでとうございます！タスクマネージャーを Web アプリケーションとして再構築し、Thymeleaf テンプレートの使用方法を学びました。</p>
+        <p>
+            <Links href="//server-create-websocket-application" summary="WebSockets のパワーを活用してコンテンツを送信および受信する方法を学びます。">次のチュートリアル</Links>に進み、Web Sockets の操作方法を学びましょう。
+        </p>
+    </chapter>
+</topic>

--- a/docs/ja/ktor/server-create-websocket-application.md
+++ b/docs/ja/ktor/server-create-websocket-application.md
@@ -1,0 +1,385 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="KotlinとKtorでWebSocketアプリケーションを作成する" id="server-create-websocket-application">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <var name="example_name" value="tutorial-server-websockets"/>
+    <p>
+        <b>コード例</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+    <p>
+        <b>使用するプラグイン</b>: <Links href="//server-static-content" summary="スタイルシート、スクリプト、画像などの静的コンテンツを提供する方法を学びます。">Static Content</Links>、
+        <Links href="//server-serialization" summary="ContentNegotiationプラグインは、クライアントとサーバー間のメディアタイプのネゴシエーションと、特定の形式でのコンテンツのシリアライズ/デシリアライズという2つの主な目的を果たします。">Content Negotiation</Links>、<Links href="//server-websockets" summary="Websocketsプラグインを使用すると、サーバーとクライアント間で多方向の通信セッションを作成できます。">WebSockets in Ktor Server</Links>、
+        <a href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>
+    </p>
+</tldr>
+<card-summary>
+    WebSocketsのパワーを活用してコンテンツを送信および受信する方法を学びます。
+</card-summary>
+<link-summary>
+    WebSocketsのパワーを活用してコンテンツを送信および受信する方法を学びます。
+</link-summary>
+<web-summary>
+    KotlinとKtorでWebSocketアプリケーションを構築する方法を学びます。このチュートリアルでは、WebSocketを通じてバックエンドサービスをクライアントと接続するプロセスを説明します。
+</web-summary>
+<p>
+    この記事では、KotlinとKtorを使用してWebSocketアプリケーションを作成するプロセスを説明します。これは、<Links href="//server-create-restful-apis" summary="KotlinとKtorを使用してバックエンドサービスを構築する方法を学びます。JSONファイルを生成するRESTful APIの例が含まれています。">RESTful APIの作成</Links>チュートリアルで扱った内容に基づいています。
+</p>
+<p>この記事では、以下の方法について説明します：</p>
+<list>
+    <li>JSONシリアライズを使用するサービスの作成。</li>
+    <li>WebSocket接続を介したコンテンツの送信と受信。</li>
+    <li>複数のクライアントへのコンテンツの同時ブロードキャスト。</li>
+</list>
+<chapter title="前提条件" id="prerequisites">
+    <p>このチュートリアルは単独で行うこともできますが、<Links href="//server-serialization" summary="ContentNegotiationプラグインは、クライアントとサーバー間のメディアタイプのネゴシエーションと、特定の形式でのコンテンツのシリアライズ/デシリアライズという2つの主な目的を果たします。">Content Negotiation</Links>やRESTに慣れるために、<Links href="//server-create-restful-apis" summary="KotlinとKtorを使用してバックエンドサービスを構築する方法を学びます。JSONファイルを生成するRESTful APIの例が含まれています。">RESTful APIの作成</Links>チュートリアルを先に完了することをお勧めします。
+    </p>
+    <p><a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA</a>のインストールを推奨しますが、お好みの他のIDEを使用することも可能です。
+    </p>
+</chapter>
+<chapter title="Hello WebSockets" id="hello-websockets">
+    <p>
+        このチュートリアルでは、<Links href="//server-create-restful-apis" summary="KotlinとKtorを使用してバックエンドサービスを構築する方法を学びます。JSONファイルを生成するRESTful APIの例が含まれています。">RESTful APIの作成</Links>チュートリアルで開発したタスクマネージャーサービスを拡張し、WebSocket接続を通じてクライアントと<code>Task</code>オブジェクトをやり取りする機能を追加します。これを実現するには、<Links href="//server-websockets" summary="Websocketsプラグインを使用すると、サーバーとクライアント間で多方向の通信セッションを作成できます。">WebSocketsプラグイン</Links>を追加する必要があります。既存のプロジェクトに手動で追加することもできますが、このチュートリアルでは、新しいプロジェクトを作成してゼロから始めます。
+    </p>
+    <chapter title="プラグインを含む初期プロジェクトの作成" id="create=project">
+        <procedure>
+            <step>
+                <p>
+                    <a href="https://start.ktor.io/">Ktor Project Generator</a>にアクセスします。
+                </p>
+            </step>
+            <step>
+                <p><control>Project artifact</control>フィールドに、プロジェクトのアーティファクト名として
+                    <Path>com.example.ktor-websockets-task-app</Path>
+                    と入力します。
+                    <img src="tutorial_server_websockets_project_artifact.png"
+                         alt="Ktor Project Generatorでプロジェクトアーティファクトに名前を付ける"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    プラグインセクションで、以下のプラグインを検索し、<control>Add</control>ボタンをクリックして追加します：
+                </p>
+                <list type="bullet">
+                    <li>Content Negotiation</li>
+                    <li>kotlinx.serialization</li>
+                    <li>WebSockets</li>
+                    <li>Static Content</li>
+                </list>
+                <p>
+                    <img src="ktor_project_generator_add_plugins.gif"
+                         alt="Ktor Project Generatorでプラグインを追加する"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    プラグインを追加すると、プラグインセクションの右上に表示されます。
+                </p>
+                <p>プロジェクトに追加されるすべてのプラグインのリストが表示されます：
+                    <img src="tutorial_server_websockets_project_plugins.png"
+                         alt="Ktor Project Generatorのプラグインリスト"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    <control>Download</control>ボタンをクリックして、Ktorプロジェクトを生成し、ダウンロードします。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="スターターコードの追加" id="add-starter-code">
+        <p>ダウンロードが完了したら、IntelliJ IDEAでプロジェクトを開き、以下の手順に従います：</p>
+        <procedure>
+            <step>
+                <Path>src/main/kotlin</Path>に移動し、<Path>model</Path>という新しいサブパッケージを作成します。
+            </step>
+            <step>
+                <p>
+                    <Path>model</Path>パッケージ内に、新しい<Path>Task.kt</Path>ファイルを作成します。
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>Task.kt</Path>ファイルを開き、優先度を表す<code>enum</code>と、タスクを表す<code>data class</code>を追加します：
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+                <p>
+                    <code>Task</code>クラスには、<code>kotlinx.serialization</code>ライブラリの<code>Serializable</code>型のアノテーションが付いていることに注意してください。これは、インスタンスをJSONとの間で変換でき、その内容をネットワーク経由で転送できることを意味します。
+                </p>
+                <p>
+                    WebSocketsプラグインを含めたため、ジェネレーターによって<Path>src/main/kotlin</Path>内の<Path>Websockets.kt</Path>ファイルと、<Path>Routing.kt</Path>ファイルに<code>webSocket</code>ルートが追加されています。
+                </p>
+            </step>
+            <step>
+                <Path>Websockets.kt</Path>ファイルを開き、既存の<code>.configureWebsockets()</code>関数を次のように置き換えます：
+                <code-block lang="kotlin" code="                        fun Application.configureWebsockets() {&#10;                            install(WebSockets) {&#10;                                contentConverter = KotlinxWebsocketSerializationConverter(Json)&#10;                                pingPeriod = 15.seconds&#10;                                timeout = 15.seconds&#10;                                maxFrameSize = Long.MAX_VALUE&#10;                                masking = false&#10;                            }&#10;                        }"/>
+                <list>
+                    <li>WebSocketsプラグインがインストールされ、標準設定で構成されます。</li>
+                    <li><code>contentConverter</code>プロパティが設定され、プラグインが<a
+                                href="https://github.com/Kotlin/kotlinx.serialization"><code>kotlinx.serialization</code></a>ライブラリを通じて送受信されるオブジェクトをシリアライズできるようになります。
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    <Path>Routing.kt</Path>ファイルを開き、既存の<code>Application.configureRouting()</code>関数を以下の実装に置き換えます：
+                </p>
+                <code-block lang="kotlin" code="                    fun Application.configureRouting() {&#10;                        routing {&#10;                            webSocket(&quot;/tasks&quot;) {&#10;                                val tasks = listOf(&#10;                                    Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                                    Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                                    Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                                    Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;                                )&#10;&#10;                                for (task in tasks) {&#10;                                    sendSerialized(task)&#10;                                    delay(1000.milliseconds)&#10;                                }&#10;&#10;                                close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;                            }&#10;                            staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;                        }&#10;                    }"/>
+                <list>
+                    <li>ルーティングは、相対URLが<code>/tasks</code>である単一のエンドポイントで構成されます。</li>
+                    <li>リクエストを受信すると、タスクのリストがWebSocket接続を介してシリアライズされて送信されます。</li>
+                    <li>すべてのアイテムが送信されると、サーバーは接続を閉じます。</li>
+                </list>
+                <p>
+                    デモンストレーション目的で、タスクの送信間に1秒の遅延が導入されています。これにより、クライアントでタスクが段階的に表示される様子を観察できます。この遅延がない場合、この例は以前の記事で開発した<Links href="//server-create-restful-apis" summary="KotlinとKtorを使用してバックエンドサービスを構築する方法を学びます。JSONファイルを生成するRESTful APIの例が含まれています。">RESTfulサービス</Links>や<Links href="//server-create-website" summary="Kotlin、Ktor、Thymeleafテンプレートを使用してWebサイトを構築する方法を学びます。">Webアプリケーション</Links>と同じように見えてしまいます。
+                </p>
+                <p>
+                    このイテレーションの最後のステップは、このエンドポイント用のクライアントを作成することです。<Links href="//server-static-content" summary="スタイルシート、スクリプト、画像などの静的コンテンツを提供する方法を学びます。">Static Content</Links>プラグインを含めたため、Ktorプロジェクトジェネレーターによって<Path>src/main/resources/static</Path>内に<Path>index.html</Path>ファイルが追加されています。
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>index.html</Path>ファイルを開き、既存の内容を以下のように置き換えます：
+                </p>
+                <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;Using Ktor WebSockets&lt;/title&gt;&#10;    &lt;script&gt;&#10;        function readAndDisplayAllTasks() {&#10;            clearTable();&#10;&#10;            const serverURL = 'ws://0.0.0.0:8080/tasks';&#10;            const socket = new WebSocket(serverURL);&#10;&#10;            socket.onopen = logOpenToConsole;&#10;            socket.onclose = logCloseToConsole;&#10;            socket.onmessage = readAndDisplayTask;&#10;        }&#10;&#10;        function readAndDisplayTask(event) {&#10;            let task = JSON.parse(event.data);&#10;            logTaskToConsole(task);&#10;            addTaskToTable(task);&#10;        }&#10;&#10;        function logTaskToConsole(task) {&#10;            console.log(`Received ${task.name}`);&#10;        }&#10;&#10;        function logCloseToConsole() {&#10;            console.log(&quot;Web socket connection closed&quot;);&#10;        }&#10;&#10;        function logOpenToConsole() {&#10;            console.log(&quot;Web socket connection opened&quot;);&#10;        }&#10;&#10;        function tableBody() {&#10;            return document.getElementById(&quot;tasksTableBody&quot;);&#10;        }&#10;&#10;        function clearTable() {&#10;            tableBody().innerHTML = &quot;&quot;;&#10;        }&#10;&#10;        function addTaskToTable(task) {&#10;            tableBody().appendChild(taskRow(task));&#10;        }&#10;&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Viewing Tasks Via WebSockets&lt;/h1&gt;&#10;&lt;form action=&quot;javascript:readAndDisplayAllTasks()&quot;&gt;&#10;    &lt;input type=&quot;submit&quot; value=&quot;View The Tasks&quot;&gt;&#10;&lt;/form&gt;&#10;&lt;table rules=&quot;all&quot;&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+                <p>
+                    このページでは、すべての最新ブラウザで使用可能な<a href="https://websockets.spec.whatwg.org//#websocket"><code>WebSocket</code>型</a>を使用しています。JavaScriptでこのオブジェクトを作成し、コンストラクタにエンドポイントのURLを渡します。その後、<code>onopen</code>、<code>onclose</code>、および<code>onmessage</code>イベントのイベントハンドラーをアタッチします。<code>onmessage</code>イベントがトリガーされると、documentオブジェクトのメソッドを使用してテーブルに行を追加します。
+                </p>
+            </step>
+            <step>
+                <p>IntelliJ IDEAで実行ボタン
+                    (<img src="intellij_idea_gutter_icon.svg"
+                          style="inline" height="16" width="16"
+                          alt="IntelliJ IDEA 実行アイコン"/>)
+                    をクリックしてアプリケーションを起動します。</p>
+            </step>
+            <step>
+                <p>
+                    <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a>にアクセスします。ボタンのあるフォームと空のテーブルが表示されるはずです：
+                </p>
+                <img src="tutorial_server_websockets_iteration_1.png"
+                     alt="ボタン1つのHTMLフォームを表示しているWebブラウザページ"
+                     border-effect="rounded"
+                     width="706"/>
+                <p>
+                    フォームをクリックすると、サーバーからタスクが読み込まれ、1秒間に1つのペースで表示されます。その結果、テーブルには段階的にデータが入力されます。ブラウザの<control>デベロッパーツール</control>で<control>JavaScriptコンソール</control>を開くと、ログメッセージも確認できます。
+                </p>
+                <img src="tutorial_server_websockets_iteration_1_click.gif"
+                     alt="ボタンクリックでリストアイテムを表示しているWebブラウザページ"
+                     border-effect="rounded"
+                     width="706"/>
+                <p>
+                    これで、サービスは期待どおりに動作しています。WebSocket接続が開かれ、アイテムがクライアントに送信され、接続が閉じられます。基礎となるネットワークには多くの複雑さがありますが、Ktorはデフォルトでこれらすべてを処理します。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+</chapter>
+<chapter title="WebSocketを理解する" id="understanding-websockets">
+    <p>
+        次のイテレーションに進む前に、WebSocketの基本をいくつか確認しておくと役立つかもしれません。WebSocketにすでに精通している場合は、<a href="#improve-design">サービスの設計改善</a>に進んでかまいません。
+    </p>
+    <p>
+        これまでのチュートリアルでは、クライアントはHTTPリクエストを送信し、HTTPレスポンスを受信していました。これはうまく機能し、インターネットのスケーラビリティと耐障害性を可能にしています。
+    </p>
+    <p>しかし、以下のようなシナリオには適していません：</p>
+    <list>
+        <li>コンテンツが時間の経過とともに段階的に生成される。</li>
+        <li>イベントに応じてコンテンツが頻繁に変更される。</li>
+        <li>コンテンツが生成される際にクライアントがサーバーと対話する必要がある。</li>
+        <li>1つのクライアントによって送信されたデータを他のクライアントに迅速に伝播させる必要がある。</li>
+    </list>
+    <p>
+        これらのシナリオの例としては、株取引、映画やコンサートのチケット購入、オンラインオークションでの入札、ソーシャルメディアのチャット機能などがあります。WebSocketは、これらの状況に対処するために開発されました。
+    </p>
+    <p>
+        WebSocket接続はTCP上で確立され、長期間持続させることができます。接続は<emphasis>全二重通信</emphasis>（full duplex communication）を提供します。つまり、クライアントはサーバーにメッセージを送信し、同時にサーバーからメッセージを受信することができます。
+    </p>
+    <p>
+        WebSocket APIは、4つのイベント（open、message、close、error）と2つのアクション（send、close）を定義しています。この機能へのアクセス方法は、言語やライブラリによって異なります。例えば、Kotlinでは、着信メッセージのシーケンスを<a
+            href="https://kotlinlang.org/docs/flow.html"><code>Flow</code></a>として利用できます。
+    </p>
+</chapter>
+<chapter title="設計の改善" id="improve-design">
+    <p>次に、より高度な例に対応できるように既存のコードをリファクタリングします。</p>
+    <procedure>
+        <step>
+            <p>
+                <Path>model</Path>パッケージ内に、新しい<Path>TaskRepository.kt</Path>ファイルを作成します。
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>TaskRepository.kt</Path>を開き、<code>TaskRepository</code>型を追加します：
+            </p>
+            <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&&#10;        tasks.add(task)&#10;    }&#10;&#10;    fun removeTask(name: String): Boolean {&#10;        return tasks.removeIf { it.name == name }&#10;    }&#10;}"/>
+            <p>このコードは、以前のチュートリアルで見た覚えがあるかもしれません。</p>
+        </step>
+        <step>
+            <Path>src/main/kotlin</Path>に移動し、<Path>Routing.kt</Path>ファイルを開きます。
+        </step>
+        <step>
+            <p>
+                <code>TaskRepository</code>を利用することで、<code>Application.configureRouting()</code>のルーティングを簡素化できます：
+            </p>
+            <code-block lang="kotlin" code="                    routing {&#10;                        webSocket(&quot;/tasks&quot;) {&#10;                            for (task in TaskRepository.allTasks()) {&#10;                                sendSerialized(task)&#10;                                delay(1000.milliseconds)&#10;                            }&#10;                            close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;                        }&#10;                        // ...&#10;                    }"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="WebSocket経由でメッセージを送信する" id="send-messages">
+    <p>
+        WebSocketのパワーを説明するために、次のような新しいエンドポイントを作成します：
+    </p>
+    <list>
+        <li>
+            クライアントが起動すると、既存のすべてのタスクを受信します。
+        </li>
+        <li>
+            クライアントはタスクを作成して送信できます。
+        </li>
+        <li>
+            1つのクライアントがタスクを送信すると、他のクライアントに通知されます。
+        </li>
+    </list>
+    <procedure>
+        <step>
+            <p>
+                <Path>Routing.kt</Path>ファイル内の現在の<code>.configureRouting()</code>メソッドを以下の実装に置き換えます：
+            </p>
+            <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        val sessions =&#10;            Collections.synchronizedList&lt;WebSocketServerSession&gt;(ArrayList())&#10;&#10;        webSocket(&quot;/tasks&quot;) {&#10;            sendAllTasks()&#10;            close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;        }&#10;&#10;        webSocket(&quot;/tasks2&quot;) {&#10;            sessions.add(this)&#10;            sendAllTasks()&#10;&#10;            while(true) {&#10;                ensureActive()&#10;                val newTask = receiveDeserialized&lt;Task&gt;()&#10;                TaskRepository.addTask(newTask)&#10;                for(session in sessions) {&#10;                    session.sendSerialized(newTask)&#10;                }&#10;            }&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;    }&#10;}&#10;&#10;private suspend fun DefaultWebSocketServerSession.sendAllTasks() {&#10;    for (task in TaskRepository.allTasks()) {&#10;        sendSerialized(task)&#10;        delay(1000.milliseconds)&#10;    }&#10;}"/>
+            <p>このコードで以下のことを行いました：</p>
+            <list>
+                <li>
+                    既存のすべてのタスクを送信する機能をヘルパーメソッドにリファクタリングしました。
+                </li>
+                <li>
+                    <code>routing {}</code>ブロック内で、すべてのクライアントを追跡するためのスレッドセーフな<code>session</code>オブジェクトのリストを作成しました。
+                </li>
+                <li>
+                    相対URLが<code>/tasks2</code>の新しいエンドポイントを追加しました。クライアントがこのエンドポイントに接続すると、対応する<code>session</code>オブジェクトがリストに追加されます。その後、サーバーは新しいタスクの受信を待つ無限ループに入ります。新しいタスクを受信すると、サーバーはそれをリポジトリに保存し、現在のクライアントを含むすべてのクライアントにコピーを送信します。
+                </li>
+            </list>
+            <p>
+                この機能をテストするために、<Path>index.html</Path>の機能を拡張した新しいページを作成します。
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>src/main/resources/static</Path>内に、<Path>wsClient.html</Path>という新しいHTMLファイルを作成します。
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>wsClient.html</Path>を開き、以下の内容を追加します：
+            </p>
+            <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;WebSocket Client&lt;/title&gt;&#10;    &lt;script&gt;&#10;        let serverURL;&#10;        let socket;&#10;&#10;        function setupSocket() {&#10;            serverURL = 'ws://0.0.0.0:8080/tasks2';&#10;            socket = new WebSocket(serverURL);&#10;&#10;            socket.onopen = logOpenToConsole;&#10;            socket.onclose = logCloseToConsole;&#10;            socket.onmessage = readAndDisplayTask;&#10;        }&#10;&#10;        function readAndDisplayTask(event) {&#10;            let task = JSON.parse(event.data);&#10;            logTaskToConsole(task);&#10;            addTaskToTable(task);&#10;        }&#10;&#10;        function logTaskToConsole(task) {&#10;            console.log(`Received ${task.name}`);&#10;        }&#10;&#10;        function logCloseToConsole() {&#10;            console.log(&quot;Web socket connection closed&quot;);&#10;        }&#10;&#10;        function logOpenToConsole() {&#10;            console.log(&quot;Web socket connection opened&quot;);&#10;        }&#10;&#10;        function tableBody() {&#10;            return document.getElementById(&quot;tasksTableBody&quot;);&#10;        }&#10;&#10;        function addTaskToTable(task) {&#10;            tableBody().appendChild(taskRow(task));&#10;        }&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;&#10;        function getFormValue(name) {&#10;            return document.forms[0][name].value&#10;        }&#10;&#10;        function buildTaskFromForm() {&#10;            return {&#10;                name: getFormValue(&quot;newTaskName&quot;),&#10;                description: getFormValue(&quot;newTaskDescription&quot;),&#10;                priority: getFormValue(&quot;newTaskPriority&quot;)&#10;            }&#10;        }&#10;&#10;        function logSendingToConsole(data) {&#10;            console.log(&quot;About to send&quot;,data);&#10;        }&#10;&#10;        function sendTaskViaSocket(data) {&#10;            socket.send(JSON.stringify(data));&#10;        }&#10;&#10;        function sendTaskToServer() {&#10;            let data = buildTaskFromForm();&#10;            logSendingToConsole(data);&#10;            sendTaskViaSocket(data);&#10;            //フォームの送信を防止&#10;            return false;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body onload=&quot;setupSocket()&quot;&gt;&#10;&lt;h1&gt;Viewing Tasks Via WebSockets&lt;/h1&gt;&#10;&lt;table rules=&quot;all&quot;&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;Create a new task&lt;/h3&gt;&#10;    &lt;form onsubmit=&quot;return sendTaskToServer()&quot;&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskName&quot;&gt;Name: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;newTaskName&quot;&#10;                   name=&quot;newTaskName&quot; size=&quot;10&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskDescription&quot;&gt;Description: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;newTaskDescription&quot;&#10;                   name=&quot;newTaskDescription&quot; size=&quot;20&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskPriority&quot;&gt;Priority: &lt;/label&gt;&#10;            &lt;select id=&quot;newTaskPriority&quot; name=&quot;newTaskPriority&quot;&gt;&#10;                &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;                &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;                &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;                &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;            &lt;/select&gt;&#10;        &lt;/div&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            <p>
+                この新しいページには、ユーザーが新しいタスクの情報を入力できるHTMLフォームが導入されています。フォームを送信すると、<code>sendTaskToServer()</code>イベントハンドラーが呼び出されます。これにより、フォームデータを使用してJavaScriptオブジェクトが構築され、WebSocketオブジェクトの<code>.send()</code>メソッドを使用してサーバーに送信されます。
+            </p>
+        </step>
+        <step>
+            <p>
+                IntelliJ IDEAで、再実行ボタン (<img src="intellij_idea_rerun_icon.svg"
+                                               style="inline" height="16" width="16"
+                                               alt="IntelliJ IDEA 再実行アイコン"/>) をクリックしてアプリケーションを再起動します。
+            </p>
+        </step>
+        <step>
+            <p>この機能をテストするには、2つのブラウザを並べて開き、以下の手順に従います。</p>
+            <list type="decimal">
+                <li>
+                    ブラウザAで、<a href="http://0.0.0.0:8080/static/wsClient.html">http://0.0.0.0:8080/static/wsClient.html</a>にアクセスします。デフォルトのタスクが表示されるはずです。
+                </li>
+                <li>
+                    ブラウザAで新しいタスクを追加します。新しいタスクがそのページのテーブルに表示されるはずです。
+                </li>
+                <li>
+                    ブラウザBで、<a href="http://0.0.0.0:8080/static/wsClient.html">http://0.0.0.0:8080/static/wsClient.html</a>にアクセスします。デフォルトのタスクに加えて、ブラウザAで追加した新しいタスクも表示されるはずです。
+                </li>
+                <li>
+                    どちらかのブラウザでタスクを追加します。両方のページに新しいアイテムが表示されるはずです。
+                </li>
+            </list>
+            <img src="tutorial_server_websockets_iteration_2_test.gif"
+                 alt="2つのWebブラウザページを並べてHTMLフォームから新しいタスクを作成するデモンストレーション"
+                 border-effect="rounded"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="自動テストの追加" id="add-automated-tests">
+    <p>
+        QAプロセスを効率化し、高速、再現可能、かつハンズフリーにするために、Ktorに組み込まれている<Links href="//server-testing" summary="特別なテストエンジンを使用してサーバーアプリケーションをテストする方法を学びます。">自動テストのサポート</Links>を使用できます。以下の手順に従ってください：
+    </p>
+    <procedure>
+        <step>
+            <p>
+                Ktor Client内で<Links href="//server-serialization" summary="ContentNegotiationプラグインは、クライアントとサーバー間のメディアタイプのネゴシエーションと、特定の形式でのコンテンツのシリアライズ/デシリアライズという2つの主な目的を果たします。">Content Negotiation</Links>のサポートを構成できるように、以下の依存関係を<Path>build.gradle.kts</Path>に追加します：
+            </p>
+            <code-block lang="kotlin" code="    testImplementation(ktorLibs.client.contentNegotiation)"/>
+        </step>
+        <step>
+            <p>
+                <p>IntelliJ IDEAで、エディターの右側にあるGradle通知アイコン
+                    (<img alt="IntelliJ IDEA Gradle アイコン"
+                          src="intellij_idea_gradle_icon.svg" width="16" height="26"/>)
+                    をクリックしてGradleの変更をロードします。</p>
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>src/test/kotlin</Path>に移動し、<Path>ServerTest.kt</Path>ファイルを開きます。
+            </p>
+        </step>
+        <step>
+            <p>
+                生成されたテストクラスを以下の実装に置き換えます：
+            </p>
+            <code-block lang="kotlin" code="import com.example.model.Priority&#10;import com.example.model.Task&#10;import io.ktor.client.plugins.contentnegotiation.ContentNegotiation&#10;import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession&#10;import io.ktor.client.plugins.websocket.WebSockets&#10;import io.ktor.client.plugins.websocket.converter&#10;import io.ktor.client.plugins.websocket.webSocket&#10;import io.ktor.serialization.deserialize&#10;import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter&#10;import io.ktor.serialization.kotlinx.json.json&#10;import io.ktor.server.testing.testApplication&#10;import kotlinx.coroutines.flow.consumeAsFlow&#10;import kotlinx.coroutines.flow.map&#10;import kotlinx.coroutines.flow.scan&#10;import kotlinx.serialization.json.Json&#10;import kotlin.test.Test&#10;import kotlin.test.assertEquals&#10;&#10;class ServerTest {&#10;    @Test&#10;    fun testRoot() = testApplication {&#10;        configure()&#10;&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;            install(WebSockets) {&#10;                contentConverter =&#10;                    KotlinxWebsocketSerializationConverter(Json)&#10;            }&#10;        }&#10;&#10;        val expectedTasks = listOf(&#10;            Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;            Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;            Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;            Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;        )&#10;        var actualTasks = emptyList&lt;Task&gt;()&#10;&#10;        client.webSocket(&quot;/tasks&quot;) {&#10;            consumeTasksAsFlow().collect { allTasks -&gt;&#10;                actualTasks = allTasks&#10;            }&#10;        }&#10;&#10;        assertEquals(expectedTasks.size, actualTasks.size)&#10;        expectedTasks.forEachIndexed { index, task -&gt;&#10;            assertEquals(task, actualTasks[index])&#10;        }&#10;    }&#10;&#10;    private fun DefaultClientWebSocketSession.consumeTasksAsFlow() = incoming&#10;        .consumeAsFlow()&#10;        .map {&#10;            converter!!.deserialize&lt;Task&gt;(it)&#10;        }&#10;        .scan(emptyList&lt;Task&gt;()) { list, task -&gt;&#10;            list + task&#10;        }&#10;}"/>
+            <p>
+                このセットアップで、以下のことを行いました：
+            </p>
+            <list>
+                <li>
+                    サービスがテスト環境内で実行されるように構成し、JSONシリアライズやWebSocketなど、本番環境と同じ機能を有効にしました。
+                </li>
+                <li>
+                    <Links href="//client-create-and-configure" summary="Ktorクライアントの作成と構成方法を学びます。">Ktor Client</Links>内でコンテントネゴシエーションとWebSocketサポートを構成しました。これがないと、クライアントはWebSocket接続を使用する際にオブジェクトをJSONとして（デ）シリアライズする方法を認識できません。
+                </li>
+                <li>
+                    サービスから返されることが期待される<code>Tasks</code>のリストを宣言しました。
+                </li>
+                <li>
+                    <code>client</code>オブジェクトの<code>.webSocket</code>関数を使用して、<code>/tasks</code>にリクエストを送信しました。
+                </li>
+                <li>
+                    着信タスクを<code>Flow</code>として受け取り、それらをリストに順次追加しました。
+                </li>
+                <li>
+                    すべてのタスクを受信したら、通常の方法で<code>expectedTasks</code>と<code>actualTasks</code>を比較しました。
+                </li>
+            </list>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="次のステップ" id="next-steps">
+    <p>
+        お疲れ様でした！WebSocket通信とKtor Clientによる自動テストを組み込むことで、タスクマネージャーサービスを大幅に強化できました。
+    </p>
+    <p>
+        <Links href="//server-integrate-database" summary="Exposed SQLライブラリを使用してKtorサービスをデータベースリポジトリに接続するプロセスを学びます。">次のチュートリアル</Links>に進み、Exposedライブラリを使用してサービスがリレーショナルデータベースとシームレスに対話する方法を学んでください。
+    </p>
+</chapter>
+</topic>

--- a/docs/ja/ktor/server-dependencies.md
+++ b/docs/ja/ktor/server-dependencies.md
@@ -1,0 +1,220 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   title="サーバーの依存関係の追加"
+   id="server-dependencies" help-id="Gradle">
+<show-structure for="chapter" depth="2"/>
+<link-summary>既存のGradle/MavenプロジェクトにKtorサーバーの依存関係を追加する方法を学びます。</link-summary>
+<p>
+    このトピックでは、既存のGradle/MavenプロジェクトにKtorサーバーに必要な依存関係を追加する方法を説明します。
+</p>
+<chapter title="リポジトリの設定" id="repositories">
+    <p>
+        Ktorの依存関係を追加する前に、このプロジェクトのリポジトリを設定する必要があります。
+    </p>
+    <list>
+        <li>
+            <p>
+                <control>プロダクション</control>
+            </p>
+            <p>
+                KtorのプロダクションリリースはMaven Centralリポジトリで利用可能です。
+                ビルドスクリプトで以下のようにこのリポジトリを宣言できます。
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                            repositories {&#10;                                mavenCentral()&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                            repositories {&#10;                                mavenCentral()&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <note>
+                        <p>
+                            プロジェクトは<a href="https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#super-pom">Super POM</a>からCentralリポジトリを継承しているため、<Path>pom.xml</Path>ファイルにMaven Centralリポジトリを追加する必要はありません。
+                        </p>
+                    </note>
+                </TabItem>
+            </Tabs>
+        </li>
+        <li>
+            <p>
+                <control>早期アクセスプログラム (EAP)</control>
+            </p>
+            <p>
+                Ktorの<a href="https://ktor.io/eap/">EAP</a>バージョンにアクセスするには、<a href="https://redirector.kotlinlang.org/maven/ktor-eap/io/ktor/">Spaceリポジトリ</a>を参照する必要があります。
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                            repositories {&#10;                                maven {&#10;                                    url = uri(&quot;https://redirector.kotlinlang.org/maven/ktor-eap&quot;)&#10;                                }&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                            repositories {&#10;                                maven {&#10;                                    url &quot;https://redirector.kotlinlang.org/maven/ktor-eap&quot;&#10;                                }&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <code-block lang="XML" code="                            &lt;repositories&gt;&#10;                                &lt;repository&gt;&#10;                                    &lt;id&gt;ktor-eap&lt;/id&gt;&#10;                                    &lt;url&gt;https://redirector.kotlinlang.org/maven/ktor-eap&lt;/url&gt;&#10;                                &lt;/repository&gt;&#10;                            &lt;/repositories&gt;"/>
+                </TabItem>
+            </Tabs>
+            <p>
+                KtorのEAPには<a href="https://redirector.kotlinlang.org/maven/dev">Kotlin devリポジトリ</a>が必要になる場合があることに注意してください。
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                            repositories {&#10;                                maven {&#10;                                    url = uri(&quot;https://redirector.kotlinlang.org/maven/dev&quot;)&#10;                                }&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                            repositories {&#10;                                maven {&#10;                                    url &quot;https://redirector.kotlinlang.org/maven/dev&quot;&#10;                                }&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <code-block lang="XML" code="                            &lt;repositories&gt;&#10;                                &lt;repository&gt;&#10;                                    &lt;id&gt;ktor-eap&lt;/id&gt;&#10;                                    &lt;url&gt;https://redirector.kotlinlang.org/maven/dev&lt;/url&gt;&#10;                                &lt;/repository&gt;&#10;                            &lt;/repositories&gt;"/>
+                </TabItem>
+            </Tabs>
+        </li>
+    </list>
+</chapter>
+<chapter title="依存関係の追加" id="add-ktor-dependencies">
+    <chapter title="コアの依存関係" id="core-dependencies">
+        <p>
+            すべてのKtorアプリケーションには、少なくとも以下の依存関係が必要です。
+        </p>
+        <list>
+            <li>
+                <p>
+                    <code>ktor-server-core</code>: Ktorのコア機能が含まれています。
+                </p>
+            </li>
+            <li>
+                <p>
+                    <Links href="//server-engines" summary="ネットワークリクエストを処理するエンジンについて学びます。">エンジン</Links>（例: <code>ktor-server-netty</code>）の依存関係。
+                </p>
+            </li>
+        </list>
+        <p>
+            プラットフォームごとに、Ktorは<code>-jvm</code>などのサフィックスを持つプラットフォーム固有のアーティファクトを提供しています（例: <code>ktor-server-core-jvm</code>、<code>ktor-server-netty-jvm</code>）。
+            Gradleは指定されたプラットフォームに適したアーティファクトを解決しますが、Mavenはこの機能をサポートしていないことに注意してください。
+            つまり、Mavenの場合はプラットフォーム固有のサフィックスを手動で追加する必要があります。
+            基本的なKtorアプリケーションの<code>dependencies</code>ブロックは以下のようになります。
+        </p>
+        <Tabs group="languages">
+            <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                <code-block lang="Kotlin" code="                        dependencies {&#10;                            implementation(&quot;io.ktor:ktor-server-core:%ktor_version%&quot;)&#10;                            implementation(&quot;io.ktor:ktor-server-netty:%ktor_version%&quot;)&#10;                        }"/>
+            </TabItem>
+            <TabItem title="Gradle (Groovy)" group-key="groovy">
+                <code-block lang="Groovy" code="                        dependencies {&#10;                            implementation &quot;io.ktor:ktor-server-core:%ktor_version%&quot;&#10;                            implementation &quot;io.ktor:ktor-server-netty:%ktor_version%&quot;&#10;                        }"/>
+            </TabItem>
+            <TabItem title="Maven" group-key="maven">
+                <code-block lang="XML" code="                        &lt;dependencies&gt;&#10;                            &lt;dependency&gt;&#10;                                &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                                &lt;artifactId&gt;ktor-server-core-jvm&lt;/artifactId&gt;&#10;                                &lt;version&gt;%ktor_version%&lt;/version&gt;&#10;                            &lt;/dependency&gt;&#10;                            &lt;dependency&gt;&#10;                                &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                                &lt;artifactId&gt;ktor-server-netty-jvm&lt;/artifactId&gt;&#10;                                &lt;version&gt;%ktor_version%&lt;/version&gt;&#10;                            &lt;/dependency&gt;&#10;                        &lt;/dependencies&gt;"/>
+            </TabItem>
+        </Tabs>
+    </chapter>
+    <chapter title="ロギングの依存関係" id="logging-dependency">
+        <p>
+            Ktorは、さまざまなロギングフレームワーク（例: LogbackやLog4j）のファサードとしてSLF4J APIを使用し、アプリケーションイベントをログに記録できるようにします。
+            必要なアーティファクトの追加方法については、<a href="server-logging.md#add_dependencies">ロガーの依存関係の追加</a>を参照してください。
+        </p>
+    </chapter>
+    <chapter title="プラグインの依存関係" id="plugin-dependencies">
+        <p>
+            Ktorの機能を拡張する<Links href="//server-plugins" summary="プラグインは、シリアライゼーション、コンテンツエンコーディング、圧縮などの共通機能を提供します。">プラグイン</Links>には、追加の依存関係が必要になる場合があります。
+            詳細については、対応するトピックを参照してください。
+        </p>
+    </chapter>
+</chapter>
+<var name="target_module" value="server"/>
+<chapter title="Ktorバージョンの整合性の確保" id="ensure-version-consistency">
+    <chapter id="using-gradle-plugin" title="Ktor Gradleプラグインの使用">
+        <p>
+            <a href="https://github.com/ktorio/ktor-build-plugins">Ktor Gradleプラグイン</a>を適用すると、暗黙的にKtor BOMの依存関係が追加され、すべてのKtorの依存関係が同じバージョンであることを保証できます。
+            この場合、Ktorアーティファクトに依存する際にバージョンを指定する必要がなくなります。
+        </p>
+        <Tabs group="languages">
+            <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                <code-block lang="Kotlin" code="                        plugins {&#10;                            // ...&#10;                            id(&quot;io.ktor.plugin&quot;) version &quot;%ktor_version%&quot;&#10;                        }&#10;                        dependencies {&#10;                            implementation(&quot;io.ktor:ktor-%target_module%-core&quot;)&#10;                            // ...&#10;                        }"/>
+            </TabItem>
+            <TabItem title="Gradle (Groovy)" group-key="groovy">
+                <code-block lang="Groovy" code="                        plugins {&#10;                            // ...&#10;                            id &quot;io.ktor.plugin&quot; version &quot;%ktor_version%&quot;&#10;                        }&#10;                        dependencies {&#10;                            implementation &quot;io.ktor:ktor-%target_module%-core&quot;&#10;                            // ...&#10;                        }"/>
+            </TabItem>
+        </Tabs>
+    </chapter>
+    <chapter id="using-version-catalog" title="公開されたバージョンカタログの使用">
+        <p>
+            公開されたバージョンカタログを使用して、Ktorの依存関係の宣言を一元化することもできます。
+            このアプローチには以下の利点があります。
+        </p>
+        <list id="published-version-catalog-benefits">
+            <li>
+                独自のカタログでKtorのバージョンを手動で宣言する必要がなくなります。
+            </li>
+            <li>
+                すべてのKtorモジュールを単一の名前空間で公開します。
+            </li>
+        </list>
+        <p>
+            カタログを宣言するには、<Path>settings.gradle.kts</Path>で任意の名前のバージョンカタログを作成します。
+        </p>
+        <code-block lang="kotlin" code="                dependencyResolutionManagement {&#10;                    versionCatalogs {&#10;                        create(&quot;ktorLibs&quot;) {&#10;                            from(&quot;io.ktor:ktor-version-catalog:%ktor_version%&quot;)&#10;                        }&#10;                    }&#10;                }"/>
+        <p>
+            その後、カタログ名を参照してモジュールの<Path>build.gradle.kts</Path>に依存関係を追加できます。
+        </p>
+        <code-block lang="kotlin" code="                dependencies {&#10;                    implementation(ktorLibs.%target_module%.core)&#10;                    // ...&#10;                }"/>
+    </chapter>
+</chapter>
+<chapter title="アプリケーション実行用のエントリポイントの作成" id="create-entry-point">
+    <p>
+        Gradle/Mavenを使用したKtorサーバーの<Links href="//server-run" summary="サーバーKtorアプリケーションを実行する方法を学びます。">実行</Links>は、<Links href="//server-create-and-configure" summary="アプリケーションのデプロイニーズに応じてサーバーを作成する方法を学びます。">サーバーの作成</Links>方法に依存します。
+        アプリケーションのメインクラスは、次のいずれかの方法で指定できます。
+    </p>
+    <list>
+        <li>
+            <p>
+                <a href="#embedded-server">embeddedServer</a>を使用する場合、メインクラスを次のように指定します。
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                            application {&#10;                                mainClass.set(&quot;com.example.ApplicationKt&quot;)&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                            application {&#10;                                mainClass = &quot;com.example.ApplicationKt&quot;&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <code-block lang="XML" code="                            &lt;properties&gt;&#10;                                &lt;main.class&gt;com.example.ApplicationKt&lt;/main.class&gt;&#10;                            &lt;/properties&gt;"/>
+                </TabItem>
+            </Tabs>
+        </li>
+        <li>
+            <p>
+                <a href="#engine-main">EngineMain</a>を使用する場合、それをメインクラスとして設定する必要があります。
+                Nettyの場合、以下のようになります。
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                            application {&#10;                                mainClass.set(&quot;io.ktor.server.netty.EngineMain&quot;)&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                            application {&#10;                                mainClass = &quot;io.ktor.server.netty.EngineMain&quot;&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <code-block lang="XML" code="                            &lt;properties&gt;&#10;                                &lt;main.class&gt;io.ktor.server.netty.EngineMain&lt;/main.class&gt;&#10;                            &lt;/properties&gt;"/>
+                </TabItem>
+            </Tabs>
+        </li>
+    </list>
+    <note>
+        <p>
+            アプリケーションをFat JARとしてパッケージ化する場合は、対応するプラグインを設定する際にサーバーの作成方法も考慮する必要があります。
+            詳細については、以下のトピックを参照してください。
+        </p>
+        <list>
+            <li>
+                <p>
+                    <Links href="//server-fatjar" summary="Ktor Gradleプラグインを使用して、実行可能なFat JARを作成し実行する方法を学びます。">Ktor Gradleプラグインを使用したFat JARの作成</Links>
+                </p>
+            </li>
+            <li>
+                <p>
+                    <Links href="//maven-assembly-plugin" summary="サンプルプロジェクト: tutorial-server-get-started-maven">Maven Assemblyプラグインを使用したFat JARの作成</Links>
+                </p>
+            </li>
+        </list>
+    </note>
+</chapter>
+</topic>

--- a/docs/ja/ktor/server-development-mode.md
+++ b/docs/ja/ktor/server-development-mode.md
@@ -1,0 +1,77 @@
+<topic xmlns="" xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="server-development-mode" title="開発モード"
+   help-id="development_mode;development-mode">
+<show-structure for="chapter" depth="2"/>
+<p>
+    Ktorは、開発向けに特化した特別なモードを提供しています。このモードでは、以下の機能が有効になります：
+</p>
+<list>
+    <li>サーバーを再起動せずにアプリケーションクラスをリロードするための<Links href="//server-auto-reload" summary="コードの変更時にアプリケーションクラスをリロードするためのオートリロードの使用方法について説明します。">オートリロード</Links>。
+    </li>
+    <li><a href="#pipelines">パイプライン</a>をデバッグするための拡張情報（スタックトレースを含む）。
+    </li>
+    <li><emphasis>5**</emphasis>サーバーエラーが発生した場合の<Links href="//server-status-pages" summary="%plugin_name%を使用すると、Ktorアプリケーションは、スローされた例外やステータスコードに基づいて、あらゆる失敗状態に対して適切に応答できるようになります。">レスポンスページ</Links>における拡張デバッグ情報。
+    </li>
+</list>
+<note>
+    <p>
+        開発モードはパフォーマンスに影響を与えるため、本番環境では使用しないでください。
+    </p>
+</note>
+<chapter title="開発モードを有効にする" id="enable">
+    <p>
+        開発モードは、アプリケーションの設定ファイル、専用のシステムプロパティ、または環境変数を使用して、さまざまな方法で有効にできます。
+    </p>
+    <chapter title="設定ファイル" id="application-conf">
+        <p>
+            <Links href="//server-configuration-file" summary="設定ファイルでさまざまなサーバーパラメータを構成する方法について説明します。">設定ファイル</Links>で開発モードを有効にするには、<code>development</code>オプションを<code>true</code>に設定します：
+        </p>
+        <Tabs group="config">
+            <TabItem title="application.conf" group-key="hocon">
+                <code-block code="                        ktor {&#10;                            development = true&#10;                        }"/>
+            </TabItem>
+            <TabItem title="application.yaml" group-key="yaml">
+                <code-block lang="yaml" code="                        ktor:&#10;                            development: true"/>
+            </TabItem>
+        </Tabs>
+    </chapter>
+    <chapter title="'io.ktor.development' システムプロパティ" id="system-property">
+        <p>
+            <control>io.ktor.development</control>
+            <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">システムプロパティ</a>を使用すると、アプリケーションの実行時に開発モードを有効にできます。
+        </p>
+        <p>
+            IntelliJ IDEAを使用して開発モードでアプリケーションを実行するには、<code>-D</code>フラグを付けて<code>io.ktor.development</code>を<a href="https://www.jetbrains.com/help/idea/run-debug-configuration-kotlin.html#1">VMオプション</a>に渡します：
+        </p>
+        <code-block code="                -Dio.ktor.development=true"/>
+        <p>
+            <Links href="//server-dependencies" summary="既存のGradle/MavenプロジェクトにKtorサーバーの依存関係を追加する方法について説明します。">Gradle</Links>タスクを使用してアプリケーションを実行する場合、次の2つのいずれかの方法で開発モードを有効にできます：
+        </p>
+        <list>
+            <li>
+                <p>
+                    <Path>build.gradle.kts</Path>ファイルの<code>ktor</code>ブロックを設定します：
+                </p>
+                <code-block lang="Kotlin" code="                        ktor {&#10;                            development = true&#10;                        }"/>
+            </li>
+            <li>
+                <p>
+                    Gradle CLIフラグを渡して、1回の実行に対して開発モードを有効にします：
+                </p>
+                <code-block lang="bash" code="                          ./gradlew run -Pio.ktor.development=true"/>
+            </li>
+        </list>
+        <tip>
+            <p>
+                <code>-ea</code>フラグを使用して開発モードを有効にすることもできます。
+                <code>-D</code>フラグで渡される<code>io.ktor.development</code>システムプロパティは、<code>-ea</code>よりも優先されることに注意してください。
+            </p>
+        </tip>
+    </chapter>
+    <chapter title="'io.ktor.development' 環境変数" id="environment-variable">
+        <p>
+            <a href="#native">Nativeクライアント</a>で開発モードを有効にするには、<code>io.ktor.development</code>環境変数を使用します。
+        </p>
+    </chapter>
+</chapter>
+</topic>

--- a/docs/ko/ktor/FAQ.md
+++ b/docs/ko/ktor/FAQ.md
@@ -1,0 +1,167 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   title="FAQ"
+   id="FAQ">
+<chapter title="Ktor는 어떻게 발음하는 것이 올바른가요?" id="pronounce">
+    <p>
+        <emphasis>/keɪ-tor/</emphasis>
+    </p>
+</chapter>
+<chapter title='"Ktor"라는 이름은 무엇을 의미하나요?' id="name-meaning">
+    <p>
+        Ktor라는 이름은 <code>ctor</code>(생성자, constructor)라는 약어에서 유래되었으며, 첫 글자를 Kotlin의 'K'로 바꾼 것입니다.
+    </p>
+</chapter>
+<chapter title="질문, 버그 보고, 연락, 기여, 피드백 제출 등은 어떻게 하나요?" id="feedback">
+    <p>
+        <a href="https://ktor.io/support/">Support</a> 페이지에서 이용 가능한 지원 채널에 대해 자세히 알아보세요.
+        <a href="https://github.com/ktorio/ktor/blob/main/CONTRIBUTING.md">How to contribute</a> 가이드는 Ktor에 기여할 수 있는 다양한 방법을 설명합니다.
+    </p>
+</chapter>
+<chapter title="CIO는 무엇을 의미하나요?" id="cio">
+    <p>
+        CIO는
+        <emphasis>Coroutine-based I/O</emphasis>(코루틴 기반 I/O)
+        의 약자입니다.
+        보통 외부 JVM 기반 라이브러리에 의존하지 않고 Kotlin과 코루틴(Coroutines)을 사용하여 IETF RFC나 다른 프로토콜을 구현하는 로직을 가진 엔진을 의미합니다.
+    </p>
+</chapter>
+<chapter title="해결되지 않은(빨간색) Ktor 임포트(import) 문제를 어떻게 해결하나요?" id="ktor-artifact">
+    <p>
+        해당하는 <Links href="//server-dependencies" summary="기존 Gradle/Maven 프로젝트에 Ktor 서버 의존성을 추가하는 방법을 알아봅니다.">Ktor 아티팩트(artifact)</Links>가 빌드 스크립트에 추가되었는지 확인하세요.
+    </p>
+</chapter>
+<chapter
+        title="Ktor는 서버가 안정적으로 종료(graceful shutdown)될 수 있도록 IPC 시그널(예: SIGTERM 또는 SIGINT)을 캐치하는 방법을 제공하나요?"
+        id="sigterm">
+    <p>
+        <a href="#engine-main">EngineMain</a>을 실행 중이라면 자동으로 처리됩니다.
+        그렇지 않으면 직접 처리해야 합니다.
+        JVM의 <code>Runtime.getRuntime().addShutdownHook</code> 기능을 사용할 수 있습니다.
+    </p>
+</chapter>
+<chapter title="프록시 뒤에 있는 클라이언트 IP를 어떻게 가져오나요?" id="proxy-ip">
+    <p>
+        프록시가 적절한 헤더를 제공하고 <Links href="//server-forward-headers" summary="필요한 의존성: io.ktor:%artifact_name%">ForwardedHeader</Links> 플러그인이 설치된 경우, <code>call.request.origin</code> 속성은 원래 호출자(프록시)에 대한 <a href="#request_information">연결 정보</a>를 제공합니다.
+    </p>
+</chapter>
+<chapter title="main 브랜치의 최신 커밋을 어떻게 테스트할 수 있나요?" id="bleeding-edge">
+    <p>
+        <code>jetbrains.space</code>에서 Ktor 나이틀리 빌드(nightly build)를 받을 수 있습니다.
+        <a href="https://ktor.io/eap/">Early Access Program</a>에서 더 자세한 내용을 확인하세요.
+    </p>
+</chapter>
+<chapter title="사용 중인 Ktor 버전을 어떻게 확인할 수 있나요?" id="ktor-version-used">
+    <p>
+        Ktor 버전이 포함된 <code>Server</code> 응답 헤더를 보내는 <Links href="//server-default-headers" summary="필요한 의존성: io.ktor:%artifact_name%">DefaultHeaders</Links> 플러그인을 사용할 수 있습니다. 예시:
+    </p>
+    <code-block code="            Server: ktor-server-core/%ktor_version%"/>
+</chapter>
+<chapter title="라우트가 실행되지 않습니다. 어떻게 디버깅하나요?" id="route-not-executing">
+    <p>
+        Ktor는 라우팅 결정을 문제 해결하는 데 도움이 되는 추적(tracing) 메커니즘을 제공합니다.
+        <a href="#trace_routes">Tracing routes</a> 섹션을 확인하세요.
+    </p>
+</chapter>
+<chapter title="'Response has already been sent' 오류를 어떻게 해결하나요?" id="response-already-sent">
+    <p>
+        이 오류는 사용자 본인 또는 플러그인이나 인터셉터(interceptor)가 이미 <code>call.respond&#42; </code> 함수를 호출했으며, 이를 다시 호출하려고 함을 의미합니다.
+    </p>
+</chapter>
+<chapter title="Ktor 이벤트를 어떻게 구독하나요?" id="ktor-events">
+    <p>
+        자세한 내용은 <Links href="//server-events" summary="">Application monitoring</Links> 페이지를 참조하세요.
+    </p>
+</chapter>
+<chapter title="'No configuration setting found for key ktor' 오류를 어떻게 해결하나요?" id="cannot-find-application-conf">
+    <p>
+        이것은 Ktor가 <Links href="//server-configuration-file" summary="설정 파일에서 다양한 서버 파라미터를 설정하는 방법을 알아봅니다.">설정 파일</Links>을 찾을 수 없음을 의미합니다.
+        <code>resources</code> 폴더에 설정 파일이 있는지, 그리고 <code>resources</code> 폴더가 제대로 지정되었는지 확인하세요.
+        작동하는 프로젝트를 기반으로 시작하려면 <a href="https://start.ktor.io/">Ktor 프로젝트 생성기</a> 또는
+        <a href="https://plugins.jetbrains.com/plugin/16008-ktor">IntelliJ IDEA Ultimate용 Ktor 플러그인</a>을 사용하여 프로젝트를 구성하는 것이 좋습니다. 자세한 내용은 <Links href="//server-create-a-new-project" summary="Ktor 서버 애플리케이션을 열고, 실행하고, 테스트하는 방법을 알아봅니다.">새 Ktor 프로젝트 생성, 열기 및 실행</Links>을 참조하세요.
+    </p>
+</chapter>
+<chapter title="Android에서 Ktor를 사용할 수 있나요?" id="android-support">
+    <p>
+        네, Ktor 서버와 클라이언트는 적어도 Netty 엔진을 사용하면 Android 5 (API 21) 이상에서 작동하는 것으로 알려져 있습니다.
+    </p>
+</chapter>
+<chapter title="왜 'CURL -I'가 '404 Not Found'를 반환하나요?" id="curl-head-not-found">
+    <p>
+        <code>CURL -I</code>는 <code>HEAD</code> 요청을 수행하는 <code>CURL --head</code>의 별칭입니다.
+        기본적으로 Ktor는 <code>GET</code> 핸들러에 대해 <code>HEAD</code> 요청을 처리하지 않습니다.
+        이 기능을 활성화하려면 <Links href="//server-autoheadresponse" summary="%plugin_name%은 GET이 정의된 모든 라우트에 대해 HEAD 요청에 자동으로 응답하는 기능을 제공합니다.">AutoHeadResponse</Links> 플러그인을 설치하세요.
+    </p>
+</chapter>
+<chapter title="'HttpsRedirect' 플러그인을 사용할 때 발생하는 무한 리다이렉트(infinite redirect) 문제를 어떻게 해결하나요?" id="infinite-redirect">
+    <p>
+        가장 가능성 있는 원인은 백엔드가 리버스 프록시(reverse proxy) 또는 로드 밸런서(load balancer) 뒤에 있고, 이 중개 장치가 백엔드에 일반 HTTP 요청을 보내고 있기 때문입니다. 따라서 Ktor 백엔드 내부의 <code>HttpsRedirect</code> 플러그인은 이를 일반 HTTP 요청으로 간주하고 리다이렉트로 응답하게 됩니다.
+    </p>
+    <p>
+        보통 리버스 프록시는 원래 요청에 대한 정보(예: HTTPS 여부 또는 원래 IP 주소)를 설명하는 헤더를 보내며, <Links href="//server-forward-headers" summary="필요한 의존성: io.ktor:%artifact_name%">ForwardedHeader</Links> 플러그인을 사용하여 해당 헤더를 파싱하면 <Links href="//server-https-redirect" summary="필요한 의존성: io.ktor:%artifact_name%">HttpsRedirect</Links> 플러그인이 원래 요청이 HTTPS였음을 알 수 있습니다.
+    </p>
+</chapter>
+<chapter title="Kotlin/Native에서 해당 엔진을 사용하기 위해 Windows에 'curl'을 설치하는 방법은 무엇인가요?" id="native-curl">
+    <p>
+        <a href="#curl">Curl</a> 클라이언트 엔진은
+        <code>curl</code> 라이브러리 설치가 필요합니다.
+        Windows의 경우 MinGW/MSYS2 <code>curl</code> 바이너리 사용을 고려해 볼 수 있습니다.
+    </p>
+    <procedure>
+        <step>
+            <p>
+                <a href="https://www.msys2.org/">MinGW/MSYS2</a>에 설명된 대로 MinGW/MSYS2를 설치합니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                다음 명령어를 사용하여 <code>libcurl</code>을 설치합니다:
+            </p>
+            <code-block lang="shell" code="                    pacman -S mingw-w64-x86_64-curl"/>
+        </step>
+        <step>
+            <p>
+                MinGW/MSYS2를 기본 위치에 설치했다면, <code>PATH</code> 환경 변수에
+                <Path>C:\\msys64\\mingw64\\bin\\</Path>
+                를 추가하세요.
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="'NoTransformationFoundException'을 어떻게 해결하나요?" id="no-transformation-found-exception">
+    <p>
+        <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.call/-no-transformation-found-exception/index.html">NoTransformationFoundException</a>은
+        *수신된 본문(received body)*에 대해 **결과(resulted)** 타입에서 클라이언트가 **기대하는(expected)** 타입으로의 적절한 변환을 찾을 수 없음을 나타냅니다.
+    </p>
+    <procedure>
+        <step>
+            <p>
+                요청의 <code>Accept</code> 헤더가 원하는 콘텐츠 타입을 지정하고 있는지, 그리고 서버 응답의 <code>Content-Type</code> 헤더가 클라이언트 측에서 기대하는 타입과 일치하는지 확인하세요.
+            </p>
+        </step>
+        <step>
+            <p>
+                작업 중인 특정 콘텐츠 타입에 필요한 콘텐츠 변환을 등록하세요.
+            </p>
+            <p>
+                클라이언트 측에서 <a href="https://ktor.io/docs/serialization-client.html">ContentNegotiation</a>
+                플러그인을 사용할 수 있습니다.
+                이 플러그인을 사용하면 다양한 콘텐츠 타입에 대해 데이터를 직렬화(serialize) 및 역직렬화(deserialize)하는 방법을 지정할 수 있습니다.
+            </p>
+            <code-block lang="kotlin" code="                    val client = HttpClient(CIO) {&#10;                        install(ContentNegotiation) {&#10;                            json() // 예시: JSON 콘텐츠 변환 등록&#10;                            // 필요한 다른 콘텐츠 타입에 대한 변환 추가&#10;                        }&#10;                    }"/>
+        </step>
+        <step>
+            <p>
+                필요한 모든 플러그인을 설치했는지 확인하세요. 누락되었을 수 있는 기능들:
+            </p>
+            <list type="bullet">
+                <li>클라이언트 <a href="https://ktor.io/docs/websocket-client.html">WebSockets</a> 및
+                    서버 <a href="https://ktor.io/docs/websocket.html">WebSockets</a></li>
+                <li>클라이언트 <a href="https://ktor.io/docs/serialization-client.html">ContentNegotiation</a> 및
+                    서버 <a href="https://ktor.io/docs/server-serialization.html">ContentNegotiation</a></li>
+                <li><a href="https://ktor.io/docs/compression.html">Compression</a></li>
+            </list>
+        </step>
+    </procedure>
+</chapter>
+</topic>

--- a/docs/ko/ktor/client-create-new-application.md
+++ b/docs/ko/ktor/client-create-new-application.md
@@ -1,0 +1,308 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="클라이언트 애플리케이션 생성하기"
+       id="client-create-new-application"
+       help-id="getting_started_ktor_client;client-getting-started;client-get-started;client-create-a-new-application">
+    <show-structure for="chapter" depth="2"/>
+    <tldr>
+        <var name="example_name" value="tutorial-client-get-started"/>
+        <p>
+            <b>코드 예제</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+    </tldr>
+    <link-summary>
+        요청을 보내고 응답을 받기 위한 첫 번째 클라이언트 애플리케이션을 생성합니다.
+    </link-summary>
+    <p>
+        Ktor는 멀티플랫폼 비동기 HTTP 클라이언트를 포함하고 있어, <Links href="//client-requests" summary="요청을 보내고 요청 URL, HTTP 메서드, 헤더 및 요청 본문과 같은 다양한 요청 매개변수를 지정하는 방법을 알아봅니다.">요청을 보내고</Links> <Links href="//client-responses" summary="응답을 받고, 응답 본문을 가져오고, 응답 매개변수를 얻는 방법을 알아봅니다.">응답을 처리</Links>할 수 있으며, <Links href="//client-auth" summary="Auth 플러그인은 클라이언트 애플리케이션에서 인증 및 권한 부여를 처리합니다.">인증(authentication)</Links>,
+        <Links href="//client-serialization" summary="ContentNegotiation 플러그인은 클라이언트와 서버 간의 미디어 타입 협상과 요청 전송 및 응답 수신 시 특정 형식으로 콘텐츠를 직렬화/역직렬화하는 두 가지 주요 목적을 수행합니다.">JSON 직렬화(JSON serialization)</Links> 등과 같은 <Links href="//client-plugins" summary="클라이언트 플러그인을 사용하여 로깅, 직렬화, 인증과 같은 일반적인 기능을 추가하는 방법을 알아봅니다.">플러그인</Links>으로 기능을 확장할 수 있습니다.
+    </p>
+    <p>
+        이 튜토리얼에서는 요청을 보내고 응답을 출력하는 첫 번째 Ktor 클라이언트 애플리케이션을 만드는 방법을 보여줍니다.
+    </p>
+    <chapter title="사전 준비 사항" id="prerequisites">
+        <p>
+            이 튜토리얼을 시작하기 전에,
+            <a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA Community 또는
+                Ultimate를 설치</a>하세요.
+        </p>
+    </chapter>
+    <chapter title="새 프로젝트 생성하기" id="new-project">
+        <p>
+            기존 프로젝트에서 Ktor 클라이언트를 수동으로 <Links href="//client-create-and-configure" summary="Ktor 클라이언트를 생성하고 구성하는 방법을 알아봅니다.">생성하고 구성</Links>할 수 있지만, 처음부터 시작하는 편리한 방법은 IntelliJ IDEA에 내장된 Kotlin 플러그인을 사용하여 새 프로젝트를 생성하는 것입니다.
+        </p>
+        <p>
+            새 Kotlin 프로젝트를 생성하려면,
+            <a href="https://www.jetbrains.com/help/idea/run-for-the-first-time.html">IntelliJ IDEA를 열고</a> 다음 단계를 따르세요:
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    시작 화면에서 <control>New Project</control>를 클릭합니다.
+                </p>
+                <p>
+                    또는 메인 메뉴에서 <ui-path>File | New | Project</ui-path>를 선택합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <control>New Project</control>
+                    마법사의 왼쪽 목록에서
+                    <control>Kotlin</control>을 선택합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    오른쪽 창에서 다음 설정을 지정합니다.
+                </p>
+                <img src="client_get_started_new_project.png" alt="IntelliJ IDEA의 새 Kotlin 프로젝트 창"
+                     border-effect="rounded"
+                     width="706"/>
+                <list id="kotlin_app_settings">
+                    <li>
+                        <p>
+                            <control>Name</control>
+                            : 프로젝트 이름을 지정합니다.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Location</control>
+                            : 프로젝트 디렉토리를 지정합니다.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Build system</control>
+                            : <control>Gradle</control>이 선택되었는지 확인합니다.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Gradle DSL</control>
+                            : <control>Kotlin</control>을 선택합니다.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Add sample code</control>
+                            : 생성된 프로젝트에 샘플 코드를 포함하려면 이 옵션을 선택합니다.
+                        </p>
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    <control>Create</control>를 클릭하고 IntelliJ IDEA가 프로젝트를 생성하고 의존성을 설치할 때까지 기다립니다.
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="의존성 추가하기" id="add-dependencies">
+        <p>
+            Ktor 클라이언트에 필요한 의존성을 추가해 보겠습니다.
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    <Path>gradle.properties</Path>
+                    파일을 열고 Ktor 버전을 지정하기 위해 다음 줄을 추가합니다.
+                </p>
+                <code-block lang="kotlin" code="                    ktor_version=%ktor_version%"/>
+                <note id="eap-note">
+                    <p>
+                        Ktor의 EAP 버전을 사용하려면 <a href="#repositories">Space 저장소(Space repository)</a>를 추가해야 합니다.
+                    </p>
+                </note>
+            </step>
+            <step>
+                <p>
+                    <Path>build.gradle.kts</Path>
+                    파일을 열고 dependencies 블록에 다음 아티팩트(artifact)들을 추가합니다.
+                </p>
+                <code-block lang="kotlin" code="val ktor_version: String by project&#10;&#10;dependencies {&#10;    implementation(&quot;io.ktor:ktor-client-core:$ktor_version&quot;)&#10;    implementation(&quot;io.ktor:ktor-client-cio:$ktor_version&quot;)&#10;}"/>
+                <list>
+                    <li><code>ktor-client-core</code>는 핵심 클라이언트 기능을 제공하는 핵심 의존성입니다.
+                    </li>
+                    <li>
+                        <code>ktor-client-cio</code>는 네트워크 요청을 처리하는 <Links href="//client-engines" summary="네트워크 요청을 처리하는 엔진에 대해 알아봅니다.">엔진(engine)</Links>에 대한 의존성입니다.
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    <Path>build.gradle.kts</Path>
+                    파일 오른쪽 상단에 있는
+                    <control>Load Gradle Changes</control>
+                    아이콘을 클릭하여 새로 추가된 의존성을 설치합니다.
+                </p>
+                <img src="client_get_started_load_gradle_changes_name.png" alt="Load Gradle Changes" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="클라이언트 생성하기" id="create-client">
+        <p>
+            클라이언트 구현을 추가하려면
+            <Path>src/main/kotlin</Path>으로 이동하여 다음 단계를 따르세요.
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    <Path>Main.kt</Path>
+                    파일을 열고 기존 코드를 다음 구현으로 교체합니다.
+                </p>
+                <code-block lang="kotlin" code="                    import io.ktor.client.*&#10;                    import io.ktor.client.engine.cio.*&#10;&#10;                    fun main() {&#10;                        val client = HttpClient(CIO)&#10;                    }"/>
+                <p>
+                    Ktor에서 클라이언트는 <a
+                        href="https://api.ktor.io/ktor-client-core/io.ktor.client/-http-client/index.html">HttpClient</a> 클래스로 표현됩니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.request/get.html"><code>HttpClient.get()</code></a> 메서드를 사용하여 <Links href="//client-requests" summary="요청을 보내고 요청 URL, HTTP 메서드, 헤더 및 요청 본문과 같은 다양한 요청 매개변수를 지정하는 방법을 알아봅니다.">GET 요청을 보냅니다</Links>.
+                    <Links href="//client-responses" summary="응답을 받고, 응답 본문을 가져오고, 응답 매개변수를 얻는 방법을 알아봅니다.">응답(response)</Links>은 <code>HttpResponse</code> 클래스 객체로 수신됩니다.
+                </p>
+                <code-block lang="kotlin" code="                    import io.ktor.client.*&#10;                    import io.ktor.client.engine.cio.*&#10;                    import io.ktor.client.request.*&#10;                    import io.ktor.client.statement.*&#10;&#10;                    fun main() {&#10;                        val client = HttpClient(CIO)&#10;                        val response: HttpResponse = client.get(&quot;https://ktor.io/&quot;)&#10;                    }"/>
+                <p>
+                    위의 코드를 추가한 후, IDE는 <code>get()</code> 함수에 대해 다음과 같은 에러를 표시합니다:
+                    <emphasis>Suspend function 'get' should be called only from a coroutine or another suspend
+                        function
+                    </emphasis>
+                    .
+                </p>
+                <img src="client_get_started_suspend_error.png" alt="Suspend 함수 에러" width="706"/>
+                <p>
+                    이를 해결하려면 <code>main()</code> 함수를 중단 함수(suspending function)로 만들어야 합니다.
+                </p>
+                <tip>
+                    <code>suspend</code> 함수 호출에 대해 더 자세히 알아보려면 <a
+                        href="https://kotlinlang.org/docs/coroutines-basics.html">코루틴 기초(Coroutines basics)</a>를 참조하세요.
+                </tip>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA에서 정의 옆의 빨간 전구를 클릭하고
+                    <control>Make main suspend</control>를 선택합니다.
+                </p>
+                <img src="client_get_started_suspend_error_fix.png" alt="Make main suspend" width="706"/>
+            </step>
+            <step>
+                <p>
+                    <code>println()</code> 함수를 사용하여 서버에서 반환한 <a href="#status">상태 코드(status code)</a>를 출력하고, <code>close()</code> 함수를 사용하여 스트림을 닫고 이와 관련된 모든 리소스를 해제합니다.
+                    <Path>Main.kt</Path>
+                    파일은 다음과 같아야 합니다:
+                </p>
+                <code-block lang="kotlin" code="import io.ktor.client.*&#10;import io.ktor.client.engine.cio.*&#10;import io.ktor.client.request.*&#10;import io.ktor.client.statement.*&#10;&#10;suspend fun main() {&#10;    val client = HttpClient(CIO)&#10;    val response: HttpResponse = client.get(&quot;https://ktor.io/&quot;)&#10;    println(response.status)&#10;    client.close()&#10;}"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="애플리케이션 실행하기" id="make-request">
+        <p>
+            애플리케이션을 실행하려면
+            <Path>Main.kt</Path>
+            파일로 이동하여 다음 단계를 따르세요.
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    IntelliJ IDEA에서 <code>main()</code> 함수 옆의 거터(gutter) 아이콘을 클릭하고
+                    <control>Run 'MainKt'</control>를 선택합니다.
+                </p>
+                <img src="client_get_started_run_main.png" alt="앱 실행" width="706"/>
+            </step>
+            <step>
+                IntelliJ IDEA가 애플리케이션을 실행할 때까지 기다립니다.
+            </step>
+            <step>
+                <p>
+                    IDE 하단의
+                    <control>Run</control>
+                    창에 출력이 표시되는 것을 볼 수 있습니다.
+                </p>
+                <img src="client_get_started_run_output_with_warning.png" alt="서버 응답" width="706"/>
+                <p>
+                    서버가 <code>200 OK</code> 메시지로 응답하지만, SLF4J가 <code>StaticLoggerBinder</code> 클래스를 찾는 데 실패하여 기본적으로 NOP(no-operation) 로거 구현을 사용한다는 에러 메시지도 표시될 것입니다. 이는 사실상 로깅이 비활성화되었음을 의미합니다.
+                </p>
+                <p>
+                    이제 작동하는 클라이언트 애플리케이션이 생성되었습니다. 하지만 이 경고를 해결하고 로깅을 통해 HTTP 호출을 디버깅하려면 <a href="#enable-logging">추가 단계</a>가 필요합니다.
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="로깅 활성화하기" id="enable-logging">
+        <p>
+            Ktor는 JVM에서 로깅을 위해 SLF4J 추상화 레이어를 사용하므로, 로깅을 활성화하려면 <a href="https://logback.qos.ch/">Logback</a>과 같은
+            <a href="#jvm">로깅 프레임워크를 제공</a>해야 합니다.
+        </p>
+        <procedure id="enable-logging-procedure">
+            <step>
+                <p>
+                    <Path>gradle.properties</Path>
+                    파일에 로깅 프레임워크의 버전을 지정합니다.
+                </p>
+                <code-block lang="kotlin" code="                    logback_version=%logback_version%"/>
+            </step>
+            <step>
+                <p>
+                    <Path>build.gradle.kts</Path>
+                    파일을 열고 dependencies 블록에 다음 아티팩트를 추가합니다.
+                </p>
+                <code-block lang="kotlin" code="                    //...&#10;                    val logback_version: String by project&#10;&#10;                    dependencies {&#10;                        //...&#10;                        implementation(&quot;ch.qos.logback:logback-classic:$logback_version&quot;)&#10;                    }"/>
+            </step>
+            <step>
+                <control>Load Gradle Changes</control>
+                아이콘을 클릭하여 새로 추가된 의존성을 설치합니다.
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA에서 다시 실행 버튼(<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="intelliJ IDEA rerun icon"/>)을 클릭하여 애플리케이션을 다시 시작합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    더 이상 에러가 표시되지 않아야 하며, IDE 하단의
+                    <control>Run</control>
+                    창에 동일한 <code>200 OK</code> 메시지가 표시될 것입니다.
+                </p>
+                <img src="client_get_started_run_output.png" alt="서버 응답" width="706"/>
+                <p>
+                    이제 로깅이 활성화되었습니다. 로그를 확인하려면 로깅 구성을 추가해야 합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>src/main/resources</Path>로 이동하여 다음 구현이 포함된 새로운
+                    <Path>logback.xml</Path>
+                    파일을 생성합니다.
+                </p>
+                <code-block lang="xml" ignore-vars="true" code="                    &lt;configuration&gt;&#10;                        &lt;appender name=&quot;APPENDER&quot; class=&quot;ch.qos.logback.core.ConsoleAppender&quot;&gt;&#10;                            &lt;encoder&gt;&#10;                                &lt;pattern&gt;%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n&lt;/pattern&gt;&#10;                            &lt;/encoder&gt;&#10;                        &lt;/appender&gt;&#10;                        &lt;root level=&quot;trace&quot;&gt;&#10;                            undefined&#10;                        &lt;/root&gt;&#10;                    &lt;/configuration&gt;"/>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA에서 다시 실행 버튼(<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="intelliJ IDEA rerun icon"/>)을 클릭하여 애플리케이션을 다시 시작합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    이제 <control>Run</control> 창의 출력된 응답 위에 트레이스(trace) 로그가 표시되는 것을 볼 수 있습니다.
+                </p>
+                <img src="client_get_started_run_output_with_logs.png" alt="서버 응답" width="706"/>
+            </step>
+        </procedure>
+        <tip>
+            Ktor는 <Links href="//client-logging" summary="필요한 의존성: io.ktor:ktor-client-logging">Logging</Links> 플러그인을 통해 HTTP 호출에 대한 로그를 추가하는 간단하고 명확한 방법을 제공하며, 구성 파일을 추가하면 복잡한 애플리케이션에서 로깅 동작을 세밀하게 조정할 수 있습니다.
+        </tip>
+    </chapter>
+    <chapter title="다음 단계" id="next-steps">
+        <p>
+            이 구성을 더 잘 이해하고 확장하려면, <Links href="//client-create-and-configure" summary="Ktor 클라이언트를 생성하고 구성하는 방법을 알아봅니다.">Ktor 클라이언트를 생성하고 구성하는 방법</Links>을 살펴보세요.
+        </p>
+    </chapter>
+</topic>

--- a/docs/ko/ktor/client-server-sent-events.md
+++ b/docs/ko/ktor/client-server-sent-events.md
@@ -1,0 +1,202 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="client-server-sent-events" title="Ktor 클라이언트의 Server-Sent Events (SSE)" help-id="sse_client">
+<show-structure for="chapter" depth="2"/>
+<primary-label ref="client-plugin"/>
+<tldr>
+    <var name="example_name" value="client-sse"/>
+    <p>
+        <b>코드 예제</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+</tldr>
+<link-summary>
+    SSE 플러그인을 사용하면 클라이언트가 HTTP 연결을 통해 서버로부터 이벤트 기반 업데이트를 받을 수 있습니다.
+</link-summary>
+<p>
+    Server-Sent Events (SSE)는 서버가 HTTP 연결을 통해 클라이언트에 지속적으로 이벤트를 푸시할 수 있도록 하는 기술입니다. 이는 클라이언트가 서버를 반복적으로 폴링(polling)할 필요 없이 서버가 이벤트 기반 업데이트를 보내야 하는 경우에 특히 유용합니다.
+</p>
+<p>
+    Ktor에서 지원하는 SSE 플러그인은 서버와 클라이언트 간의 단방향 연결을 생성하는 간단한 방법을 제공합니다.
+</p>
+<tip>
+    <p>서버 측 지원을 위한 SSE 플러그인에 대해 자세히 알아보려면
+        <Links href="//server-server-sent-events" summary="SSE 플러그인을 사용하면 서버가 HTTP 연결을 통해 클라이언트에 이벤트 기반 업데이트를 보낼 수 있습니다.">SSE 서버 플러그인</Links>
+        을 참조하세요.
+    </p>
+</tip>
+<chapter title="의존성 추가" id="add_dependencies">
+    <p>
+        <code>SSE</code>는 <Links href="//client-dependencies" summary="기존 프로젝트에 클라이언트 의존성을 추가하는 방법을 알아보세요.">ktor-client-core</Links> 아티팩트만 필요하며 별도의 특정 의존성은 필요하지 않습니다.
+    </p>
+</chapter>
+<chapter title="SSE 설치" id="install_plugin">
+    <p>
+        <code>SSE</code> 플러그인을 설치하려면, <a href="#configure-client">클라이언트 구성 블록</a> 내부의 <code>install</code> 함수에 전달하세요:
+    </p>
+    <code-block lang="kotlin" code="            import io.ktor.client.*&#10;            import io.ktor.client.engine.cio.*&#10;            import io.ktor.client.plugins.sse.*&#10;&#10;            //...&#10;            val client = HttpClient(CIO) {&#10;                install(SSE)&#10;            }"/>
+</chapter>
+<chapter title="SSE 플러그인 구성" id="configure">
+    <p>
+        선택적으로 <code>install</code> 블록 내에서
+        <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-s-s-e-config/index.html">SSEConfig</a>
+        클래스의 지원되는 속성을 설정하여 SSE 플러그인을 구성할 수 있습니다.
+    </p>
+    <chapter title="SSE 재연결" id="sse-reconnect">
+        <p>
+            자동 재연결을 활성화하려면 <code>maxReconnectionAttempts</code>를 <code>0</code>보다 큰 값으로 설정하세요. <code>reconnectionTime</code>을 사용하여 시도 간의 지연 시간을 구성할 수도 있습니다:
+        </p>
+        <code-block lang="kotlin" code="                install(SSE) {&#10;                    maxReconnectionAttempts = 4&#10;                    reconnectionTime = 2.seconds&#10;                }"/>
+        <p>
+            서버와의 연결이 끊어지면 클라이언트는 재연결을 시도하기 전에 지정된 <code>reconnectionTime</code> 동안 기다립니다. 연결을 재설정하기 위해 지정된 <code>maxReconnectionAttempts</code> 횟수까지 시도합니다.
+        </p>
+    </chapter>
+    <chapter title="이벤트 필터링" id="filter-events">
+        <p>
+            다음 예제에서는 SSE 플러그인을 HTTP 클라이언트에 설치하고, 수신 플로우(flow)에 주석만 포함된 이벤트와 <code>retry</code> 필드만 포함된 이벤트를 포함하도록 구성합니다:
+        </p>
+        <code-block lang="kotlin" code="        install(SSE) {&#10;            showCommentEvents()&#10;            showRetryEvents()&#10;        }"/>
+    </chapter>
+    <chapter title="응답 버퍼링" id="response-buffering">
+        <p>
+            SSE 응답은 본질적으로 스트리밍 방식이므로 전체 본문을 캡처하는 것이 현실적이지 않습니다. SSE 스트림이 실패할 때 응답 본문을 안전하게 검색하기 위해 진단 버퍼를 활성화할 수 있습니다. 버퍼에는 이미 처리된 데이터만 포함되며(네트워크에서 다시 읽지 않음), 실패 시 로깅 및 오류 분석을 위한 용도입니다.
+        </p>
+        <code-block lang="kotlin" code="                install(SSE) {&#10;                    bufferPolicy = SSEBufferPolicy.LastEvents(10)&#10;                }"/>
+        <p>
+            호출별로 버퍼를 구성할 수도 있습니다:
+        </p>
+        <code-block lang="kotlin" code="                client.sse(url, {&#10;                    bufferPolicy(SSEBufferPolicy.All)&#10;                }) {&#10;                    // ...&#10;                }"/>
+        <chapter title="버퍼 정책" id="buffer-policies">
+            <p>
+                <code>SSEBufferPolicy</code> 타입은 처리된 SSE 데이터를 저장하기 위한 여러 전략을 제공합니다. 이 정책들은 메모리에 유지되는 스트림의 양과 오류 발생 시 사용 가능한 양을 제어합니다.
+            </p>
+            <deflist>
+                <def id="buffer-off">
+                    <title><code>Off</code> (기본값)</title>
+                    버퍼링 없음.
+                </def>
+                <def id="buffer-lastlines">
+                    <title><code>LastLines(n)</code></title>
+                    마지막 n개 라인을 유지함.
+                </def>
+                <def id="buffer-lastevent">
+                    <title><code>LastEvent</code></title>
+                    마지막으로 완료된 SSE 이벤트를 유지함.
+                </def>
+                <def id="buffer-lastevents">
+                    <title><code>LastEvents(n)</code></title>
+                    마지막 n개의 완료된 SSE 이벤트를 유지함.
+                </def>
+                <def id="buffer-all">
+                    <title><code>All</code></title>
+                    지금까지 처리된 모든 이벤트를 유지함.
+                    <note>수명이 긴 스트림의 경우 주의해서 사용하세요.</note>
+                </def>
+            </deflist>
+            <p>
+                실패 시 네트워크에서 다시 읽지 않고 <code>response?.bodyAsText()</code>를 사용하여 버퍼에 접근할 수 있습니다.
+            </p>
+        </chapter>
+    </chapter>
+</chapter>
+<chapter title="SSE 세션 처리" id="handle-sse-sessions">
+    <p>
+        클라이언트의 SSE 세션은
+        <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session/index.html">
+            <code>ClientSSESession</code>
+        </a>
+        인터페이스로 표현됩니다. 이 인터페이스는 서버로부터 서버 전송 이벤트를 받을 수 있는 API를 노출합니다.
+    </p>
+    <chapter title="SSE 세션 접근" id="access-sse-session">
+        <p><code>HttpClient</code>를 사용하면 다음 방법 중 하나로 SSE 세션에 접근할 수 있습니다:</p>
+        <list>
+            <li>
+                <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/sse.html">
+                    <code>sse()</code>
+                </a>
+                함수는 SSE 세션을 생성하고 해당 세션에서 동작할 수 있게 합니다.
+            </li>
+            <li>
+                <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/sse-session.html">
+                    <code>sseSession()</code>
+                </a>
+                함수는 SSE 세션을 열 수 있게 합니다.
+            </li>
+        </list>
+        <p>URL 엔드포인트를 지정하기 위해 다음 두 가지 옵션 중 선택할 수 있습니다:</p>
+        <list>
+            <li><code>urlString</code> 파라미터를 사용하여 전체 URL을 문자열로 지정합니다.</li>
+            <li><code>schema</code>, <code>host</code>, <code>port</code>, <code>path</code> 파라미터를 사용하여 각각 프로토콜 스킴, 도메인 이름, 포트 번호, 경로 이름을 지정합니다.</li>
+        </list>
+        <code-block lang="kotlin" code="                runBlocking {&#10;                    client.sse(host = &amp;quot;127.0.0.1&amp;quot;, port = 8080, path = &amp;quot;/events&amp;quot;) {&#10;                        // this: ClientSSESession&#10;                    }&#10;                }"/>
+        <note>
+            <code>ClientSSESession</code> 및 <code>ClientSSESessionWithDeserialization</code> 인스턴스는 세션이 유지되는 동안에만 유효합니다. <code>serverSentEvents { ... }</code> 블록이 완료되거나 연결이 닫히면 해당 스코프는 자동으로 취소됩니다.
+        </note>
+        <p>선택적으로 연결을 구성하기 위해 다음 파라미터들을 사용할 수 있습니다:</p>
+        <deflist>
+            <def id="reconnectionTime-param">
+                <title><code>reconnectionTime</code></title>
+                재연결 지연 시간을 설정합니다.
+            </def>
+            <def id="showCommentEvents-param">
+                <title><code>showCommentEvents</code></title>
+                수신 플로우에 주석만 포함된 이벤트를 표시할지 여부를 지정합니다.
+            </def>
+            <def id="showRetryEvents-param">
+                <title><code>showRetryEvents</code></title>
+                수신 플로우에 <code>retry</code> 필드만 포함된 이벤트를 표시할지 여부를 지정합니다.
+            </def>
+            <def id="deserialize-param">
+                <title><code>deserialize</code></title>
+                <code>TypedServerSentEvent</code>의 <code>data</code> 필드를 객체로 변환하는 역직렬화 함수입니다. 자세한 내용은 <a href="#deserialization">역직렬화(Deserialization)</a>를 참조하세요.
+            </def>
+        </deflist>
+    </chapter>
+    <chapter title="SSE 세션 블록" id="sse-session-block">
+        <p>
+            람다 인자 내에서는
+            <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session/index.html"><code>ClientSSESession</code></a>
+            컨텍스트에 접근할 수 있습니다. 블록 내에서 다음 속성을 사용할 수 있습니다:
+        </p>
+        <deflist>
+            <def id="call">
+                <title><code>call</code></title>
+                세션을 시작한 관련 <code>HttpClientCall</code>입니다.
+            </def>
+            <def id="incoming">
+                <title><code>incoming</code></title>
+                수신되는 서버 전송 이벤트 플로우입니다.
+            </def>
+        </deflist>
+        <p>
+            아래 예제는 <code>events</code> 엔드포인트로 새로운 SSE 세션을 생성하고, <code>incoming</code> 속성을 통해 이벤트를 읽고 수신된 
+            <a href="https://api.ktor.io/ktor-sse/io.ktor.sse/-server-sent-event/index.html"><code>ServerSentEvent</code></a>를 출력합니다.
+        </p>
+        <code-block lang="kotlin" code="fun main() {&#10;    val client = HttpClient {&#10;        install(SSE) {&#10;            showCommentEvents()&#10;            showRetryEvents()&#10;        }&#10;    }&#10;    runBlocking {&#10;        client.sse(host = &quot;0.0.0.0&quot;, port = 8080, path = &quot;/events&quot;) {&#10;            while (true) {&#10;                incoming.collect { event -&gt;&#10;                    println(&quot;Event from server:&quot;)&#10;                    println(event)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+        <p>전체 예제는 
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-sse">client-sse</a>를 참조하세요.
+        </p>
+    </chapter>
+    <chapter title="역직렬화(Deserialization)" id="deserialization">
+        <p>
+            SSE 플러그인은 서버 전송 이벤트를 타입 안정성이 보장된 Kotlin 객체로 역직렬화하는 기능을 지원합니다. 이 기능은 서버의 구조화된 데이터로 작업할 때 특히 유용합니다.
+        </p>
+        <p>
+            역직렬화를 활성화하려면 SSE 접근 함수에서 <code>deserialize</code> 파라미터를 사용하여 커스텀 역직렬화 함수를 제공하고, 
+            <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session-with-deserialization/index.html">
+                <code>ClientSSESessionWithDeserialization</code>
+            </a>
+            클래스를 사용하여 역직렬화된 이벤트를 처리하세요.
+        </p>
+        <p>
+            다음은 <code>kotlinx.serialization</code>을 사용하여 JSON 데이터를 역직렬화하는 예제입니다:
+        </p>
+        <code-block lang="Kotlin" code="        client.sse({&#10;            url(&quot;http://localhost:8080/serverSentEvents&quot;)&#10;        }, deserialize = {&#10;                typeInfo, jsonString -&gt;&#10;            val serializer = Json.serializersModule.serializer(typeInfo.kotlinType!!)&#10;            Json.decodeFromString(serializer, jsonString)!!&#10;        }) { // `this` is `ClientSSESessionWithDeserialization`&#10;            incoming.collect { event: TypedServerSentEvent&lt;String&gt; -&gt;&#10;                when (event.event) {&#10;                    &quot;customer&quot; -&gt; {&#10;                        val customer: Customer? = deserialize&lt;Customer&gt;(event.data)&#10;                    }&#10;                    &quot;product&quot; -&gt; {&#10;                        val product: Product? = deserialize&lt;Product&gt;(event.data)&#10;                    }&#10;                }&#10;            }&#10;        }"/>
+        <p>전체 예제는 
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-sse">client-sse</a>를 참조하세요.
+        </p>
+    </chapter>
+</chapter>
+</topic>

--- a/docs/ko/ktor/client-websockets.md
+++ b/docs/ko/ktor/client-websockets.md
@@ -1,0 +1,148 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="client-websockets" title="Ktor 클라이언트의 WebSockets">
+    <show-structure for="chapter" depth="3"/>
+    <primary-label ref="client-plugin"/>
+    <var name="example_name" value="client-websockets"/>
+    <var name="artifact_name" value="ktor-client-websockets"/>
+    <tldr>
+        <p>
+            <b>필수 의존성</b>: <code>io.ktor:ktor-client-websockets</code>
+        </p>
+        <p>
+            <b>코드 예제</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+    </tldr>
+    <link-summary>
+        Websockets 플러그인을 사용하면 서버와 클라이언트 간에 다중 통신 세션을 생성할 수 있습니다.
+    </link-summary>
+    WebSocket은 단일 TCP 연결을 통해 사용자의 브라우저와 서버 간에 전이중(full-duplex) 통신 세션을 제공하는 프로토콜입니다. 이는 서버와 실시간으로 데이터를 주고받아야 하는 애플리케이션을 제작할 때 특히 유용합니다.
+    Ktor는 서버 측과 클라이언트 측 모두에서 WebSocket 프로토콜을 지원합니다.
+    <p>클라이언트용 Websockets 플러그인을 사용하면 서버와 메시지를 교환하기 위한 WebSocket 세션을 처리할 수 있습니다.</p>
+    <note>
+        <p>모든 엔진이 WebSocket을 지원하는 것은 아닙니다. 지원되는 엔진에 대한 개요는 <a href="client-engines.md#limitations">제한 사항(Limitations)</a>을 참조하세요.</p>
+    </note>
+    <tip>
+        <p>서버 측의 WebSocket 지원에 대해 알아보려면 <Links href="//server-websockets" summary="Websockets 플러그인을 사용하면 서버와 클라이언트 간에 다중 통신 세션을 생성할 수 있습니다.">Ktor 서버의 WebSockets</Links>를 참조하세요.</p>
+    </tip>
+    <chapter title="의존성 추가" id="add_dependencies">
+        <p><code>WebSockets</code>를 사용하려면 빌드 스크립트에 <code>%artifact_name%</code> 아티팩트를 포함해야 합니다:</p>
+        <Tabs group="languages">
+            <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                <code-block lang="Kotlin" code="                    implementation(&quot;io.ktor:%artifact_name%:$ktor_version&quot;)"/>
+            </TabItem>
+            <TabItem title="Gradle (Groovy)" group-key="groovy">
+                <code-block lang="Groovy" code="                    implementation &quot;io.ktor:%artifact_name%:$ktor_version&quot;"/>
+            </TabItem>
+            <TabItem title="Maven" group-key="maven">
+                <code-block lang="XML" code="                    &lt;dependency&gt;&#10;                        &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                        &lt;artifactId&gt;%artifact_name%-jvm&lt;/artifactId&gt;&#10;                        &lt;version&gt;${ktor_version}&lt;/version&gt;&#10;                    &lt;/dependency&gt;"/>
+            </TabItem>
+        </Tabs>
+        <tip>
+            Ktor 클라이언트에 필요한 아티팩트에 대해 자세히 알아보려면 <Links href="//client-dependencies" summary="기존 프로젝트에 클라이언트 의존성을 추가하는 방법을 알아봅니다.">클라이언트 의존성 추가하기</Links>를 참조하세요.
+        </tip>
+    </chapter>
+    <chapter title="WebSockets 설치" id="install_plugin">
+        <p><code>WebSockets</code> 플러그인을 설치하려면, <a href="#configure-client">클라이언트 설정 블록</a> 내의 <code>install</code> 함수에 전달하세요:</p>
+        <code-block lang="kotlin" code="            import io.ktor.client.*&#10;            import io.ktor.client.engine.cio.*&#10;            import io.ktor.client.plugins.websocket.*&#10;&#10;            //...&#10;            val client = HttpClient(CIO) {&#10;                install(WebSockets)&#10;            }"/>
+    </chapter>
+    <chapter title="설정" id="configure_plugin">
+        <p>선택 사항으로, <code>install</code> 블록 내에서 <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/-web-sockets/-config/index.html">WebSockets.Config</a>의 지원되는 속성들을 전달하여 플러그인을 설정할 수 있습니다.
+        </p>
+        <deflist>
+            <def id="maxFrameSize">
+                <title><code>maxFrameSize</code></title>
+                수신 또는 전송할 수 있는 최대 <code>Frame</code> 크기를 설정합니다.
+            </def>
+            <def id="contentConverter">
+                <title><code>contentConverter</code></title>
+                직렬화/역직렬화를 위한 컨버터를 설정합니다.
+            </def>
+            <def id="pingIntervalMillis">
+                <title><code>pingIntervalMillis</code></title>
+                <code>Long</code> 형식으로 핑(ping) 사이의 간격을 지정합니다.
+            </def>
+            <def id="pingInterval">
+                <title><code>pingInterval</code></title>
+                <code>Duration</code> 형식으로 핑 사이의 간격을 지정합니다.
+            </def>
+        </deflist>
+        <warning>
+            <p><code>pingInterval</code> 및 <code>pingIntervalMillis</code> 속성은 OkHttp 엔진에는 적용되지 않습니다. OkHttp의 핑 간격을 설정하려면 <a href="#okhttp">엔진 설정</a>을 사용할 수 있습니다:
+            </p>
+            <code-block lang="kotlin" code="                import io.ktor.client.engine.okhttp.OkHttp&#10;&#10;                val client = HttpClient(OkHttp) {&#10;                    engine {&#10;                        preconfigured = OkHttpClient.Builder()&#10;                            .pingInterval(20, TimeUnit.SECONDS)&#10;                            .build()&#10;                    }&#10;                }"/>
+        </warning>
+        <p>
+            다음 예제에서는 핑 프레임을 자동으로 전송하고 WebSocket 연결을 유지하기 위해 WebSockets 플러그인을 20초(<code>20_000</code> 밀리초)의 핑 간격으로 설정합니다:
+        </p>
+        <code-block lang="kotlin" code="    val client = HttpClient(CIO) {&#10;        install(WebSockets) {&#10;            pingIntervalMillis = 20_000&#10;        }&#10;    }"/>
+    </chapter>
+    <chapter title="WebSocket 세션 작업" id="working-wtih-session">
+        <p>클라이언트의 WebSocket 세션은 <a href="https://api.ktor.io/ktor-websockets/io.ktor.websocket/-default-web-socket-session/index.html">DefaultClientWebSocketSession</a> 인터페이스로 표현됩니다. 이 인터페이스는 WebSocket 프레임을 주고받고 세션을 닫을 수 있는 API를 제공합니다.
+        </p>
+        <chapter title="WebSocket 세션 액세스" id="access-session">
+            <p>
+                <code>HttpClient</code>는 WebSocket 세션에 액세스하는 두 가지 주요 방법을 제공합니다:
+            </p>
+            <list>
+                <li>
+                    <p><a
+                            href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/web-socket.html">webSocket()</a>
+                        함수는 <code>DefaultClientWebSocketSession</code>을 블록 인자로 받습니다.</p>
+                    <code-block lang="kotlin" code="                        runBlocking {&#10;                            client.webSocket(&#10;                                method = HttpMethod.Get,&#10;                                host = &quot;127.0.0.1&quot;,&#10;                                port = 8080,&#10;                                path = &quot;/echo&quot;&#10;                            ) {&#10;                                // this: DefaultClientWebSocketSession&#10;                            }&#10;                        }"/>
+                </li>
+                <li>
+                    <a
+                        href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/web-socket-session.html">webSocketSession()</a>
+                    함수는 <code>DefaultClientWebSocketSession</code> 인스턴스를 반환하며, <code>runBlocking</code> 또는 <code>launch</code> 스코프 외부에서 세션에 액세스할 수 있게 해줍니다.
+                </li>
+            </list>
+        </chapter>
+        <chapter title="WebSocket 세션 처리" id="handle-session">
+            <p>함수 블록 내에서 지정된 경로에 대한 핸들러를 정의합니다. 블록 내에서는 다음과 같은 함수와 속성을 사용할 수 있습니다:</p>
+            <deflist>
+                <def id="send">
+                    <title><code>send()</code></title>
+                    <code>send()</code> 함수를 사용하여 서버에 텍스트 콘텐츠를 보냅니다.
+                </def>
+                <def id="outgoing">
+                    <title><code>outgoing</code></title>
+                    <code>outgoing</code> 속성을 사용하여 WebSocket 프레임을 보내기 위한 채널에 액세스합니다. 프레임은 <code>Frame</code> 클래스로 표현됩니다.
+                </def>
+                <def id="incoming">
+                    <title><code>incoming</code></title>
+                    <code>incoming</code> 속성을 사용하여 WebSocket 프레임을 받기 위한 채널에 액세스합니다. 프레임은 <code>Frame</code> 클래스로 표현됩니다.
+                </def>
+                <def id="close">
+                    <title><code>close()</code></title>
+                    <code>close()</code> 함수를 사용하여 지정된 사유와 함께 종료(close) 프레임을 보냅니다.
+                </def>
+            </deflist>
+        </chapter>
+        <chapter title="프레임 유형" id="frame-types">
+            <p>
+                WebSocket 프레임의 유형을 검사하고 그에 따라 처리할 수 있습니다. 주요 프레임 유형은 다음과 같습니다:
+            </p>
+            <list>
+                <li><code>Frame.Text</code>는 텍스트 프레임을 나타냅니다. 콘텐츠를 읽으려면
+                    <code>Frame.Text.readText()</code>를 사용하세요.
+                </li>
+                <li><code>Frame.Binary</code>는 바이너리 프레임을 나타냅니다. 콘텐츠를 읽으려면 <code>Frame.Binary.readBytes()</code>를 사용하세요.
+                </li>
+                <li><code>Frame.Close</code>는 종료 프레임을 나타냅니다. 세션 종료 사유를 가져오려면 <code>Frame.Close.readReason()</code>을 사용하세요.
+                </li>
+            </list>
+        </chapter>
+        <chapter title="예제" id="example">
+            <p>아래 예제는 <code>echo</code> WebSocket 엔드포인트를 생성하고 서버와 메시지를 주고받는 방법을 보여줍니다.</p>
+            <code-block lang="kotlin"
+                        include-symbol="main" code="package com.example&#10;&#10;import io.ktor.client.*&#10;import io.ktor.client.engine.cio.*&#10;import io.ktor.client.plugins.websocket.*&#10;import io.ktor.http.*&#10;import io.ktor.websocket.*&#10;import kotlinx.coroutines.*&#10;import java.util.*&#10;&#10;fun main() {&#10;    val client = HttpClient(CIO) {&#10;        install(WebSockets) {&#10;            pingIntervalMillis = 20_000&#10;        }&#10;    }&#10;    runBlocking {&#10;        client.webSocket(method = HttpMethod.Get, host = &quot;127.0.0.1&quot;, port = 8080, path = &quot;/echo&quot;) {&#10;            while(true) {&#10;                val othersMessage = incoming.receive() as? Frame.Text&#10;                println(othersMessage?.readText())&#10;                val myMessage = Scanner(System.`in`).next()&#10;                if(myMessage != null) {&#10;                    send(myMessage)&#10;                }&#10;            }&#10;        }&#10;    }&#10;    client.close()&#10;}"/>
+            <p>전체 예제는
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-websockets">client-websockets</a>를 참조하세요.
+            </p>
+        </chapter>
+    </chapter>
+</topic>

--- a/docs/ko/ktor/docker-compose.md
+++ b/docs/ko/ktor/docker-compose.md
@@ -1,0 +1,123 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="docker-compose" title="Docker Compose">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <p>
+        <control>시작 프로젝트</control>
+        : <a
+            href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-db-integration">tutorial-server-db-integration</a>
+    </p>
+    <p>
+        <control>완료 프로젝트</control>
+        : <a
+            href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-docker-compose">tutorial-server-docker-compose</a>
+    </p>
+</tldr>
+<p>이 주제에서는 <a href="https://docs.docker.com/compose/">Docker Compose</a> 환경에서 Ktor 서버 애플리케이션을 실행하는 방법을 살펴봅니다. 여기서는 <Links href="//server-integrate-database" summary="Learn the process of connecting Ktor services to database repositories with the Exposed SQL Library.">데이터베이스 통합</Links> 튜토리얼에서 생성한 프로젝트를 사용합니다. 이 프로젝트는 <a href="https://github.com/JetBrains/Exposed">Exposed</a>를 사용하여 데이터베이스와 웹 애플리케이션이 별도로 실행되는 <a href="https://www.postgresql.org/docs/">PostgreSQL</a> 데이터베이스에 연결합니다.</p>
+<chapter title="애플리케이션 준비하기" id="prepare-app">
+    <chapter title="데이터베이스 설정 추출" id="extract-db-settings">
+        <p>
+            <a href="server-integrate-database.topic#config-db-connection">데이터베이스 연결 구성</a> 튜토리얼에서 생성된 프로젝트는 데이터베이스 연결을 설정하기 위해 하드코딩된 속성을 사용합니다.</p>
+        <p>
+            PostgreSQL 데이터베이스의 연결 설정을 <Links href="//server-configuration-file" summary="Learn how to configure various server parameters in a configuration file.">사용자 정의 설정 그룹</Links>으로 추출해 보겠습니다.
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    <Path>src/main/resources</Path>에 있는 <Path>application.yaml</Path> 파일을 열고, 다음과 같이 <code>ktor</code> 그룹 외부에 <code>storage</code> 그룹을 추가합니다:
+                </p>
+                <code-block lang="yaml" code="ktor:&#10;  application:&#10;    modules:&#10;      - com.example.ApplicationKt.module&#10;  deployment:&#10;    port: 8080&#10;storage:&#10;  driverClassName: &quot;org.postgresql.Driver&quot;&#10;  jdbcURL: &quot;jdbc:postgresql://localhost:5432/ktor_tutorial_db&quot;&#10;  user: &quot;postgres&quot;&#10;  password: &quot;password&quot;"/>
+                <p>이 설정들은 나중에 <a href="#configure-docker">
+                    <Path>compose.yml</Path>
+                </a> 파일에서 구성됩니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>src/main/kotlin/com/example/plugins/</Path>에 있는 <Path>Databases.kt</Path> 파일을 열고, 설정 파일에서 저장소 설정을 로드하도록 <code>configureDatabases()</code> 함수를 업데이트합니다:
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureDatabases(config: ApplicationConfig) {&#10;    val url = config.property(&quot;storage.jdbcURL&quot;).getString()&#10;    val user = config.property(&quot;storage.user&quot;).getString()&#10;    val password = config.property(&quot;storage.password&quot;).getString()&#10;&#10;    Database.connect(&#10;        url,&#10;        user = user,&#10;        password = password&#10;    )&#10;}"/>
+                <p>
+                    이제 <code>configureDatabases()</code> 함수는 <code>ApplicationConfig</code>를 매개변수로 받아 <code>config.property</code>를 사용해 사용자 정의 설정을 로드합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>src/main/kotlin/com/example/</Path>에 있는 <Path>Application.kt</Path> 파일을 열고, 애플리케이션 시작 시 연결 설정을 로드할 수 있도록 <code>configureDatabases()</code>에 <code>environment.config</code>를 전달합니다:
+                </p>
+                <code-block lang="kotlin" code="fun Application.module() {&#10;    val repository = PostgresTaskRepository()&#10;&#10;    configureSerialization(repository)&#10;    configureDatabases(environment.config)&#10;    configureRouting()&#10;}"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="Ktor 플러그인 구성" id="configure-ktor-plugin">
+        <p>Docker에서 실행하려면 애플리케이션의 모든 필수 파일이 컨테이너에 배포되어야 합니다. 사용하는 빌드 시스템에 따라 이를 수행하는 다양한 플러그인이 있습니다:</p>
+        <list>
+            <li><Links href="//server-fatjar" summary="Learn how to create and run an executable fat JAR using the Ktor Gradle plugin.">Ktor Gradle 플러그인을 사용하여 fat JAR 생성하기</Links></li>
+            <li><Links href="//maven-assembly-plugin" summary="Sample project: tutorial-server-get-started-maven">Maven Assembly 플러그인을 사용하여 fat JAR 생성하기</Links></li>
+        </list>
+        <p>이 예제에서는 <Path>build.gradle.kts</Path> 파일에 Ktor 플러그인이 이미 적용되어 있습니다.
+        </p>
+        <code-block lang="kotlin" code="plugins {&#10;    application&#10;    kotlin(&quot;jvm&quot;)&#10;    id(&quot;io.ktor.plugin&quot;) version &quot;3.5.1&quot;&#10;    id(&quot;org.jetbrains.kotlin.plugin.serialization&quot;) version &quot;2.2.20&quot;&#10;}"/>
+    </chapter>
+</chapter>
+<chapter title="Docker 구성" id="configure-docker">
+    <chapter title="Docker 이미지 준비" id="prepare-docker-image">
+        <p>
+            애플리케이션을 도커화(Dockerize)하려면, 프로젝트의 루트 디렉터리에 새 <Path>Dockerfile</Path>을 생성하고 다음 내용을 입력합니다:
+        </p>
+        <code-block lang="Docker" code="# Stage 1: Cache Gradle dependencies&#10;FROM gradle:latest AS cache&#10;RUN mkdir -p /home/gradle/cache_home&#10;ENV GRADLE_USER_HOME=/home/gradle/cache_home&#10;COPY build.gradle.* gradle.properties /home/gradle/app/&#10;COPY gradle /home/gradle/app/gradle&#10;WORKDIR /home/gradle/app&#10;RUN gradle dependencies --no-daemon&#10;&#10;# Stage 2: Build Application&#10;FROM gradle:latest AS build&#10;COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle&#10;COPY --chown=gradle:gradle . /home/gradle/src&#10;WORKDIR /home/gradle/src&#10;# Build the fat JAR, Gradle also supports shadow&#10;# and boot JAR by default.&#10;RUN gradle buildFatJar --no-daemon&#10;&#10;# Stage 3: Create the Runtime Image&#10;FROM amazoncorretto:22 AS runtime&#10;EXPOSE 8080&#10;RUN mkdir /app&#10;COPY --from=build /home/gradle/src/build/libs/*.jar /app/ktor-docker-sample.jar&#10;ENTRYPOINT [&quot;java&quot;,&quot;-jar&quot;,&quot;/app/ktor-docker-sample.jar&quot;]"/>
+        <tip>
+            이 멀티 스테이지 빌드(multi-stage build)의 작동 방식에 대한 자세한 내용은 <a href="docker.md#prepare-docker">Docker 이미지 준비</a>를 참조하세요.
+        </tip>
+        <p>
+         이 예제에서는 Amazon Corretto Docker 이미지를 사용하지만, 다음과 같은 다른 적절한 대안으로 교체할 수 있습니다:
+        </p>
+        <list>
+          <li><a href="https://hub.docker.com/_/eclipse-temurin">Eclipse Temurin</a></li>
+          <li><a href="https://hub.docker.com/_/ibm-semeru-runtimes">IBM Semeru</a></li>
+          <li><a href="https://hub.docker.com/_/ibmjava">IBM Java</a></li>
+          <li><a href="https://hub.docker.com/_/sapmachine">SAP Machine JDK</a></li>
+        </list>
+    </chapter>
+    <chapter title="Docker Compose 구성" id="configure-docker-compose">
+        <p>프로젝트 루트 디렉터리에 새 <Path>compose.yml</Path> 파일을 생성하고 다음 내용을 추가합니다:
+        </p>
+        <code-block lang="yaml" code="services:&#10;  web:&#10;    build: .&#10;    ports:&#10;      - &quot;8080:8080&quot;&#10;    depends_on:&#10;      db:&#10;        condition: service_healthy&#10;  db:&#10;    image: postgres&#10;    volumes:&#10;      - ./tmp/db:/var/lib/postgresql/data&#10;    environment:&#10;      POSTGRES_DB: ktor_tutorial_db&#10;      POSTGRES_HOST_AUTH_METHOD: trust&#10;    ports:&#10;      - &quot;5432:5432&quot;&#10;    healthcheck:&#10;      test: [ &quot;CMD-SHELL&quot;, &quot;pg_isready -U postgres&quot; ]&#10;      interval: 1s"/>
+        <list>
+            <li><code>web</code> 서비스는 <a href="#prepare-docker-image">이미지</a> 내부에 패키징된 Ktor 애플리케이션을 실행하는 데 사용됩니다.
+            </li>
+            <li><code>db</code> 서비스는 <code>postgres</code> 이미지를 사용하여 태스크를 저장하기 위한 <code>ktor_tutorial_db</code> 데이터베이스를 생성합니다.
+            </li>
+        </list>
+    </chapter>
+</chapter>
+<chapter title="서비스 빌드 및 실행" id="build-run">
+    <procedure>
+        <step>
+            <p>
+                Ktor 애플리케이션이 포함된 <a href="#configure-ktor-plugin">fat JAR</a>를 생성하려면 다음 명령을 실행합니다:
+            </p>
+            <code-block lang="Bash" code="                    ./gradlew :tutorial-server-docker-compose:buildFatJar"/>
+        </step>
+        <step>
+            <p>
+                <code>docker compose up</code> 명령을 사용하여 이미지를 빌드하고 컨테이너를 시작합니다:
+            </p>
+            <code-block lang="Bash" code="                    docker compose --project-directory snippets/tutorial-server-docker-compose up"/>
+        </step>
+        <step>
+            Docker Compose가 이미지 빌드를 마칠 때까지 기다립니다.
+        </step>
+        <step>
+            <p>
+                <a href="http://localhost:8080/static/index.html">http://localhost:8080/static/index.html</a>로 이동하여 웹 애플리케이션을 엽니다. 태스크를 필터링하고 새로 추가하기 위한 세 개의 폼과 태스크 목록 테이블이 포함된 Task Manager Client 페이지가 표시되어야 합니다.
+            </p>
+            <img src="tutorial_server_db_integration_manual_test.gif"
+                 alt="A browser window showing the Task Manager Client"
+                 border-effect="rounded"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+</topic>

--- a/docs/ko/ktor/full-stack-development-with-kotlin-multiplatform.md
+++ b/docs/ko/ktor/full-stack-development-with-kotlin-multiplatform.md
@@ -1,0 +1,571 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="코틀린 멀티플랫폼으로 풀스택 애플리케이션 구축하기" id="full-stack-development-with-kotlin-multiplatform">
+<show-structure for="chapter, procedure" depth="2"/>
+<web-summary>
+    Kotlin과 Ktor를 사용하여 크로스 플랫폼 풀스택 애플리케이션을 개발하는 방법을 배워보세요. 이 튜토리얼에서는
+    Kotlin Multiplatform을 사용하여 Android, iOS 및 데스크톱용 앱을 빌드하고 Ktor를 사용하여 데이터를 손쉽게
+    처리하는 방법을 알아봅니다.
+</web-summary>
+<link-summary>
+    Kotlin과 Ktor를 사용하여 크로스 플랫폼 풀스택 애플리케이션을 개발하는 방법을 배워보세요.
+</link-summary>
+<card-summary>
+    Kotlin과 Ktor를 사용하여 크로스 플랫폼 풀스택 애플리케이션을 개발하는 방법을 배워보세요.
+</card-summary>
+<tldr>
+    <var name="example_name" value="full-stack-task-manager"/>
+    <p>
+        <b>코드 예제</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+    <p>
+        <b>사용된 플러그인</b>: <Links href="//server-routing" summary="라우팅은 서버 애플리케이션에서 들어오는 요청을 처리하기 위한 핵심 플러그인입니다.">Routing</Links>,
+        <a href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>,
+        <Links href="//server-serialization" summary="ContentNegotiation 플러그인은 클라이언트와 서버 간의 미디어 유형 협상과 특정 형식의 콘텐츠 직렬화/역직렬화라는 두 가지 주요 목적을 수행합니다.">Content Negotiation</Links>,
+        <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a>,
+        <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">Kotlin Multiplatform</a>
+    </p>
+</tldr>
+<p>
+    이 문서에서는 Ktor를 활용하여 원활한 데이터 처리를 구현하면서 Android, iOS, 웹 및 데스크톱 플랫폼에서 실행되는 Kotlin 기반 풀스택 애플리케이션을 개발하는 방법을 배웁니다.
+</p>
+<p>이 튜토리얼을 마치면 다음 사항을 수행할 수 있게 됩니다:</p>
+<list>
+    <li><a
+            href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">
+        Kotlin Multiplatform</a>을 사용하여 풀스택 애플리케이션 생성.
+    </li>
+    <li>IntelliJ IDEA에서 생성된 프로젝트 구조 이해.</li>
+    <li>Ktor 서비스를 호출하는 <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a> 클라이언트 제작.
+    </li>
+    <li>설계의 여러 계층에서 공유 타입(Shared types) 재사용.</li>
+    <li>멀티플랫폼 라이브러리의 올바른 포함 및 구성.</li>
+</list>
+<p>
+    이전 튜토리얼들에서는 할 일 관리자(Task Manager) 예제를 사용하여
+    <Links href="//server-requests-and-responses" summary="Ktor와 Kotlin을 사용하여 할 일 관리자 애플리케이션을 빌드하며 라우팅, 요청 처리 및 매개변수의 기초를 배워보세요.">요청 처리</Links>,
+    <Links href="//server-create-restful-apis" summary="JSON 파일을 생성하는 RESTful API 예제를 통해 Kotlin과 Ktor를 사용하여 백엔드 서비스를 빌드하는 방법을 배워보세요.">RESTful API 생성</Links>, 그리고
+    <Links href="//server-integrate-database" summary="Exposed SQL 라이브러리를 사용하여 Ktor 서비스를 데이터베이스 리포지토리에 연결하는 프로세스를 배워보세요.">Exposed를 통한 데이터베이스 통합</Links> 방법을 살펴보았습니다.
+    당시 클라이언트 애플리케이션은 Ktor의 핵심 기능을 배우는 데 집중할 수 있도록 최대한 단순하게 유지되었습니다.
+</p>
+<p>
+    이제 표시할 데이터를 가져오기 위해 Ktor 서비스를 사용하는 Android, iOS, 웹 및 데스크톱 플랫폼용 클라이언트를 만들 것입니다. 가능한 한 클라이언트와 서버 간에 데이터 타입을 공유하여 개발 속도를 높이고 오류 발생 가능성을 줄일 것입니다.
+</p>
+<chapter title="사전 요구 사항" id="prerequisites">
+    <p>
+        이전 문서들과 마찬가지로 IntelliJ IDEA를 IDE로 사용합니다. 환경 설치 및 구성에 대해서는
+        <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/quickstart.html">
+            Kotlin Multiplatform 퀵스타트
+        </a>를 참조하세요.
+    </p>
+    <p>
+        Compose Multiplatform을 처음 사용하는 경우, 이 튜토리얼을 시작하기 전에
+        <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-getting-started.html">
+            Compose Multiplatform 시작하기
+        </a> 튜토리얼을 먼저 완료하는 것을 권장합니다. 작업의 복잡도를 줄이기 위해 단일 클라이언트 플랫폼에 집중할 수도 있습니다. 예를 들어 iOS를 사용해 본 적이 없다면 데스크톱이나 Android 개발에 집중하는 것이 현명할 수 있습니다.
+    </p>
+</chapter>
+<chapter title="새 프로젝트 생성하기" id="create-project">
+    <p>
+        Ktor 프로젝트 생성기 대신 IntelliJ IDEA의 Kotlin Multiplatform 프로젝트 위저드(Wizard)를 사용합니다.
+        이를 통해 클라이언트와 서비스를 확장해 나갈 수 있는 기본 멀티플랫폼 프로젝트가 생성됩니다. 클라이언트는 SwiftUI와 같은 네이티브 UI 라이브러리를 사용할 수도 있지만, 이 튜토리얼에서는 <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a>을 사용하여 모든 플랫폼을 위한 공유 UI를 만들 것입니다.
+    </p>
+    <procedure id="generate-project">
+        <step>
+            IntelliJ IDEA를 실행합니다.
+        </step>
+        <step>
+            IntelliJ IDEA에서
+            <ui-path>File | New | Project</ui-path>를 선택합니다.
+        </step>
+        <step>
+            왼쪽 패널에서
+            <ui-path>Kotlin Multiplatform</ui-path>을 선택합니다.
+        </step>
+        <step>
+            <ui-path>New Project</ui-path> 창에서 다음 필드를 지정합니다:
+            <list>
+                <li>
+                    <ui-path>Name</ui-path>
+                    : full-stack-task-manager
+                </li>
+                <li>
+                    <ui-path>Project ID</ui-path>
+                    : com.example.ktor
+                </li>
+            </list>
+        </step>
+        <step>
+            <p>
+                대상 플랫폼으로
+                <ui-path>Android</ui-path>,
+                <ui-path>Desktop</ui-path>,
+                <ui-path>Web</ui-path>, 그리고
+                <ui-path>Server</ui-path>를 선택합니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                Mac을 사용 중이라면
+                <ui-path>iOS</ui-path>도 선택하세요.
+                <ui-path>Share UI</ui-path> 옵션이 선택되어 있는지 확인합니다.
+                <img style="block" src="full_stack_development_tutorial_create_project.png"
+                     alt="Kotlin Multiplatform 위저드 설정" width="706" border-effect="rounded"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                <control>Create</control> 버튼을 클릭하고 IDE가 프로젝트를 생성하고 임포트할 때까지 기다립니다.
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="서비스 실행하기" id="run-service">
+    <procedure id="run-service-procedure">
+        <step>
+            IntelliJ IDEA에서
+            <Path>ApplicationKt</Path> 실행 구성을 선택합니다.
+            <img src="full_stack_development_tutorial_server_run_configuration.png"
+                 alt="Run &amp; Debug 창" width="300"
+                 border-effect="line" style="block"/>
+        </step>
+        <step>
+            <ui-path>Run</ui-path> 버튼
+            (<img src="intellij_idea_run_icon.svg"
+                  style="inline" height="16" width="16"
+                  alt="IntelliJ IDEA 실행 아이콘"/>)을 클릭하여 해당 구성을 실행합니다.
+            <p>
+                <ui-path>Run</ui-path> 도구 창에 새 탭이 열립니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                브라우저에서 <a href="http://0.0.0.0:8080/">http://0.0.0.0:8080/</a>로 접속하여 애플리케이션을 엽니다.
+                브라우저에 Ktor가 표시하는 메시지가 나타나야 합니다.
+                <img src="full_stack_development_tutorial_run.png"
+                     alt="Ktor 서버 브라우저 응답" width="706"
+                     border-effect="rounded" style="block"/>
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="프로젝트 살펴보기" id="examine-project">
+    <p>
+        <Path>server</Path> 폴더는 프로젝트에 있는 세 개의 Kotlin 모듈 중 하나입니다. 나머지 두 개는
+        <Path>core</Path>와
+        <Path>app</Path>입니다.
+    </p>
+    <p>
+        <Path>server</Path> 모듈의 구조는 <a href="https://start.ktor.io/">Ktor 프로젝트 생성기</a>에서 생성된 구조와 매우 유사합니다.
+        플러그인과 의존성을 선언하기 위한 전용 빌드 파일이 있으며, Ktor 서비스를 빌드하고 실행하기 위한 코드가 포함된 소스 세트가 있습니다:
+    </p>
+    <img src="full_stack_development_tutorial_server_folder.png"
+         alt="Kotlin Multiplatform 프로젝트 내 server 폴더 내용" width="300"
+         border-effect="line"/>
+    <p>
+        <Path>Application.kt</Path> 파일의 라우팅 지침을 살펴보면 <code>sayHello()</code> 함수를 호출하는 것을 볼 수 있습니다:
+    </p>
+    <code-block lang="kotlin" code="            fun Application.module() {&#10;                routing {&#10;                    get(&quot;/&quot;) {&#10;                        call.respondText(sayHello(&quot;Ktor&quot;))&#10;                    }&#10;                }&#10;            }"/>
+    <p>
+        <code>sayHello()</code> 함수는 <Path>core</Path> 모듈에 정의되어 있습니다. 이곳이 서버와 모든 다양한 클라이언트 플랫폼 간에 공유될 공통 코드를 두는 곳입니다.
+    </p>
+    <p>
+       <Path>app/shared/src/commonMain</Path> 모듈 내의 <Path>Greeting.kt</Path> 파일을 열어보면 <code>sayHello()</code> 함수가 그곳에서도 사용되고 있음을 확인할 수 있습니다:
+    </p>
+    <code-block lang="kotlin" code="            class Greeting {&#10;                private val platform = getPlatform()&#10;&#10;                fun greet(): String {&#10;                    return sayHello(platform.name)&#10;                }&#10;            }"/>
+    <p>
+        <Path>app</Path> 모듈에는 다음 서브모듈들이 포함되어 있습니다:
+    </p>
+    <list>
+        <li>
+            <Path>androidApp</Path>, <Path>desktopApp</Path>, <Path>iosApp</Path>, <Path>webApp</Path> 서브모듈은 각각 Android, 데스크톱, iOS, 웹 클라이언트 앱을 위한 플랫폼별 코드를 담고 있습니다. 현재 이 클라이언트 앱들 중 어느 것도 Ktor 서비스와 연결되어 있지 않습니다.
+        </li>
+        <li>
+            <p>
+                <Path>shared</Path> 서브모듈은 클라이언트를 제공하려는 각 플랫폼에 대한 소스 세트를 포함합니다. 이는 <Path>commonMain</Path> 내에 선언된 타입들이 대상 플랫폼마다 다른 기능을 필요로 하기 때문입니다.
+            </p>
+            <p>
+                예를 들어, <code>Greeting</code> 타입에서 현재 플랫폼의 이름은 <a
+                    href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-connect-to-apis.html">기대(expected) 및 실제(actual) 선언</a>을 통해 플랫폼별 API를 사용하여 가져옵니다.
+            </p>
+            <p>
+                <Path>shared</Path> 서브모듈의 <Path>commonMain</Path> 소스 세트에서 <code>getPlatform()</code> 함수는 <code>expect</code> 키워드와 함께 선언되어 있습니다:
+            </p>
+            <Tabs>
+                <TabItem title="commonMain/Platform.kt" id="commonMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;interface Platform {&#10;    val name: String&#10;}&#10;&#10;expect fun getPlatform(): Platform"/>
+                </TabItem>
+            </Tabs>
+            <p>
+                그런 다음 아래와 같이 각 대상 플랫폼은 <code>getPlatform()</code> 함수의 <code>actual</code> 선언을 제공합니다:
+            </p>
+            <Tabs>
+                <TabItem title="Platform.ios.kt" id="iosMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import platform.UIKit.UIDevice&#10;&#10;class IOSPlatform : Platform {&#10;    override val name: String = UIDevice.currentDevice.systemName() + &quot; &quot; + UIDevice.currentDevice.systemVersion&#10;}&#10;&#10;actual fun getPlatform(): Platform = IOSPlatform()"/>
+                </TabItem>
+                <TabItem title="Platform.android.kt" id="androidMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import android.os.Build&#10;&#10;class AndroidPlatform : Platform {&#10;    override val name: String = &quot;Android ${Build.VERSION.SDK_INT}&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = AndroidPlatform()"/>
+                </TabItem>
+                <TabItem title="Platform.jvm.kt" id="jvmMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;class JVMPlatform : Platform {&#10;    override val name: String = &quot;Java ${System.getProperty(&quot;java.version&quot;)}&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = JVMPlatform()"/>
+                </TabItem>
+                <TabItem title="Platform.wasmJs.kt" id="wasmJsMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;class WasmPlatform : Platform {&#10;    override val name: String = &quot;Web with Kotlin/Wasm&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = WasmPlatform()"/>
+                </TabItem>
+            </Tabs>
+        </li>
+    </list>
+</chapter>
+<chapter title="클라이언트 애플리케이션 실행하기" id="run-client-app">
+    <p>
+        대상 플랫폼에 대한 실행 구성을 실행하여 클라이언트 애플리케이션을 구동할 수 있습니다. iOS 시뮬레이터에서 애플리케이션을 실행하려면 아래 단계를 따르세요:
+    </p>
+    <procedure id="run-ios-app-procedure">
+        <step>
+            IntelliJ IDEA에서
+            <Path>iosApp</Path> 실행 구성과 시뮬레이션 장치를 선택합니다.
+            <img src="full_stack_development_tutorial_run_configurations.png"
+                 alt="Run &amp; Debug 창" width="400"
+                 border-effect="line" style="block"/>
+        </step>
+        <step>
+            <ui-path>Run</ui-path> 버튼
+            (<img src="intellij_idea_run_icon.svg"
+                  style="inline" height="16" width="16"
+                  alt="IntelliJ IDEA 실행 아이콘"/>)을 클릭하여 구성을 실행합니다.
+        </step>
+        <step>
+            <p>
+                iOS 앱을 실행하면 내부적으로 Xcode로 빌드되어 iOS 시뮬레이터에서 실행됩니다.
+                앱에는 클릭 시 이미지를 토글하는 버튼이 표시됩니다.
+                <img style="block" src="full_stack_development_tutorial_run_ios.gif"
+                     alt="iOS 시뮬레이터에서 앱 실행 중" width="300" border-effect="rounded"/>
+            </p>
+            <p>
+                버튼을 처음 누르면 현재 플랫폼의 세부 정보가 텍스트에 추가됩니다. 이를 구현하는 코드는
+                <Path>app/shared/src/commonMain/kotlin/com/example/ktor/App.kt</Path>에서 찾을 수 있습니다:
+            </p>
+            <code-block lang="kotlin" code="                @Composable&#10;                @Preview&#10;                fun App() {&#10;                    MaterialTheme {&#10;                        var showContent by remember { mutableStateOf(false) }&#10;                        Column(&#10;                            modifier = Modifier&#10;                                .background(MaterialTheme.colorScheme.primaryContainer)&#10;                                .safeContentPadding()&#10;                                .fillMaxSize(),&#10;                            horizontalAlignment = Alignment.CenterHorizontally,&#10;                        ) {&#10;                            Button(onClick = { showContent = !showContent }) {&#10;                                Text(&quot;Click me!&quot;)&#10;                            }&#10;                            AnimatedVisibility(showContent) {&#10;                                val greeting = remember { Greeting().greet() }&#10;                                Column(&#10;                                    modifier = Modifier.fillMaxWidth(),&#10;                                    horizontalAlignment = Alignment.CenterHorizontally,&#10;                                ) {&#10;                                    Image(painterResource(Res.drawable.compose_multiplatform), null)&#10;                                    Text(&quot;Compose: $greeting&quot;)&#10;                                }&#10;                            }&#10;                        }&#10;                    }&#10;                }"/>
+            <p>
+                이것은 Composable 함수이며, 이 문서의 뒷부분에서 수정할 예정입니다. 지금 중요한 것은 이것이 UI를 표시하고 공유 <code>Greeting</code> 타입을 활용하며, 이 타입은 다시 공통 <code>Platform</code> 인터페이스를 구현하는 플랫폼별 클래스를 사용한다는 점입니다.
+            </p>
+        </step>
+    </procedure>
+    <p>
+        생성된 프로젝트의 구조를 이해했으므로, 이제 할 일 관리자 기능을 점진적으로 추가할 수 있습니다.
+    </p>
+</chapter>
+<chapter title="모델 타입 추가하기" id="add-model-types">
+    <p>
+        먼저 모델 타입을 추가하고 클라이언트와 서버 모두에서 접근 가능한지 확인합니다.
+    </p>
+    <procedure id="add-model-types-procedure">
+        <step>
+            <Path>gradle/libs.versions.toml</Path> 파일로 이동하여 다음 <code>kotlinx.serialization</code> 의존성을 정의합니다:
+            <code-block lang="toml" code="[versions]&#10;kotlinx-serialization-json = &quot;1.11.0&quot;&#10;&#10;[libraries]&#10;kotlinx-serialization-json = { module = &quot;org.jetbrains.kotlinx:kotlinx-serialization-json&quot;, version.ref = &quot;kotlinx-serialization-json&quot; }&#10;&#10;[plugins]&#10;kotlinSerialization = { id = &quot;org.jetbrains.kotlin.plugin.serialization&quot;, version.ref = &quot;kotlin&quot; }"/>
+        </step>
+        <step>
+            <p>
+                <Path>core/build.gradle.kts</Path> 파일로 이동하여 직렬화(serialization) 플러그인을 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="plugins {&#10;    //...&#10;    alias(libs.plugins.kotlinSerialization)&#10;}"/>
+        </step>
+        <step>
+            <p>
+                같은 파일에서 <Path>commonMain</Path> 소스 세트에 새 의존성을 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="    sourceSets {&#10;        commonMain.dependencies {&#10;            // 여기에 멀티플랫폼 의존성을 넣으세요&#10;            implementation(libs.kotlinx.serialization.json)&#10;        }&#10;        //...&#10;    }"/>
+        </step>
+        <step>
+            IntelliJ IDEA에서
+            <ui-path>Build | Sync Project with Gradle Files</ui-path>를 선택하여 업데이트를 적용합니다. Gradle 임포트가 완료되면
+            <Path>Task.kt</Path> 파일이 성공적으로 컴파일되는 것을 확인할 수 있습니다.
+        </step>
+        <step>
+            <Path>core/src/commonMain/kotlin/com/example/ktor</Path> 폴더로 이동하여
+            <Path>model</Path>이라는 새 패키지를 생성합니다.
+        </step>
+        <step>
+            새 패키지 안에 <Path>Task.kt</Path>라는 새 파일을 생성합니다.
+        </step>
+        <step>
+            <p>
+                우선순위를 나타내는 enum과 할 일을 나타내는 클래스를 추가합니다.
+                <code>Task</code> 클래스는 <code>kotlinx.serialization</code> 라이브러리의
+                <code>Serializable</code> 어노테이션을 가집니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="서버 생성하기" id="create-server">
+    <p>
+        다음 단계는 할 일 관리자를 위한 서버 구현을 만드는 것입니다.
+    </p>
+    <procedure id="create-server-procedure">
+        <step>
+            <Path>server/src/main/kotlin/com/example/ktor</Path> 폴더로 이동하여
+            <Path>model</Path>이라는 서브 패키지를 생성합니다.
+        </step>
+        <step>
+            <p>
+                이 패키지 안에 <Path>TaskRepository.kt</Path> 파일을 새로 만들고 리포지토리를 위한 다음 인터페이스를 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;interface TaskRepository {&#10;    fun allTasks(): List&lt;Task&gt;&#10;    fun tasksByPriority(priority: Priority): List&lt;Task&gt;&#10;    fun taskByName(name: String): Task?&#10;    fun addOrUpdateTask(task: Task)&#10;    fun removeTask(name: String): Boolean&#10;}"/>
+        </step>
+        <step>
+            <p>
+                같은 패키지에 <Path>InMemoryTaskRepository.kt</Path>라는 새 파일을 만들고 다음 클래스를 작성합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;class InMemoryTaskRepository : TaskRepository {&#10;    private var tasks = listOf(&#10;        Task(&quot;Cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;Gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;Shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;Painting&quot;, &quot;Paint the fence&quot;, Priority.Low),&#10;        Task(&quot;Cooking&quot;, &quot;Cook the dinner&quot;, Priority.Medium),&#10;        Task(&quot;Relaxing&quot;, &quot;Take a walk&quot;, Priority.High),&#10;        Task(&quot;Exercising&quot;, &quot;Go to the gym&quot;, Priority.Low),&#10;        Task(&quot;Learning&quot;, &quot;Read a book&quot;, Priority.Medium),&#10;        Task(&quot;Snoozing&quot;, &quot;Go for a nap&quot;, Priority.High),&#10;        Task(&quot;Socializing&quot;, &quot;Go to a party&quot;, Priority.High)&#10;    )&#10;&#10;    override fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    override fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    override fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    override fun addOrUpdateTask(task: Task) {&#10;        var notFound = true&#10;&#10;        tasks = tasks.map {&#10;            if (it.name == task.name) {&#10;                notFound = false&#10;                task&#10;            } else {&#10;                it&#10;            }&#10;        }&#10;        if (notFound) {&#10;            tasks = tasks.plus(task)&#10;        }&#10;    }&#10;&#10;    override fun removeTask(name: String): Boolean {&#10;        val oldTasks = tasks&#10;        tasks = tasks.filterNot { it.name == name }&#10;        return oldTasks.size &gt; tasks.size&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                <Path>server/src/main/kotlin/.../Application.kt</Path>로 이동하여 기존 코드를 아래 구현으로 교체합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import com.example.ktor.model.InMemoryTaskRepository&#10;import com.example.ktor.model.Priority&#10;import com.example.ktor.model.Task&#10;import io.ktor.http.*&#10;import io.ktor.serialization.*&#10;import io.ktor.serialization.kotlinx.json.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.plugins.contentnegotiation.*&#10;import io.ktor.server.plugins.cors.routing.*&#10;import io.ktor.server.request.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;, module = Application::module)&#10;        .start(wait = true)&#10;}&#10;&#10;fun Application.module() {&#10;    install(ContentNegotiation) {&#10;        json()&#10;    }&#10;    install(CORS) {&#10;        allowHeader(HttpHeaders.ContentType)&#10;        allowMethod(HttpMethod.Delete)&#10;        // 데모의 편의를 위해 모든 연결을 허용합니다.&#10;        // 프로덕션 환경에서는 이렇게 하지 마세요.&#10;        anyHost()&#10;    }&#10;    val repository = InMemoryTaskRepository()&#10;&#10;    routing {&#10;        route(&quot;/tasks&quot;) {&#10;            get {&#10;                val tasks = repository.allTasks()&#10;                call.respond(tasks)&#10;            }&#10;            get(&quot;/byName/{taskName}&quot;) {&#10;                val name = call.parameters[&quot;taskName&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                val task = repository.taskByName(name)&#10;                if (task == null) {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                    return@get&#10;                }&#10;                call.respond(task)&#10;            }&#10;            get(&quot;/byPriority/{priority}&quot;) {&#10;                val priorityAsText = call.parameters[&quot;priority&quot;]&#10;                if (priorityAsText == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(priorityAsText)&#10;                    val tasks = repository.tasksByPriority(priority)&#10;&#10;&#10;                    if (tasks.isEmpty()) {&#10;                        call.respond(HttpStatusCode.NotFound)&#10;                        return@get&#10;                    }&#10;                    call.respond(tasks)&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;            post {&#10;                try {&#10;                    val task = call.receive&lt;Task&gt;()&#10;                    repository.addOrUpdateTask(task)&#10;                    call.respond(HttpStatusCode.NoContent)&#10;                } catch (ex: IllegalStateException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                } catch (ex: JsonConvertException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;            delete(&quot;/{taskName}&quot;) {&#10;                val name = call.parameters[&quot;taskName&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@delete&#10;                }&#10;                if (repository.removeTask(name)) {&#10;                    call.respond(HttpStatusCode.NoContent)&#10;                } else {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                이 구현은 단순화를 위해 모든 라우팅 코드를 <code>Application.module()</code> 함수 안에 배치했다는 점을 제외하면 이전 튜토리얼의 내용과 매우 유사합니다.
+            </p>
+            <p>
+                이 코드를 입력하고 임포트를 추가하면 컴파일 에러가 여러 개 발생할 것입니다. 이는 코드에서 웹 클라이언트와의 상호 작용을 위한 <Links href="//server-cors" summary="필요한 의존성: io.ktor:%artifact_name%">CORS</Links> 플러그인을 포함하여 의존성으로 추가해야 할 여러 Ktor 플러그인을 사용하고 있기 때문입니다.
+            </p>
+        </step>
+        <step>
+            <Path>gradle/libs.versions.toml</Path> 파일을 열고 다음 라이브러리들을 정의합니다:
+            <code-block lang="toml" code="[libraries]&#10;ktor-serialization-kotlinx-json-jvm = { module = &quot;io.ktor:ktor-serialization-kotlinx-json-jvm&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-server-content-negotiation-jvm = { module = &quot;io.ktor:ktor-server-content-negotiation-jvm&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-server-cors-jvm = { module = &quot;io.ktor:ktor-server-cors-jvm&quot;, version.ref = &quot;ktor&quot; }"/>
+        </step>
+        <step>
+            <p>
+                서버 모듈 빌드 파일(<Path>server/build.gradle.kts</Path>)을 열고 다음 의존성들을 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="dependencies {&#10;    //...&#10;    implementation(libs.ktor.serialization.kotlinx.json.jvm)&#10;    implementation(libs.ktor.server.content.negotiation.jvm)&#10;    implementation(libs.ktor.server.cors.jvm)&#10;}"/>
+        </step>
+        <step>
+            다시 한번 메인 메뉴에서 <ui-path>Build | Sync Project with Gradle Files</ui-path>를 실행합니다.
+            임포트가 완료되면 <code>ContentNegotiation</code> 타입과 <code>json()</code> 함수에 대한 임포트가 정상적으로 작동하는 것을 확인할 수 있습니다.
+        </step>
+        <step>
+            서버를 다시 실행합니다. 브라우저에서 경로에 접근할 수 있음을 확인할 수 있습니다.
+        </step>
+        <step>
+            <p>
+                <a href="http://0.0.0.0:8080/tasks"></a> 및 <a href="http://0.0.0.0:8080/tasks/byPriority/Medium"></a>로 접속하여
+                JSON 형식의 할 일 목록이 담긴 서버 응답을 확인하세요.
+                <img style="block" src="full_stack_development_tutorial_run_server.gif"
+                     width="707" border-effect="rounded" alt="브라우저에서의 서버 응답"/>
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="클라이언트 생성하기" id="create-client">
+    <p>
+        클라이언트가 서버에 접근할 수 있도록 하려면 Ktor Client를 포함해야 합니다. 여기에는 세 가지 유형의 의존성이 관련됩니다:
+    </p>
+    <list>
+        <li>Ktor Client의 핵심(Core) 기능.</li>
+        <li>네트워킹을 처리하기 위한 플랫폼별 엔진.</li>
+        <li>콘텐츠 협상(Content Negotiation) 및 직렬화 지원.</li>
+    </list>
+    <procedure id="create-client-procedure">
+        <step>
+            <Path>gradle/libs.versions.toml</Path> 파일에 다음 라이브러리들을 추가합니다:
+            <code-block lang="toml" code="[libraries]&#10;ktor-client-android = { module = &quot;io.ktor:ktor-client-android&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-cio = { module = &quot;io.ktor:ktor-client-cio&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-content-negotiation = { module = &quot;io.ktor:ktor-client-content-negotiation&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-core = { module = &quot;io.ktor:ktor-client-core&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-darwin = { module = &quot;io.ktor:ktor-client-darwin&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-wasm = { module = &quot;io.ktor:ktor-client-js-wasm-js&quot;, version.ref = &quot;ktor&quot;}&#10;ktor-serialization-kotlinx-json = { module = &quot;io.ktor:ktor-serialization-kotlinx-json&quot;, version.ref = &quot;ktor&quot; }"/>
+        </step>
+        <step>
+            <Path>app/shared/build.gradle.kts</Path>로 이동하여 다음 의존성들을 추가합니다:
+            <code-block lang="kotlin" code="kotlin {&#10;    //...&#10;    sourceSets {&#10;        androidMain.dependencies {&#10;            //...&#10;            implementation(libs.ktor.client.android)&#10;        }&#10;        commonMain.dependencies {&#10;            //...&#10;            implementation(libs.ktor.client.core)&#10;            implementation(libs.ktor.client.content.negotiation)&#10;            implementation(libs.ktor.serialization.kotlinx.json)&#10;        }&#10;        jvmMain.dependencies {&#10;            implementation(libs.ktor.client.cio)&#10;        }&#10;        iosMain.dependencies {&#10;            implementation(libs.ktor.client.darwin)&#10;        }&#10;        wasmJsMain.dependencies {&#10;            implementation(libs.ktor.client.wasm)&#10;        }&#10;    }&#10;}"/>
+            <p>
+                이 작업이 완료되면 클라이언트에서 Ktor Client를 감싸는 얇은 래퍼(wrapper) 역할을 할 <code>TaskApi</code> 타입을 추가할 수 있습니다.
+            </p>
+        </step>
+        <step>
+            메인 메뉴에서 <ui-path>Build | Sync Project with Gradle Files</ui-path>를 선택하여 빌드 파일의 변경 사항을 임포트합니다.
+        </step>
+        <step>
+            <Path>app/shared/src/commonMain/kotlin/com/example/ktor</Path> 폴더로 이동하여
+            <Path>network</Path>라는 새 패키지를 생성합니다.
+        </step>
+        <step>
+            <p>
+                새 패키지 안에 클라이언트 설정을 위한 <Path>HttpClientManager.kt</Path> 파일을 생성합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.network&#10;&#10;import io.ktor.client.HttpClient&#10;import io.ktor.client.plugins.contentnegotiation.ContentNegotiation&#10;import io.ktor.client.plugins.defaultRequest&#10;import io.ktor.serialization.kotlinx.json.json&#10;import kotlinx.serialization.json.Json&#10;&#10;fun createHttpClient() = HttpClient {&#10;    install(ContentNegotiation) {&#10;        json(Json {&#10;            encodeDefaults = true&#10;            isLenient = true&#10;            coerceInputValues = true&#10;            ignoreUnknownKeys = true&#10;        })&#10;    }&#10;    defaultRequest {&#10;        host = &quot;1.2.3.4&quot; // 현재 머신의 IP 주소로 바꾸세요.&#10;        port = 8080&#10;    }&#10;}"/>
+            <p>
+                <code>1.2.3.4</code>를 현재 머신의 IP 주소로 바꾸세요. Android 가상 장치나 iOS 시뮬레이터에서 실행되는 코드에서는 <code>0.0.0.0</code> 또는 <code>localhost</code>로 호출할 수 없습니다.
+            </p>
+            <tip>
+                <p><b>IP 주소 찾기:</b></p>
+                <p>
+                    모바일 시뮬레이터는 <code>localhost</code>에 도달할 수 없으므로 머신의 실제 IP 주소가 필요합니다. IP 주소를 확인하려면 다음 명령어 중 하나를 실행하세요:
+                </p>
+                <list>
+                    <li><b>macOS:</b> <code>ifconfig | grep "inet " | grep -v 127.0.0.1</code></li>
+                    <li><b>Linux:</b> <code>hostname -I | awk '{print $1}'</code></li>
+                    <li><b>Windows:</b> <code>ipconfig</code> 실행 후 "IPv4 Address" 확인</li>
+                </list>
+            </tip>
+        </step>
+        <step>
+            <p>
+                같은 <Path>app/shared/.../network</Path> 패키지에 다음 구현이 담긴 <Path>TaskApi.kt</Path> 파일을 생성합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.network&#10;&#10;import com.example.ktor.model.Task&#10;import io.ktor.client.HttpClient&#10;import io.ktor.client.call.body&#10;import io.ktor.client.request.delete&#10;import io.ktor.client.request.get&#10;import io.ktor.client.request.post&#10;import io.ktor.client.request.setBody&#10;import io.ktor.http.ContentType&#10;import io.ktor.http.contentType&#10;&#10;class TaskApi(private val httpClient: HttpClient) {&#10;&#10;    suspend fun getAllTasks(): List&lt;Task&gt; {&#10;        return httpClient.get(&quot;tasks&quot;).body()&#10;    }&#10;&#10;    suspend fun removeTask(task: Task) {&#10;        httpClient.delete(&quot;tasks/${task.name}&quot;)&#10;    }&#10;&#10;    suspend fun updateTask(task: Task) {&#10;        httpClient.post(&quot;tasks&quot;) {&#10;            contentType(ContentType.Application.Json)&#10;            setBody(task)&#10;        }&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                <Path>app/shared/.../App.kt</Path>로 이동하여 코드를 아래 구현으로 교체합니다.
+                이 코드는 <code>TaskApi</code> 타입을 사용하여 서버에서 할 일 목록을 가져온 다음, 각 할 일의 이름을 컬럼(Column)에 표시합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import com.example.ktor.network.TaskApi&#10;import com.example.ktor.network.createHttpClient&#10;import com.example.ktor.model.Task&#10;import androidx.compose.foundation.layout.Column&#10;import androidx.compose.foundation.layout.fillMaxSize&#10;import androidx.compose.foundation.layout.safeContentPadding&#10;import androidx.compose.material3.Button&#10;import androidx.compose.material3.MaterialTheme&#10;import androidx.compose.material3.Text&#10;import androidx.compose.runtime.*&#10;import androidx.compose.ui.Alignment&#10;import androidx.compose.ui.Modifier&#10;import kotlinx.coroutines.launch&#10;&#10;@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        val tasks = remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;&#10;        Column(&#10;            modifier = Modifier&#10;                .safeContentPadding()&#10;                .fillMaxSize(),&#10;            horizontalAlignment = Alignment.CenterHorizontally,&#10;        ) {&#10;            Button(onClick = {&#10;                scope.launch {&#10;                    tasks.value = taskApi.getAllTasks()&#10;                }&#10;            }) {&#10;                Text(&quot;Fetch Tasks&quot;)&#10;            }&#10;            for (task in tasks.value) {&#10;                Text(task.name)&#10;            }&#10;        }&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                서버가 실행 중인 상태에서 <ui-path>iosApp</ui-path> 실행 구성을 사용하여 iOS 애플리케이션을 테스트합니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                <control>Fetch Tasks</control> 버튼을 클릭하여 할 일 목록을 표시합니다:
+                <img style="block" src="full_stack_development_tutorial_run_iOS.png"
+                     alt="iOS에서 실행 중인 앱" width="363" border-effect="rounded"/>
+            </p>
+            <note>
+                이 데모에서는 명확성을 위해 프로세스를 단순화했습니다. 실제 애플리케이션에서는 네트워크를 통해 암호화되지 않은 데이터를 전송하는 것을 피하는 것이 매우 중요합니다.
+            </note>
+        </step>
+        <step>
+            <p>
+                Android 플랫폼에서는 애플리케이션에 네트워킹 권한을 명시적으로 부여하고 일반 텍스트(cleartext) 데이터를 주고받을 수 있도록 허용해야 합니다. 이 권한을 활성화하려면
+                <Path>app/androidApp/src/main/AndroidManifest.xml</Path>을 열고 다음 설정을 추가하세요:
+            </p>
+            <code-block lang="xml" code="                    &lt;manifest&gt;&#10;                        ...&#10;                        &lt;application&#10;                                android:usesCleartextTraffic=&quot;true&quot;&gt;&#10;                        ...&#10;                        ...&#10;                        &lt;/application&gt;&#10;                        &lt;uses-permission android:name=&quot;android.permission.INTERNET&quot;/&gt;&#10;                    &lt;/manifest&gt;"/>
+        </step>
+        <step>
+            <p>
+                <ui-path>app.androidApp</ui-path> 실행 구성을 사용하여 Android 애플리케이션을 실행합니다.
+                이제 Android 클라이언트도 정상적으로 실행되는 것을 볼 수 있습니다:
+                <img style="block" src="full_stack_development_tutorial_run_android.png"
+                     alt="Android에서 실행 중인 앱" width="350" />
+            </p>
+        </step>
+        <step>
+            <p>
+                데스크톱 클라이언트의 경우, 창에 크기와 타이틀을 지정할 것입니다.
+                <Path>app/desktopApp/src/.../main.kt</Path> 파일을 열고 <code>title</code>을 변경하고 <code>state</code> 속성을 설정하여 코드를 수정합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import androidx.compose.ui.unit.DpSize&#10;import androidx.compose.ui.unit.dp&#10;import androidx.compose.ui.window.Window&#10;import androidx.compose.ui.window.WindowPosition&#10;import androidx.compose.ui.window.WindowState&#10;import androidx.compose.ui.window.application&#10;&#10;fun main() = application {&#10;    val state = WindowState(&#10;        size = DpSize(400.dp, 600.dp),&#10;        position = WindowPosition(200.dp, 100.dp)&#10;    )&#10;    Window(&#10;        title = &quot;Task Manager (Desktop)&quot;,&#10;        state = state,&#10;        onCloseRequest = ::exitApplication,&#10;    ) {&#10;        App()&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                <ui-path>app [hot] 🔥</ui-path> 실행 구성을 사용하여 데스크톱 애플리케이션을 실행합니다:
+                <img style="block" src="full_stack_development_tutorial_run_desktop_resized.png"
+                     alt="데스크톱에서 실행 중인 앱" width="400" border-effect="rounded"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                다음 실행 구성 중 하나를 사용하여 웹 클라이언트를 실행합니다:
+            </p>
+            <list>
+                <li>
+                    <ui-path>app [js]</ui-path>: Kotlin/JS 애플리케이션을 실행합니다.
+                </li>
+                <li>
+                    <ui-path>app [wasmJs]</ui-path>: Kotlin/Wasm 애플리케이션을 실행합니다.
+                </li>
+            </list>
+            <img style="block" src="full_stack_development_tutorial_run_web.png"
+                 alt="웹에서 실행 중인 앱" width="400" border-effect="rounded"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="UI 개선하기" id="improve-ui">
+    <p>
+        이제 클라이언트가 서버와 통신하고 있지만, 아직 매력적인 UI라고 하기는 어렵습니다.
+    </p>
+    <procedure id="improve-ui-procedure">
+        <step>
+            <p>
+                <Path>app/shared/src/commonMain/.../ktor</Path>에 위치한
+                <Path>App.kt</Path> 파일을 열고 기존 <code>App</code>을 아래의 <code>App</code> 및 <code>TaskCard</code>
+                Composable로 교체합니다:
+            </p>
+            <code-block lang="kotlin" collapsed-title-line-number="31" collapsible="true" code="package com.example.ktor&#10;&#10;import com.example.ktor.network.TaskApi&#10;import com.example.ktor.model.Priority&#10;import com.example.ktor.model.Task&#10;import androidx.compose.foundation.layout.Column&#10;import androidx.compose.foundation.layout.Row&#10;import androidx.compose.foundation.layout.Spacer&#10;import androidx.compose.foundation.layout.fillMaxSize&#10;import androidx.compose.foundation.layout.fillMaxWidth&#10;import androidx.compose.foundation.layout.padding&#10;import androidx.compose.foundation.layout.safeContentPadding&#10;import androidx.compose.foundation.layout.width&#10;import androidx.compose.foundation.lazy.LazyColumn&#10;import androidx.compose.foundation.lazy.items&#10;import androidx.compose.foundation.shape.CornerSize&#10;import androidx.compose.foundation.shape.RoundedCornerShape&#10;import androidx.compose.material3.Card&#10;import androidx.compose.material3.MaterialTheme&#10;import androidx.compose.material3.OutlinedButton&#10;import androidx.compose.material3.Text&#10;import androidx.compose.runtime.*&#10;import androidx.compose.ui.Modifier&#10;import androidx.compose.ui.text.font.FontWeight&#10;import androidx.compose.ui.unit.dp&#10;import androidx.compose.ui.unit.sp&#10;import com.example.ktor.network.createHttpClient&#10;import kotlinx.coroutines.launch&#10;&#10;@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        var tasks by remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;&#10;        LaunchedEffect(Unit) {&#10;            tasks = taskApi.getAllTasks()&#10;        }&#10;&#10;        LazyColumn(&#10;            modifier = Modifier&#10;                .safeContentPadding()&#10;                .fillMaxSize()&#10;        ) {&#10;            items(tasks) { task -&gt;&#10;                TaskCard(&#10;                    task,&#10;                    onDelete = {&#10;                        scope.launch {&#10;                            taskApi.removeTask(it)&#10;                            tasks = taskApi.getAllTasks()&#10;                        }&#10;                    },&#10;                    onUpdate = {&#10;                    }&#10;                )&#10;            }&#10;        }&#10;    }&#10;}&#10;&#10;@Composable&#10;fun TaskCard(&#10;    task: Task,&#10;    onDelete: (Task) -&gt; Unit,&#10;    onUpdate: (Task) -&gt; Unit&#10;) {&#10;    fun pickWeight(priority: Priority) = when (priority) {&#10;        Priority.Low -&gt; FontWeight.SemiBold&#10;        Priority.Medium -&gt; FontWeight.Bold&#10;        Priority.High, Priority.Vital -&gt; FontWeight.ExtraBold&#10;    }&#10;&#10;    Card(&#10;        modifier = Modifier.fillMaxWidth().padding(4.dp),&#10;        shape = RoundedCornerShape(CornerSize(4.dp))&#10;    ) {&#10;        Column(modifier = Modifier.padding(10.dp)) {&#10;            Text(&#10;                &quot;${task.name}: ${task.description}&quot;,&#10;                fontSize = 20.sp,&#10;                fontWeight = pickWeight(task.priority)&#10;            )&#10;&#10;            Row {&#10;                OutlinedButton(onClick = { onDelete(task) }) {&#10;                    Text(&quot;Delete&quot;)&#10;                }&#10;                Spacer(Modifier.width(8.dp))&#10;                OutlinedButton(onClick = { onUpdate(task) }) {&#10;                    Text(&quot;Update&quot;)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                이 구현을 통해 클라이언트는 기본적인 기능을 갖추게 되었습니다.
+            </p>
+            <p>
+                <code>LaunchedEffect</code> 타입을 사용하여 시작 시 모든 할 일을 로드하고, <code>LazyColumn</code>
+                Composable을 사용하여 사용자가 할 일 목록을 스크롤할 수 있게 했습니다.
+            </p>
+            <p>
+                마지막으로 별도의 <code>TaskCard</code> Composable을 만들어 <code>Card</code>를 사용하여 각 <code>Task</code>의 세부 정보를 표시했습니다. 할 일을 삭제하거나 업데이트하기 위한 버튼들도 추가되었습니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                클라이언트 애플리케이션(예: Android 앱)을 다시 실행합니다.
+                이제 할 일 목록을 스크롤하고 세부 정보를 확인하며 삭제할 수 있습니다:
+                <img style="block" src="full_stack_development_tutorial_improved_ui.gif"
+                     alt="개선된 UI로 Android에서 실행 중인 앱" width="350" border-effect="rounded"/>
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="업데이트 기능 추가하기" id="add-update-functionality">
+    <p>
+        클라이언트를 완성하기 위해 할 일의 세부 정보를 업데이트할 수 있는 기능을 통합합니다.
+    </p>
+    <procedure id="add-update-func-procedure">
+        <step>
+            <Path>app/shared/src/commonMain/.../ktor</Path>에 있는
+            <Path>App.kt</Path> 파일로 이동합니다.
+        </step>
+        <step>
+            <p>
+                아래와 같이 <code>UpdateTaskDialog</code> Composable과 필요한 임포트를 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="import androidx.compose.material3.TextField&#10;import androidx.compose.material3.TextFieldDefaults&#10;import androidx.compose.ui.graphics.Color&#10;import androidx.compose.ui.window.Dialog&#10;&#10;@Composable&#10;fun UpdateTaskDialog(&#10;    task: Task,&#10;    onConfirm: (Task) -&gt; Unit&#10;) {&#10;    var description by remember { mutableStateOf(task.description) }&#10;    var priorityText by remember { mutableStateOf(task.priority.toString()) }&#10;    val colors = TextFieldDefaults.colors(&#10;        focusedTextColor = Color.Blue,&#10;        focusedContainerColor = Color.White,&#10;    )&#10;&#10;    Dialog(onDismissRequest = {}) {&#10;        Card(&#10;            modifier = Modifier.fillMaxWidth().padding(4.dp),&#10;            shape = RoundedCornerShape(CornerSize(4.dp))&#10;        ) {&#10;            Column(modifier = Modifier.padding(10.dp)) {&#10;                Text(&quot;Update ${task.name}&quot;, fontSize = 20.sp)&#10;                TextField(&#10;                    value = description,&#10;                    onValueChange = { description = it },&#10;                    label = { Text(&quot;Description&quot;) },&#10;                    colors = colors&#10;                )&#10;                // 주의: Priority 입력은 실제로는 드롭다운 등을 사용하는 것이 좋지만 여기서는 텍스트로 구현합니다.&#10;                TextField(&#10;                    value = priorityText,&#10;                    onValueChange = { priorityText = it },&#10;                    label = { Text(&quot;Priority&quot;) },&#10;                    colors = colors&#10;                )&#10;                OutlinedButton(onClick = {&#10;                    val newTask = Task(&#10;                        task.name,&#10;                        description,&#10;                        try {&#10;                            Priority.valueOf(priorityText)&#10;                        } catch (e: IllegalArgumentException) {&#10;                            Priority.Low&#10;                        }&#10;                    )&#10;                    onConfirm(newTask)&#10;                }) {&#10;                    Text(&quot;Update&quot;)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                이 Composable은 다이얼로그 박스로 <code>Task</code>의 세부 정보를 표시합니다. <code>description</code>과
+                <code>priority</code>는 <code>TextField</code> Composable 안에 배치되어 업데이트가 가능합니다. 사용자가 업데이트 버튼을 누르면 <code>onConfirm()</code> 콜백이 호출됩니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                같은 파일에서 <code>App</code> Composable을 업데이트합니다:
+            </p>
+            <code-block lang="kotlin" code="@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        var tasks by remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;        var currentTask by remember { mutableStateOf&lt;Task?&gt;(null) }&#10;&#10;        LaunchedEffect(Unit) {&#10;            tasks = taskApi.getAllTasks()&#10;        }&#10;&#10;        if (currentTask != null) {&#10;            UpdateTaskDialog(&#10;                currentTask!!,&#10;                onConfirm = {&#10;                    scope.launch {&#10;                        taskApi.updateTask(it)&#10;                        tasks = taskApi.getAllTasks()&#10;                    }&#10;                    currentTask = null&#10;                }&#10;            )&#10;        }&#10;&#10;        LazyColumn(modifier = Modifier&#10;            .safeContentPadding()&#10;            .fillMaxSize()&#10;        ) {&#10;            items(tasks) { task -&gt;&#10;                TaskCard(&#10;                    task,&#10;                    onDelete = {&#10;                        scope.launch {&#10;                            taskApi.removeTask(it)&#10;                            tasks = taskApi.getAllTasks()&#10;                        }&#10;                    },&#10;                    onUpdate = {&#10;                        currentTask = task&#10;                    }&#10;                )&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                선택된 현재 할 일을 저장하기 위해 추가적인 상태(state)를 관리합니다. 이 값이 null이 아니면 <code>UpdateTaskDialog</code> Composable을 호출하고, <code>onConfirm()</code> 콜백이 <code>TaskApi</code>를 사용하여 서버에 POST 요청을 보내도록 설정합니다.
+            </p>
+            <p>
+                마지막으로 <code>TaskCard</code> Composable을 생성할 때 <code>onUpdate()</code> 콜백을 사용하여 <code>currentTask</code> 상태 변수를 설정합니다.
+            </p>
+        </step>
+        <step>
+            클라이언트 애플리케이션을 다시 실행합니다. 이제 버튼을 사용하여 각 할 일의 세부 정보를 업데이트할 수 있습니다.
+            <img style="block" src="full_stack_development_tutorial_update_task.gif"
+                 alt="Android에서 할 일 삭제하기" width="350" border-effect="rounded"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="다음 단계" id="next-steps">
+    <p>
+        이 문서에서는 Kotlin Multiplatform 애플리케이션의 맥락 내에서 Ktor를 사용해 보았습니다. 이제 다양한 플랫폼을 대상으로 하는 여러 서비스와 클라이언트가 포함된 프로젝트를 만들 수 있습니다.
+    </p>
+    <p>
+        살펴보았듯이 코드 중복이나 낭비 없이 기능을 구축할 수 있습니다. 프로젝트의 모든 계층에서 필요한 타입은
+        <Path>core</Path> 멀티플랫폼 모듈에 배치할 수 있습니다. 서비스에만 필요한 기능은
+        <Path>server</Path> 모듈에, 클라이언트에만 필요한 기능은
+        <Path>app</Path> 모듈에 배치합니다.
+    </p>
+    <p>
+        이러한 방식의 개발은 클라이언트와 서버 기술 모두에 대한 지식이 필요합니다. 하지만 <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">Kotlin Multiplatform</a> 라이브러리와 <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a>을 사용하면 새로 배워야 할 내용의 양을 최소화할 수 있습니다. 처음에는 단일 플랫폼에만 집중하더라도 애플리케이션에 대한 수요가 늘어남에 따라 다른 플랫폼을 쉽게 추가할 수 있습니다.
+    </p>
+</chapter>
+</topic>

--- a/docs/ko/ktor/migration-from-express-js.md
+++ b/docs/ko/ktor/migration-from-express-js.md
@@ -16,110 +16,102 @@
 </p>
 <chapter title="애플리케이션 생성" id="generate">
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
-                    <code>express-generator</code> 도구를 사용하여 새로운 Express 애플리케이션을 생성할 수 있습니다:
+<control>Express</control>
+</td>
+<td>
+<p>
+<code>express-generator</code> 도구를 사용하여 새로운 Express 애플리케이션을 생성할 수 있습니다:
                 </p>
-                <code-block lang="shell" code="                        npx express-generator"/>
-            </td>
+<code-block lang="shell" code="                        npx express-generator"/>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor는 애플리케이션 스켈레톤을 생성하는 다음과 같은 방법들을 제공합니다:
                 </p>
-                <list>
-                    <li>
-                        <p>
-                            <a href="https://start.ktor.io/">Ktor Project Generator</a> — 웹 기반 생성기를 사용합니다.
+<list>
+<li>
+<p>
+<a href="https://start.ktor.io/">Ktor Project Generator</a> — 웹 기반 생성기를 사용합니다.
                         </p>
-                    </li>
-                    <li>
-                        <p>
-                            <a href="https://github.com/ktorio/ktor-cli">
+</li>
+<li>
+<p>
+<a href="https://github.com/ktorio/ktor-cli">
                                 Ktor CLI 도구
                             </a> — <code>ktor new</code> 명령어를 통해 커맨드 라인 인터페이스에서 Ktor 프로젝트를 생성합니다:
                         </p>
-                        <code-block lang="shell" code="                                ktor new ktor-sample"/>
-                    </li>
-                    <li>
-                        <p>
-                            <a href="https://www.npmjs.com/package/generator-ktor">
+<code-block lang="shell" code="                                ktor new ktor-sample"/>
+</li>
+<li>
+<p>
+<a href="https://www.npmjs.com/package/generator-ktor">
                                 Yeoman generator
                             </a>
                             — 대화형으로 프로젝트 설정을 구성하고 필요한 플러그인을 선택합니다:
                         </p>
-                        <code-block lang="shell" code="                                yo ktor"/>
-                    </li>
-                    <li>
-                        <p>
-                            <a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 내장된 Ktor 프로젝트 마법사를 사용합니다.
+<code-block lang="shell" code="                                yo ktor"/>
+</li>
+<li>
+<p>
+<a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 내장된 Ktor 프로젝트 마법사를 사용합니다.
                         </p>
-                    </li>
-                </list>
-                <p>
+</li>
+</list>
+<p>
                     자세한 지침은 <Links href="//server-create-a-new-project" summary="Learn how to open, run and test a server application with Ktor.">새로운 Ktor 프로젝트 생성, 열기 및 실행</Links> 튜토리얼을 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="Hello world" id="hello">
     <p>
         이 섹션에서는 <code>GET</code> 요청을 수락하고 미리 정의된 평문 텍스트로 응답하는 가장 간단한 서버 애플리케이션을 만드는 방법을 살펴보겠습니다.
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     아래 예제는 서버를 시작하고 <control>3000</control> 포트에서 연결을 리스닝하는 Express 애플리케이션을 보여줍니다.
                 </p>
-                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor에서는 코드 내에서 서버 파라미터를 구성하고 애플리케이션을 빠르게 실행하기 위해 <a href="#embedded-server">embeddedServer</a> 함수를 사용할 수 있습니다.
                 </p>
-                <code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
-                <p>
+<code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a>
                     프로젝트를 참조하세요.
                 </p>
-                <p>
+<p>
                     HOCON 또는 YAML 형식을 사용하는 <a href="#engine-main">외부 구성 파일</a>에서 서버 설정을 지정할 수도 있습니다.
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         위의 Express 애플리케이션은 다음과 같은 <control>Date</control>, <control>X-Powered-By</control>, <control>ETag</control> 응답 헤더를 추가할 수 있습니다:
     </p>
@@ -134,43 +126,39 @@
     </p>
     <code-block code="            public&#10;            ├── index.html&#10;            ├── ktor_logo.png&#10;            ├── css&#10;            │   └──styles.css&#10;            └── js&#10;                └── script.js"/>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     Express에서는 <control>express.static</control> 함수에 폴더 이름을 전달합니다.
                 </p>
-                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor에서는 <a href="#folders"><code>staticFiles()</code></a> 함수를 사용하여 <Path>/</Path> 경로로 들어오는 모든 요청을 <Path>public</Path> 물리 폴더로 매핑합니다. 이 함수는 <Path>public</Path> 폴더의 모든 파일을 재귀적으로 제공할 수 있게 합니다.
                 </p>
-                <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
-                <p>
+<code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
+<p>
                     전체 예제는 <a
                         href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         정적 콘텐츠를 제공할 때 Express는 다음과 같은 몇 가지 응답 헤더를 추가합니다:
     </p>
@@ -207,138 +195,126 @@
         <Links href="//server-routing" summary="Routing is a core plugin for handling incoming requests in a server application.">라우팅</Links>은 특정 HTTP 요청 메서드(<code>GET</code>, <code>POST</code> 등)와 경로로 정의된 특정 엔드포인트로 들어오는 요청을 처리할 수 있게 해줍니다. 아래 예제는 <Path>/</Path> 경로로 들어오는 <code>GET</code> 및 <code>POST</code> 요청을 처리하는 방법을 보여줍니다.
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
-                <tip>
-                    <p>
-                        <code>POST</code>, <code>PUT</code>, 또는 <code>PATCH</code> 요청의 요청 본문을 수신하는 방법은 <a href="#receive-request">요청 수신하기</a>를 참조하세요.
+<control>Ktor</control>
+</td>
+<td>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
+<tip>
+<p>
+<code>POST</code>, <code>PUT</code>, 또는 <code>PATCH</code> 요청의 요청 본문을 수신하는 방법은 <a href="#receive-request">요청 수신하기</a>를 참조하세요.
                     </p>
-                </tip>
-                <p>
+</tip>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         다음 예제는 경로별로 라우트 핸들러를 그룹화하는 방법을 보여줍니다.
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     Express에서는 <code>app.route()</code>를 사용하여 라우트 경로에 대해 체이닝 가능한 라우트 핸들러를 만들 수 있습니다.
                 </p>
-                <code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
-                <p>
+<code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor는 <code>route</code> 함수를 제공하며, 여기서 경로를 정의한 다음 해당 경로에 대한 메서드들을 중첩된 함수로 배치할 수 있습니다.
                 </p>
-                <code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
-                <p>
+<code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         두 프레임워크 모두 단일 파일에서 관련 라우트를 그룹화할 수 있습니다.
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     Express는 마운트 가능한 라우트 핸들러를 만들기 위해 <code>express.Router</code> 클래스를 제공합니다. 애플리케이션 디렉토리에 <Path>birds.js</Path> 라우터 파일이 있다고 가정해 봅시다. 이 라우터 모듈은 <Path>app.js</Path>에서 보여주는 것처럼 애플리케이션에 로드될 수 있습니다:
                 </p>
-                <Tabs>
-                    <TabItem title="birds.js">
-                        <code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
-                    </TabItem>
-                    <TabItem title="app.js">
-                        <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                    </TabItem>
-                </Tabs>
-                <p>
+<Tabs>
+<TabItem title="birds.js">
+<code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
+</TabItem>
+<TabItem title="app.js">
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+</TabItem>
+</Tabs>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor에서 일반적인 패턴은 <code>Routing</code> 타입에 대한 확장 함수를 사용하여 실제 라우트를 정의하는 것입니다. 아래 샘플(<Path>Birds.kt</Path>)은 <code>birdsRoutes</code> 확장 함수를 정의합니다. <code>routing</code> 블록 내에서 이 함수를 호출하여 해당 라우트를 애플리케이션(<Path>Application.kt</Path>)에 포함할 수 있습니다:
                 </p>
-                <Tabs>
-                    <TabItem title="Birds.kt" id="birds-kt">
-                        <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
-                    </TabItem>
-                    <TabItem title="Application.kt" id="application-kt">
-                        <code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
-                    </TabItem>
-                </Tabs>
-                <p>
+<Tabs>
+<TabItem title="Birds.kt" id="birds-kt">
+<code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
+</TabItem>
+<TabItem title="Application.kt" id="application-kt">
+<code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
+</TabItem>
+</Tabs>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         URL 경로를 문자열로 지정하는 것 외에도, Ktor는 <Links href="//server-resources" summary="The Resources plugin allows you to implement type-safe routing.">타입 세이프 라우트</Links>를 구현하는 기능을 포함하고 있습니다.
     </p>
@@ -351,84 +327,76 @@
         라우트(또는 경로) 파라미터는 URL에서 해당 위치에 지정된 값을 캡처하는 데 사용되는 명명된 URL 세그먼트입니다.
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     Express에서 라우트 파라미터에 접근하려면 <code>Request.params</code>를 사용할 수 있습니다. 예를 들어, 아래 코드 스니펫의 <code>req.parameters["login"]</code>은 <Path>/user/admin</Path> 경로에 대해 <emphasis>admin</emphasis>을 반환합니다:
                 </p>
-                <code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
-                <p>
+<code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor에서 라우트 파라미터는 <code>{param}</code> 구문을 사용하여 정의됩니다. 라우트 핸들러에서 라우트 파라미터에 접근하려면 <code>call.parameters</code>를 사용할 수 있습니다:
                 </p>
-                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
-                <p>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         아래 표는 쿼리 스트링의 파라미터에 접근하는 방법을 비교합니다.
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     Express에서 라우트 파라미터에 접근하려면 <code>Request.params</code>를 사용할 수 있습니다. 예를 들어, 아래 코드 스니펫의 <code>req.parameters["login"]</code>은 <Path>/user/admin</Path> 경로에 대해 <emphasis>admin</emphasis>을 반환합니다:
                 </p>
-                <code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
-                <p>
+<code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor에서 라우트 파라미터는 <code>{param}</code> 구문을 사용하여 정의됩니다. 라우트 핸들러에서 라우트 파라미터에 접근하려면 <code>call.parameters</code>를 사용할 수 있습니다:
                 </p>
-                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
-                <p>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="응답 보내기" id="send-response">
     <p>
@@ -436,174 +404,158 @@
     </p>
     <chapter title="JSON" id="send-json">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express에서 적절한 콘텐츠 타입으로 JSON 응답을 보내려면 <code>res.json</code> 함수를 호출합니다:
                     </p>
-                    <code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor에서는 <Links href="//server-serialization" summary="The ContentNegotiation plugin serves two primary purposes: negotiating media types between the client and server and serializing/deserializing the content in a specific format.">ContentNegotiation</Links> 플러그인을 설치하고 JSON 직렬화 도구를 구성해야 합니다:
                     </p>
-                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
-                    <p>
+<code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
+<p>
                         데이터를 JSON으로 직렬화하려면 <code>@Serializable</code> 어노테이션이 있는 데이터 클래스를 만들어야 합니다:
                     </p>
-                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
-                    <p>
+<code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+<p>
                         그런 다음, <code>call.respond</code>를 사용하여 이 클래스의 객체를 응답으로 보낼 수 있습니다:
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="파일" id="send-file">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express에서 파일로 응답하려면 <code>res.sendFile</code>을 사용합니다:
                     </p>
-                    <code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor는 클라이언트에 파일을 전송하기 위해 <code>call.respondFile</code> 함수를 제공합니다:
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
         <p>
             Express 애플리케이션은 파일로 응답할 때 <control>Accept-Ranges</control> HTTP 응답 헤더를 추가합니다. 서버는 파일 다운로드를 위한 클라이언트의 부분 요청(partial requests) 지원을 알리기 위해 이 헤더를 사용합니다. Ktor에서 부분 요청을 지원하려면 <Links href="//server-partial-content" summary="Required dependencies: io.ktor:%artifact_name% Server example: download-file, client example: client-download-file-range">PartialContent</Links> 플러그인을 설치해야 합니다.
         </p>
     </chapter>
     <chapter title="파일 첨부" id="send-file-attachment">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
-                        <code>res.download</code> 함수는 지정된 파일을 첨부 파일로 전송합니다:
+<control>Express</control>
+</td>
+<td>
+<p>
+<code>res.download</code> 함수는 지정된 파일을 첨부 파일로 전송합니다:
                     </p>
-                    <code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor에서는 파일을 첨부 파일로 전송하기 위해 <control>Content-Disposition</control> 헤더를 수동으로 구성해야 합니다:
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="리다이렉트" id="redirect">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express에서 리다이렉션 응답을 생성하려면 <code>redirect</code> 함수를 호출합니다:
                     </p>
-                    <code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor에서는 <code>respondRedirect</code>를 사용하여 리다이렉션 응답을 보냅니다:
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
 </chapter>
 <chapter title="템플릿" id="templates">
@@ -611,47 +563,43 @@
         Express와 Ktor 모두 뷰 작업을 위한 템플릿 엔진을 사용할 수 있습니다.
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
-                    <Path>views</Path> 폴더에 다음과 같은 Pug 템플릿이 있다고 가정해 봅시다:
+<control>Express</control>
+</td>
+<td>
+<p>
+<Path>views</Path> 폴더에 다음과 같은 Pug 템플릿이 있다고 가정해 봅시다:
                 </p>
-                <code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
-                <p>
+<code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
+<p>
                     이 템플릿으로 응답하려면 <code>res.render</code>를 호출합니다:
                 </p>
-                <code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
-                <p>
+<code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor는 FreeMarker, Velocity 등 여러 <Links href="//server-templating" summary="Learn how to work with views built with HTML/CSS or JVM template engines.">JVM 템플릿 엔진</Links>을 지원합니다. 예를 들어, 애플리케이션 리소스에 배치된 FreeMarker 템플릿으로 응답해야 하는 경우, <code>FreeMarker</code> 플러그인을 설치 및 구성한 다음 <code>call.respond</code>를 사용하여 템플릿을 전송합니다:
                 </p>
-                <code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
-                <p>
+<code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="요청 수신하기" id="receive-request">
     <p>
@@ -666,47 +614,43 @@
             서버 측에서 이 요청의 본문을 평문 텍스트로 수신하는 방법을 살펴보겠습니다.
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express에서 들어오는 요청 본문을 파싱하려면 <code>body-parser</code>를 추가해야 합니다:
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
-                    <p>
-                        <code>post</code> 핸들러에서 텍스트 파서(<code>bodyParser.text</code>)를 전달해야 합니다. 요청 본문은 <code>req.body</code> 속성을 통해 사용할 수 있습니다:
+<code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
+<p>
+<code>post</code> 핸들러에서 텍스트 파서(<code>bodyParser.text</code>)를 전달해야 합니다. 요청 본문은 <code>req.body</code> 속성을 통해 사용할 수 있습니다:
                     </p>
-                    <code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor에서는 <code>call.receiveText</code>를 사용하여 본문을 텍스트로 수신할 수 있습니다:
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="JSON" id="receive-json">
         <p>
@@ -714,51 +658,47 @@
         </p>
         <code-block lang="http" code="POST http://0.0.0.0:3000/json&#10;Content-Type: application/json&#10;&#10;{&#10;  &quot;type&quot;: &quot;Fiat&quot;,&#10;  &quot;model&quot; : &quot;500&quot;,&#10;  &quot;color&quot;: &quot;white&quot;&#10;}"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express에서 JSON을 수신하려면 <code>bodyParser.json</code>을 사용합니다:
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor에서는 <Links href="//server-serialization" summary="The ContentNegotiation plugin serves two primary purposes: negotiating media types between the client and server and serializing/deserializing the content in a specific format.">ContentNegotiation</Links> 플러그인을 설치하고 <code>Json</code> 직렬화 도구를 구성해야 합니다:
                     </p>
-                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
-                    <p>
+<code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
+<p>
                         수신된 데이터를 객체로 역직렬화하려면 데이터 클래스를 생성해야 합니다:
                     </p>
-                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
-                    <p>
+<code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+<p>
                         그런 다음, 이 데이터 클래스를 파라미터로 받는 <code>receive</code> 메서드를 사용합니다:
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="URL-encoded" id="receive-url-encoded">
         <p>
@@ -766,43 +706,39 @@
         </p>
         <code-block lang="http" code="POST http://localhost:3000/urlencoded&#10;Content-Type: application/x-www-form-urlencoded&#10;&#10;username=JetBrains&amp;email=example@jetbrains.com&amp;password=foobar&amp;confirmation=foobar"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         평문 텍스트 및 JSON과 마찬가지로, Express에는 <code>body-parser</code>가 필요합니다. 파서 타입을 <code>bodyParser.urlencoded</code>로 설정해야 합니다:
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor에서는 <code>call.receiveParameters</code> 함수를 사용합니다:
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="Raw 데이터" id="receive-raw-data">
         <p>
@@ -810,44 +746,40 @@
         </p>
         <code-block lang="http" code="POST http://localhost:3000/raw&#10;Content-Type: application/octet-stream&#10;&#10;&lt; ./ktor_logo.png"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express에서 바이너리 데이터를 처리하려면 파서 타입을 <code>raw</code>로 설정합니다:
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor는 바이트 시퀀스를 비동기적으로 읽고 쓰기 위해 <code>ByteReadChannel</code> 및 <code>ByteWriteChannel</code>을 제공합니다:
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive
                             request</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-    </table>
+</table>
     </chapter>
     <chapter title="멀티파트" id="receive-multipart">
         <p>
@@ -855,43 +787,39 @@
         </p>
         <code-block lang="http" code="POST http://localhost:3000/multipart&#10;Content-Type: multipart/form-data; boundary=WebAppBoundary&#10;&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;description&quot;&#10;Content-Type: text/plain&#10;&#10;Ktor logo&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;image&quot;; filename=&quot;ktor_logo.png&quot;&#10;Content-Type: image/png&#10;&#10;&lt; ./ktor_logo.png&#10;--WebAppBoundary--"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express에서는 멀티파트 데이터를 파싱하기 위해 별도의 모듈이 필요합니다. 아래 예제에서는 서버에 파일을 업로드하기 위해 <control>multer</control>를 사용합니다:
                     </p>
-                    <code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor에서 멀티파트 요청의 일부로 전송된 파일을 수신해야 하는 경우, <code>receiveMultipart</code> 함수를 호출한 다음 필요에 따라 각 파트를 순회합니다. 아래 예제에서는 파일을 바이트 스트림으로 수신하기 위해 <code>PartData.FileItem</code>을 사용합니다:
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
+<p>
                         전체 예제는
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         프로젝트를 참조하세요.
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
 </chapter>
 <chapter title="미들웨어 생성" id="middleware">
@@ -899,43 +827,39 @@
         마지막으로 살펴볼 내용은 서버 기능을 확장할 수 있는 미들웨어를 만드는 방법입니다. 아래 예제는 Express와 Ktor를 사용하여 요청 로깅을 구현하는 방법을 보여줍니다.
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     Express에서 미들웨어는 <code>app.use</code>를 사용하여 애플리케이션에 바인딩된 함수입니다:
                 </p>
-                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
-                <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor는 <Links href="//server-custom-plugins" summary="Learn how to create your own custom plugins.">커스텀 플러그인</Links>을 사용하여 기능을 확장할 수 있습니다. 아래 코드 예제는 요청 로깅을 구현하기 위해 <code>onCall</code>을 처리하는 방법을 보여줍니다:
                 </p>
-                <code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
-                <p>
+<code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
+<p>
                     전체 예제는
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a>
                     프로젝트를 참조하세요.
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="다음 단계" id="next">
     <p>

--- a/docs/ko/ktor/migration-from-express-js.md
+++ b/docs/ko/ktor/migration-from-express-js.md
@@ -1,0 +1,945 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="Express에서 Ktor로 마이그레이션하기"
+       id="migration-from-express-js" help-id="express-js;migrating-from-express-js">
+<show-structure for="chapter" depth="2"/>
+<link-summary>이 가이드는 간단한 Ktor 애플리케이션을 생성하고 실행 및 테스트하는 방법을 설명합니다.</link-summary>
+<tldr>
+    <p>
+        <b>코드 예제</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express">migrating-express</a>
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor">migrating-express-ktor</a>
+    </p>
+</tldr>
+<p>
+    이 가이드에서는 애플리케이션 생성과 첫 번째 애플리케이션 작성부터 애플리케이션 기능을 확장하기 위한 미들웨어 생성에 이르기까지, 기본적인 시나리오에서 Express 애플리케이션을 Ktor로 마이그레이션하는 방법을 살펴보겠습니다.
+</p>
+<chapter title="애플리케이션 생성" id="generate">
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    <code>express-generator</code> 도구를 사용하여 새로운 Express 애플리케이션을 생성할 수 있습니다:
+                </p>
+                <code-block lang="shell" code="                        npx express-generator"/>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor는 애플리케이션 스켈레톤을 생성하는 다음과 같은 방법들을 제공합니다:
+                </p>
+                <list>
+                    <li>
+                        <p>
+                            <a href="https://start.ktor.io/">Ktor Project Generator</a> — 웹 기반 생성기를 사용합니다.
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <a href="https://github.com/ktorio/ktor-cli">
+                                Ktor CLI 도구
+                            </a> — <code>ktor new</code> 명령어를 통해 커맨드 라인 인터페이스에서 Ktor 프로젝트를 생성합니다:
+                        </p>
+                        <code-block lang="shell" code="                                ktor new ktor-sample"/>
+                    </li>
+                    <li>
+                        <p>
+                            <a href="https://www.npmjs.com/package/generator-ktor">
+                                Yeoman generator
+                            </a>
+                            — 대화형으로 프로젝트 설정을 구성하고 필요한 플러그인을 선택합니다:
+                        </p>
+                        <code-block lang="shell" code="                                yo ktor"/>
+                    </li>
+                    <li>
+                        <p>
+                            <a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 내장된 Ktor 프로젝트 마법사를 사용합니다.
+                        </p>
+                    </li>
+                </list>
+                <p>
+                    자세한 지침은 <Links href="//server-create-a-new-project" summary="Learn how to open, run and test a server application with Ktor.">새로운 Ktor 프로젝트 생성, 열기 및 실행</Links> 튜토리얼을 참조하세요.
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="Hello world" id="hello">
+    <p>
+        이 섹션에서는 <code>GET</code> 요청을 수락하고 미리 정의된 평문 텍스트로 응답하는 가장 간단한 서버 애플리케이션을 만드는 방법을 살펴보겠습니다.
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    아래 예제는 서버를 시작하고 <control>3000</control> 포트에서 연결을 리스닝하는 Express 애플리케이션을 보여줍니다.
+                </p>
+                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor에서는 코드 내에서 서버 파라미터를 구성하고 애플리케이션을 빠르게 실행하기 위해 <a href="#embedded-server">embeddedServer</a> 함수를 사용할 수 있습니다.
+                </p>
+                <code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a>
+                    프로젝트를 참조하세요.
+                </p>
+                <p>
+                    HOCON 또는 YAML 형식을 사용하는 <a href="#engine-main">외부 구성 파일</a>에서 서버 설정을 지정할 수도 있습니다.
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        위의 Express 애플리케이션은 다음과 같은 <control>Date</control>, <control>X-Powered-By</control>, <control>ETag</control> 응답 헤더를 추가할 수 있습니다:
+    </p>
+    <code-block code="            Date: Fri, 05 Aug 2022 06:30:48 GMT&#10;            X-Powered-By: Express&#10;            ETag: W/&quot;c-Lve95gjOVATpfV8EL5X4nxwjKHE&quot;"/>
+    <p>
+        Ktor에서 각 응답에 기본 <control>Server</control> 및 <control>Date</control> 헤더를 추가하려면 <Links href="//server-default-headers" summary="Required dependencies: io.ktor:%artifact_name%">DefaultHeaders</Links> 플러그인을 설치해야 합니다. <Links href="//server-conditional-headers" summary="Required dependencies: io.ktor:%artifact_name%">ConditionalHeaders</Links> 플러그인은 <control>Etag</control> 응답 헤더를 구성하는 데 사용할 수 있습니다.
+    </p>
+</chapter>
+<chapter title="정적 콘텐츠 제공" id="static">
+    <p>
+        이 섹션에서는 Express와 Ktor에서 이미지, CSS 파일, JavaScript 파일과 같은 정적 파일을 제공하는 방법을 살펴보겠습니다. 메인 <Path>index.html</Path> 페이지와 연결된 에셋들이 포함된 <Path>public</Path> 폴더가 있다고 가정해 봅시다.
+    </p>
+    <code-block code="            public&#10;            ├── index.html&#10;            ├── ktor_logo.png&#10;            ├── css&#10;            │   └──styles.css&#10;            └── js&#10;                └── script.js"/>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    Express에서는 <control>express.static</control> 함수에 폴더 이름을 전달합니다.
+                </p>
+                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor에서는 <a href="#folders"><code>staticFiles()</code></a> 함수를 사용하여 <Path>/</Path> 경로로 들어오는 모든 요청을 <Path>public</Path> 물리 폴더로 매핑합니다. 이 함수는 <Path>public</Path> 폴더의 모든 파일을 재귀적으로 제공할 수 있게 합니다.
+                </p>
+                <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
+                <p>
+                    전체 예제는 <a
+                        href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        정적 콘텐츠를 제공할 때 Express는 다음과 같은 몇 가지 응답 헤더를 추가합니다:
+    </p>
+    <code-block code="            Accept-Ranges: bytes&#10;            Cache-Control: public, max-age=0&#10;            ETag: W/&quot;181-1823feafeb1&quot;&#10;            Last-Modified: Wed, 27 Jul 2022 13:49:01 GMT"/>
+    <p>
+        Ktor에서 이러한 헤더를 관리하려면 다음 플러그인들을 설치해야 합니다:
+    </p>
+    <list>
+        <li>
+            <p>
+                <control>Accept-Ranges</control>
+                : <Links href="//server-partial-content" summary="Required dependencies: io.ktor:%artifact_name% Server example: download-file, client example: client-download-file-range">PartialContent</Links>
+            </p>
+        </li>
+        <li>
+            <p>
+                <control>Cache-Control</control>
+                : <Links href="//server-caching-headers" summary="Required dependencies: io.ktor:%artifact_name%">CachingHeaders</Links>
+            </p>
+        </li>
+        <li>
+            <p>
+                <control>ETag</control>
+                및
+                <control>Last-Modified</control>
+                :
+                <Links href="//server-conditional-headers" summary="Required dependencies: io.ktor:%artifact_name%">ConditionalHeaders</Links>
+            </p>
+        </li>
+    </list>
+</chapter>
+<chapter title="라우팅" id="routing">
+    <p>
+        <Links href="//server-routing" summary="Routing is a core plugin for handling incoming requests in a server application.">라우팅</Links>은 특정 HTTP 요청 메서드(<code>GET</code>, <code>POST</code> 등)와 경로로 정의된 특정 엔드포인트로 들어오는 요청을 처리할 수 있게 해줍니다. 아래 예제는 <Path>/</Path> 경로로 들어오는 <code>GET</code> 및 <code>POST</code> 요청을 처리하는 방법을 보여줍니다.
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
+                <tip>
+                    <p>
+                        <code>POST</code>, <code>PUT</code>, 또는 <code>PATCH</code> 요청의 요청 본문을 수신하는 방법은 <a href="#receive-request">요청 수신하기</a>를 참조하세요.
+                    </p>
+                </tip>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        다음 예제는 경로별로 라우트 핸들러를 그룹화하는 방법을 보여줍니다.
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    Express에서는 <code>app.route()</code>를 사용하여 라우트 경로에 대해 체이닝 가능한 라우트 핸들러를 만들 수 있습니다.
+                </p>
+                <code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor는 <code>route</code> 함수를 제공하며, 여기서 경로를 정의한 다음 해당 경로에 대한 메서드들을 중첩된 함수로 배치할 수 있습니다.
+                </p>
+                <code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        두 프레임워크 모두 단일 파일에서 관련 라우트를 그룹화할 수 있습니다.
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    Express는 마운트 가능한 라우트 핸들러를 만들기 위해 <code>express.Router</code> 클래스를 제공합니다. 애플리케이션 디렉토리에 <Path>birds.js</Path> 라우터 파일이 있다고 가정해 봅시다. 이 라우터 모듈은 <Path>app.js</Path>에서 보여주는 것처럼 애플리케이션에 로드될 수 있습니다:
+                </p>
+                <Tabs>
+                    <TabItem title="birds.js">
+                        <code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
+                    </TabItem>
+                    <TabItem title="app.js">
+                        <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor에서 일반적인 패턴은 <code>Routing</code> 타입에 대한 확장 함수를 사용하여 실제 라우트를 정의하는 것입니다. 아래 샘플(<Path>Birds.kt</Path>)은 <code>birdsRoutes</code> 확장 함수를 정의합니다. <code>routing</code> 블록 내에서 이 함수를 호출하여 해당 라우트를 애플리케이션(<Path>Application.kt</Path>)에 포함할 수 있습니다:
+                </p>
+                <Tabs>
+                    <TabItem title="Birds.kt" id="birds-kt">
+                        <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
+                    </TabItem>
+                    <TabItem title="Application.kt" id="application-kt">
+                        <code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        URL 경로를 문자열로 지정하는 것 외에도, Ktor는 <Links href="//server-resources" summary="The Resources plugin allows you to implement type-safe routing.">타입 세이프 라우트</Links>를 구현하는 기능을 포함하고 있습니다.
+    </p>
+</chapter>
+<chapter title="라우트 및 쿼리 파라미터" id="route-query-param">
+    <p>
+        이 섹션에서는 라우트 및 쿼리 파라미터에 접근하는 방법을 보여줍니다.
+    </p>
+    <p>
+        라우트(또는 경로) 파라미터는 URL에서 해당 위치에 지정된 값을 캡처하는 데 사용되는 명명된 URL 세그먼트입니다.
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    Express에서 라우트 파라미터에 접근하려면 <code>Request.params</code>를 사용할 수 있습니다. 예를 들어, 아래 코드 스니펫의 <code>req.parameters["login"]</code>은 <Path>/user/admin</Path> 경로에 대해 <emphasis>admin</emphasis>을 반환합니다:
+                </p>
+                <code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor에서 라우트 파라미터는 <code>{param}</code> 구문을 사용하여 정의됩니다. 라우트 핸들러에서 라우트 파라미터에 접근하려면 <code>call.parameters</code>를 사용할 수 있습니다:
+                </p>
+                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        아래 표는 쿼리 스트링의 파라미터에 접근하는 방법을 비교합니다.
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    Express에서 라우트 파라미터에 접근하려면 <code>Request.params</code>를 사용할 수 있습니다. 예를 들어, 아래 코드 스니펫의 <code>req.parameters["login"]</code>은 <Path>/user/admin</Path> 경로에 대해 <emphasis>admin</emphasis>을 반환합니다:
+                </p>
+                <code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor에서 라우트 파라미터는 <code>{param}</code> 구문을 사용하여 정의됩니다. 라우트 핸들러에서 라우트 파라미터에 접근하려면 <code>call.parameters</code>를 사용할 수 있습니다:
+                </p>
+                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="응답 보내기" id="send-response">
+    <p>
+        이전 섹션들에서 평문 텍스트 콘텐츠로 응답하는 방법을 이미 살펴보았습니다. 이제 JSON, 파일 및 리다이렉션 응답을 보내는 방법을 살펴보겠습니다.
+    </p>
+    <chapter title="JSON" id="send-json">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express에서 적절한 콘텐츠 타입으로 JSON 응답을 보내려면 <code>res.json</code> 함수를 호출합니다:
+                    </p>
+                    <code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor에서는 <Links href="//server-serialization" summary="The ContentNegotiation plugin serves two primary purposes: negotiating media types between the client and server and serializing/deserializing the content in a specific format.">ContentNegotiation</Links> 플러그인을 설치하고 JSON 직렬화 도구를 구성해야 합니다:
+                    </p>
+                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
+                    <p>
+                        데이터를 JSON으로 직렬화하려면 <code>@Serializable</code> 어노테이션이 있는 데이터 클래스를 만들어야 합니다:
+                    </p>
+                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+                    <p>
+                        그런 다음, <code>call.respond</code>를 사용하여 이 클래스의 객체를 응답으로 보낼 수 있습니다:
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="파일" id="send-file">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express에서 파일로 응답하려면 <code>res.sendFile</code>을 사용합니다:
+                    </p>
+                    <code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor는 클라이언트에 파일을 전송하기 위해 <code>call.respondFile</code> 함수를 제공합니다:
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+        </table>
+        <p>
+            Express 애플리케이션은 파일로 응답할 때 <control>Accept-Ranges</control> HTTP 응답 헤더를 추가합니다. 서버는 파일 다운로드를 위한 클라이언트의 부분 요청(partial requests) 지원을 알리기 위해 이 헤더를 사용합니다. Ktor에서 부분 요청을 지원하려면 <Links href="//server-partial-content" summary="Required dependencies: io.ktor:%artifact_name% Server example: download-file, client example: client-download-file-range">PartialContent</Links> 플러그인을 설치해야 합니다.
+        </p>
+    </chapter>
+    <chapter title="파일 첨부" id="send-file-attachment">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        <code>res.download</code> 함수는 지정된 파일을 첨부 파일로 전송합니다:
+                    </p>
+                    <code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor에서는 파일을 첨부 파일로 전송하기 위해 <control>Content-Disposition</control> 헤더를 수동으로 구성해야 합니다:
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="리다이렉트" id="redirect">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express에서 리다이렉션 응답을 생성하려면 <code>redirect</code> 함수를 호출합니다:
+                    </p>
+                    <code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor에서는 <code>respondRedirect</code>를 사용하여 리다이렉션 응답을 보냅니다:
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+</chapter>
+<chapter title="템플릿" id="templates">
+    <p>
+        Express와 Ktor 모두 뷰 작업을 위한 템플릿 엔진을 사용할 수 있습니다.
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    <Path>views</Path> 폴더에 다음과 같은 Pug 템플릿이 있다고 가정해 봅시다:
+                </p>
+                <code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
+                <p>
+                    이 템플릿으로 응답하려면 <code>res.render</code>를 호출합니다:
+                </p>
+                <code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor는 FreeMarker, Velocity 등 여러 <Links href="//server-templating" summary="Learn how to work with views built with HTML/CSS or JVM template engines.">JVM 템플릿 엔진</Links>을 지원합니다. 예를 들어, 애플리케이션 리소스에 배치된 FreeMarker 템플릿으로 응답해야 하는 경우, <code>FreeMarker</code> 플러그인을 설치 및 구성한 다음 <code>call.respond</code>를 사용하여 템플릿을 전송합니다:
+                </p>
+                <code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="요청 수신하기" id="receive-request">
+    <p>
+        이 섹션에서는 다양한 형식의 요청 본문을 수신하는 방법을 보여줍니다.
+    </p>
+    <chapter title="Raw 텍스트" id="receive-raw-text">
+        <p>
+            아래 <code>POST</code> 요청은 서버로 텍스트 데이터를 보냅니다:
+        </p>
+        <code-block lang="http" code="POST http://0.0.0.0:3000/text&#10;Content-Type: text/plain&#10;&#10;Hello, world!"/>
+        <p>
+            서버 측에서 이 요청의 본문을 평문 텍스트로 수신하는 방법을 살펴보겠습니다.
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express에서 들어오는 요청 본문을 파싱하려면 <code>body-parser</code>를 추가해야 합니다:
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
+                    <p>
+                        <code>post</code> 핸들러에서 텍스트 파서(<code>bodyParser.text</code>)를 전달해야 합니다. 요청 본문은 <code>req.body</code> 속성을 통해 사용할 수 있습니다:
+                    </p>
+                    <code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor에서는 <code>call.receiveText</code>를 사용하여 본문을 텍스트로 수신할 수 있습니다:
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="JSON" id="receive-json">
+        <p>
+            이 섹션에서는 JSON 본문을 수신하는 방법을 살펴보겠습니다. 아래 샘플은 본문에 JSON 객체가 포함된 <code>POST</code> 요청을 보여줍니다:
+        </p>
+        <code-block lang="http" code="POST http://0.0.0.0:3000/json&#10;Content-Type: application/json&#10;&#10;{&#10;  &quot;type&quot;: &quot;Fiat&quot;,&#10;  &quot;model&quot; : &quot;500&quot;,&#10;  &quot;color&quot;: &quot;white&quot;&#10;}"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express에서 JSON을 수신하려면 <code>bodyParser.json</code>을 사용합니다:
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor에서는 <Links href="//server-serialization" summary="The ContentNegotiation plugin serves two primary purposes: negotiating media types between the client and server and serializing/deserializing the content in a specific format.">ContentNegotiation</Links> 플러그인을 설치하고 <code>Json</code> 직렬화 도구를 구성해야 합니다:
+                    </p>
+                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
+                    <p>
+                        수신된 데이터를 객체로 역직렬화하려면 데이터 클래스를 생성해야 합니다:
+                    </p>
+                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+                    <p>
+                        그런 다음, 이 데이터 클래스를 파라미터로 받는 <code>receive</code> 메서드를 사용합니다:
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="URL-encoded" id="receive-url-encoded">
+        <p>
+            이제 <control>application/x-www-form-urlencoded</control> 타입을 사용하여 전송된 폼 데이터를 수신하는 방법을 살펴보겠습니다. 아래 코드 스니펫은 폼 데이터가 포함된 샘플 <code>POST</code> 요청을 보여줍니다:
+        </p>
+        <code-block lang="http" code="POST http://localhost:3000/urlencoded&#10;Content-Type: application/x-www-form-urlencoded&#10;&#10;username=JetBrains&amp;email=example@jetbrains.com&amp;password=foobar&amp;confirmation=foobar"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        평문 텍스트 및 JSON과 마찬가지로, Express에는 <code>body-parser</code>가 필요합니다. 파서 타입을 <code>bodyParser.urlencoded</code>로 설정해야 합니다:
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor에서는 <code>call.receiveParameters</code> 함수를 사용합니다:
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="Raw 데이터" id="receive-raw-data">
+        <p>
+            다음 유스케이스는 바이너리 데이터를 처리하는 것입니다. 아래 요청은 <control>application/octet-stream</control> 타입을 사용하여 PNG 이미지를 서버로 보냅니다:
+        </p>
+        <code-block lang="http" code="POST http://localhost:3000/raw&#10;Content-Type: application/octet-stream&#10;&#10;&lt; ./ktor_logo.png"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express에서 바이너리 데이터를 처리하려면 파서 타입을 <code>raw</code>로 설정합니다:
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor는 바이트 시퀀스를 비동기적으로 읽고 쓰기 위해 <code>ByteReadChannel</code> 및 <code>ByteWriteChannel</code>을 제공합니다:
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive
+                            request</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+    </table>
+    </chapter>
+    <chapter title="멀티파트" id="receive-multipart">
+        <p>
+            마지막 섹션에서는 <emphasis>멀티파트(multipart)</emphasis> 본문을 처리하는 방법을 살펴보겠습니다. 아래 <code>POST</code> 요청은 <control>multipart/form-data</control> 타입을 사용하여 설명과 함께 PNG 이미지를 보냅니다:
+        </p>
+        <code-block lang="http" code="POST http://localhost:3000/multipart&#10;Content-Type: multipart/form-data; boundary=WebAppBoundary&#10;&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;description&quot;&#10;Content-Type: text/plain&#10;&#10;Ktor logo&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;image&quot;; filename=&quot;ktor_logo.png&quot;&#10;Content-Type: image/png&#10;&#10;&lt; ./ktor_logo.png&#10;--WebAppBoundary--"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express에서는 멀티파트 데이터를 파싱하기 위해 별도의 모듈이 필요합니다. 아래 예제에서는 서버에 파일을 업로드하기 위해 <control>multer</control>를 사용합니다:
+                    </p>
+                    <code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor에서 멀티파트 요청의 일부로 전송된 파일을 수신해야 하는 경우, <code>receiveMultipart</code> 함수를 호출한 다음 필요에 따라 각 파트를 순회합니다. 아래 예제에서는 파일을 바이트 스트림으로 수신하기 위해 <code>PartData.FileItem</code>을 사용합니다:
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
+                    <p>
+                        전체 예제는
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        프로젝트를 참조하세요.
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+</chapter>
+<chapter title="미들웨어 생성" id="middleware">
+    <p>
+        마지막으로 살펴볼 내용은 서버 기능을 확장할 수 있는 미들웨어를 만드는 방법입니다. 아래 예제는 Express와 Ktor를 사용하여 요청 로깅을 구현하는 방법을 보여줍니다.
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    Express에서 미들웨어는 <code>app.use</code>를 사용하여 애플리케이션에 바인딩된 함수입니다:
+                </p>
+                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor는 <Links href="//server-custom-plugins" summary="Learn how to create your own custom plugins.">커스텀 플러그인</Links>을 사용하여 기능을 확장할 수 있습니다. 아래 코드 예제는 요청 로깅을 구현하기 위해 <code>onCall</code>을 처리하는 방법을 보여줍니다:
+                </p>
+                <code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    전체 예제는
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a>
+                    프로젝트를 참조하세요.
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="다음 단계" id="next">
+    <p>
+        이 가이드에서 다루지 않은 세션 관리, 권한 부여, 데이터베이스 통합 등 더 많은 유스케이스가 있습니다. 이러한 대부분의 기능에 대해 Ktor는 애플리케이션에 설치하고 필요에 따라 구성할 수 있는 전용 플러그인을 제공합니다. Ktor에 대해 더 자세히 알아보려면 단계별 가이드와 바로 사용할 수 있는 샘플들을 제공하는 <control><a href="https://ktor.io/learn/">학습 페이지(Learn page)</a></control>를 방문해 보세요.
+    </p>
+</chapter>
+</topic>

--- a/docs/ko/ktor/server-auto-reload.md
+++ b/docs/ko/ktor/server-auto-reload.md
@@ -1,0 +1,182 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="오토 리로드(Auto-reload)"
+       id="server-auto-reload" help-id="Auto_reload">
+    <tldr>
+        <p>
+            <b>코드 예제</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>,
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-embedded-server">autoreload-embedded-server</a>
+        </p>
+    </tldr>
+    <link-summary>
+        코드 변경 시 애플리케이션 클래스를 다시 로드하기 위해 오토 리로드(Auto-reload)를 사용하는 방법을 알아봅니다.
+    </link-summary>
+    <p>
+        개발 중에 서버를 <Links href="//server-run" summary="Learn how to run a server Ktor application.">재시작</Links>하는 것은 다소 시간이 걸릴 수 있습니다.
+        Ktor는 코드 변경 시 애플리케이션 클래스를 다시 로드하고 빠른 피드백 루프를 제공하는 <emphasis>오토 리로드(Auto-reload)</emphasis>를 통해 이러한 제한을 극복할 수 있게 해줍니다.
+        오토 리로드를 사용하려면 다음 단계를 따르세요.
+    </p>
+    <list style="decimal">
+        <li>
+            <p>
+                <a href="#enable">개발 모드 활성화</a>
+            </p>
+        </li>
+        <li>
+            <p>
+                (선택 사항) <a href="#watch-paths">감시 경로(watch paths) 구성</a>
+            </p>
+        </li>
+        <li>
+            <p>
+                <a href="#recompile">변경 시 재컴파일 활성화</a>
+            </p>
+        </li>
+    </list>
+    <chapter title="제한 사항" id="limitations">
+        오토 리로드는 특정 모듈 선언에서만 작동합니다. 다음 표는 버전별 지원 여부를 보여줍니다.
+        <table>
+            
+<tr>
+<td>모듈 유형</td>
+                <td>&lt;= 3.2</td>
+                <td>&gt; 3.2</td>
+</tr>
+
+            
+<tr>
+<td>람다 초기화(Lambda initializer)</td>
+                <td>❌ 지원되지 않음</td>
+                <td>❌ 지원되지 않음</td>
+</tr>
+
+            
+<tr>
+<td>블로킹 함수 참조(Blocking function reference)</td>
+                <td>✅ 지원됨</td>
+                <td>❌ 지원되지 않음</td>
+</tr>
+
+            
+<tr>
+<td>서스펜드 함수 참조(Suspend function reference)</td>
+                <td>❌ 지원되지 않음</td>
+                <td>✅ 지원됨</td>
+</tr>
+
+            
+<tr>
+<td>설정 참조(Config reference)</td>
+                <td>✅ 지원됨</td>
+                <td>✅ 지원됨</td>
+</tr>
+
+        </table>
+        <chapter title="지원됨" id="supported">
+            <code-block lang="kotlin" code="                // Suspend function reference&#10;                embeddedServer(Netty, port = 8080, module = Application::mySuspendModule)&#10;&#10;                // Configuration reference&#10;                ktor {&#10;                    application {&#10;                        modules = [ com.example.ApplicationKt.mySuspendModule ]&#10;                    }&#10;                }"/>
+        </chapter>
+        <chapter title="지원되지 않음" id="not-supported">
+            <code-block lang="kotlin" code="                // Lambda&#10;                embeddedServer(Netty, port = 8080) { configureServer() }&#10;&#10;                // Blocking function reference&#10;                embeddedServer(Netty, port = 8080, module = Application::myBlockingModule)"/>
+        </chapter>
+    </chapter>
+    <chapter title="개발 모드 활성화" id="enable">
+        <p>
+            오토 리로드를 사용하려면 먼저 <a href="#enable">개발 모드</a>를 활성화해야 합니다.
+            이는 <Links href="//server-create-and-configure" summary="Learn how to create a server depending on your application deployment needs.">서버를 생성하고 실행</Links>하는 방식에 따라 달라집니다.
+        </p>
+        <list>
+            <li>
+                <p>
+                    <code>EngineMain</code>을 사용하여 서버를 실행하는 경우, <a href="#application-conf">설정 파일</a>에서 개발 모드를 활성화하세요.
+                </p>
+            </li>
+            <li>
+                <p>
+                    <code>embeddedServer</code>를 사용하여 서버를 실행하는 경우, <a href="#system-property"><code>io.ktor.development</code></a> 시스템 속성을 사용할 수 있습니다.
+                </p>
+            </li>
+        </list>
+        <p>
+            개발 모드가 활성화되면 Ktor는 작업 디렉터리의 출력 파일을 자동으로 감시합니다.
+            필요한 경우, <a href="#watch-paths">감시 경로</a>를 지정하여 감시할 폴더 세트를 좁힐 수 있습니다.
+        </p>
+    </chapter>
+    <chapter title="감시 경로 구성" id="watch-paths">
+        <p>
+            개발 모드를 <a href="#enable">활성화</a>하면 Ktor는 작업 디렉터리의 출력 파일을 감시하기 시작합니다.
+            예를 들어, Gradle로 빌드된 <Path>ktor-sample</Path> 프로젝트의 경우 다음 폴더들이 감시됩니다.
+        </p>
+        <code-block code="            ktor-sample/build/classes/kotlin/main/META-INF&#10;            ktor-sample/build/classes/kotlin/main/com/example&#10;            ktor-sample/build/classes/kotlin/main/com&#10;            ktor-sample/build/classes/kotlin/main&#10;            ktor-sample/build/resources/main"/>
+        <p>
+            감시 경로(Watch paths)를 사용하면 감시할 폴더 세트를 좁힐 수 있습니다.
+            이를 위해 감시할 경로의 일부를 지정할 수 있습니다.
+            예를 들어, <Path>ktor-sample/build/classes</Path> 하위 폴더의 변경 사항을 모니터링하려면
+            감시 경로로 <code>classes</code>를 전달합니다.
+            서버를 실행하는 방식에 따라 다음과 같은 방법으로 감시 경로를 지정할 수 있습니다.
+        </p>
+        <list>
+            <li>
+                <p>
+                    <Path>application.conf</Path> 또는 <Path>application.yaml</Path> 파일에서 <code>watch</code> 옵션을 지정합니다.
+                </p>
+                <Tabs group="config">
+                    <TabItem title="application.conf" group-key="hocon">
+                        <code-block code="ktor {&#10;    development = true&#10;    deployment {&#10;        watch = [ classes ]&#10;    }&#10;}"/>
+                    </TabItem>
+                    <TabItem title="application.yaml" group-key="yaml">
+                        <code-block lang="yaml" code="ktor:&#10;    development: true&#10;    deployment:&#10;        watch:&#10;            - classes"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    다음과 같이 여러 감시 경로를 지정할 수도 있습니다.
+                </p>
+                <Tabs group="config">
+                    <TabItem title="application.conf" group-key="hocon">
+                        <code-block code="                            watch = [ classes, resources ]"/>
+                    </TabItem>
+                    <TabItem title="application.yaml" group-key="yaml">
+                        <code-block lang="yaml" code="                            watch:&#10;                                - classes&#10;                                - resources"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    전체 예제는 여기에서 확인할 수 있습니다: <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>.
+                </p>
+            </li>
+            <li>
+                <p>
+                    <code>embeddedServer</code>를 사용하는 경우, <code>watchPaths</code> 매개변수로 감시 경로를 전달합니다.
+                </p>
+                <code-block lang="Kotlin" code="fun main() {&#10;    embeddedServer(Netty, port = 8080, watchPaths = listOf(&quot;classes&quot;), host = &quot;0.0.0.0&quot;, module = Application::module)&#10;        .start(wait = true)&#10;}&#10;&#10;fun Application.module() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, world!&quot;)&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    전체 예제는 <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-embedded-server">autoreload-embedded-server</a>를 참조하세요.
+                </p>
+            </li>
+        </list>
+    </chapter>
+    <chapter title="변경 시 재컴파일" id="recompile">
+        <p>
+            오토 리로드는 출력 파일의 변경 사항을 감지하므로, 프로젝트를 다시 빌드해야 합니다.
+            IntelliJ IDEA에서 수동으로 다시 빌드하거나 Gradle의 <code>-t</code> 명령줄 옵션을 사용하여 연속 빌드 실행(continuous build execution)을 활성화할 수 있습니다.
+        </p>
+        <list>
+            <li>
+                <p>
+                    IntelliJ IDEA에서 프로젝트를 수동으로 다시 빌드하려면 메인 메뉴에서 <ui-path>Build | Rebuild Project</ui-path>를 선택하세요.
+                </p>
+            </li>
+            <li>
+                <p>
+                    Gradle을 사용하여 프로젝트를 자동으로 다시 빌드하려면 터미널에서 <code>-t</code> 옵션과 함께 <code>build</code> 태스크를 실행하면 됩니다.
+                </p>
+                <code-block lang="Bash" code="                    ./gradlew -t build"/>
+                <tip>
+                    <p>
+                        프로젝트를 다시 로드할 때 테스트 실행을 건너뛰려면 <code>build</code> 태스크에 <code>-x</code> 옵션을 전달할 수 있습니다.
+                    </p>
+                    <code-block lang="Bash" code="                        ./gradlew -t build -x test -i"/>
+                </tip>
+            </li>
+        </list>
+    </chapter>
+</topic>

--- a/docs/ko/ktor/server-auto-reload.md
+++ b/docs/ko/ktor/server-auto-reload.md
@@ -37,42 +37,32 @@
     <chapter title="제한 사항" id="limitations">
         오토 리로드는 특정 모듈 선언에서만 작동합니다. 다음 표는 버전별 지원 여부를 보여줍니다.
         <table>
-            
 <tr>
 <td>모듈 유형</td>
-                <td>&lt;= 3.2</td>
-                <td>&gt; 3.2</td>
+<td>&lt;= 3.2</td>
+<td>&gt; 3.2</td>
 </tr>
-
-            
 <tr>
 <td>람다 초기화(Lambda initializer)</td>
-                <td>❌ 지원되지 않음</td>
-                <td>❌ 지원되지 않음</td>
+<td>❌ 지원되지 않음</td>
+<td>❌ 지원되지 않음</td>
 </tr>
-
-            
 <tr>
 <td>블로킹 함수 참조(Blocking function reference)</td>
-                <td>✅ 지원됨</td>
-                <td>❌ 지원되지 않음</td>
+<td>✅ 지원됨</td>
+<td>❌ 지원되지 않음</td>
 </tr>
-
-            
 <tr>
 <td>서스펜드 함수 참조(Suspend function reference)</td>
-                <td>❌ 지원되지 않음</td>
-                <td>✅ 지원됨</td>
+<td>❌ 지원되지 않음</td>
+<td>✅ 지원됨</td>
 </tr>
-
-            
 <tr>
 <td>설정 참조(Config reference)</td>
-                <td>✅ 지원됨</td>
-                <td>✅ 지원됨</td>
+<td>✅ 지원됨</td>
+<td>✅ 지원됨</td>
 </tr>
-
-        </table>
+</table>
         <chapter title="지원됨" id="supported">
             <code-block lang="kotlin" code="                // Suspend function reference&#10;                embeddedServer(Netty, port = 8080, module = Application::mySuspendModule)&#10;&#10;                // Configuration reference&#10;                ktor {&#10;                    application {&#10;                        modules = [ com.example.ApplicationKt.mySuspendModule ]&#10;                    }&#10;                }"/>
         </chapter>

--- a/docs/ko/ktor/server-configuration-code.md
+++ b/docs/ko/ktor/server-configuration-code.md
@@ -1,0 +1,167 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="코드로 설정하기"
+       id="server-configuration-code" help-id="Configuration-code;server-configuration-in-code">
+<show-structure for="chapter"/>
+<link-summary>
+    코드로 다양한 서버 파라미터를 설정하는 방법을 알아봅니다.
+</link-summary>
+<p>
+    Ktor를 사용하면 호스트 주소, 포트, <Links href="//server-modules" summary="모듈을 사용하면 경로를 그룹화하여 애플리케이션을 구성할 수 있습니다.">서버 모듈</Links> 등을 포함한 다양한 서버 파라미터를 코드로 직접 설정할 수 있습니다. 설정 방법은 <Links href="//server-create-and-configure" summary="애플리케이션 배포 요구 사항에 따라 서버를 생성하는 방법을 알아봅니다.">embeddedServer 또는 EngineMain</Links> 중 어떤 방식으로 서버를 설정하느냐에 따라 달라집니다.
+</p>
+<p>
+    <code>embeddedServer</code>를 사용하면 원하는 파라미터를 함수에 직접 전달하여 서버를 설정합니다.
+    <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/embedded-server.html">
+        embeddedServer
+    </a>
+    함수는 <Links href="//server-engines" summary="네트워크 요청을 처리하는 엔진에 대해 알아봅니다.">서버 엔진</Links>, 서버가 수신 대기할 호스트와 포트, 그리고 추가 설정을 포함하여 서버 구성을 위한 다양한 파라미터를 받습니다.
+</p>
+<p>
+    이 섹션에서는 <code>embeddedServer</code>를 실행하는 여러 가지 예시를 살펴보며 서버를 유용하게 설정하는 방법을 설명합니다.
+</p>
+<chapter title="기본 설정" id="embedded-basic">
+    <p>
+        아래 코드 스니펫은 Netty 엔진과 <code>8080</code> 포트를 사용하는 기본 서버 설정을 보여줍니다.
+    </p>
+    <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(Netty, port = 8080) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+    <p>
+        <code>port</code> 파라미터를 <code>0</code>으로 설정하면 서버를 무작위 포트에서 실행할 수 있습니다.
+        <code>embeddedServer</code> 함수는 엔진 인스턴스를 반환하므로,
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/resolved-connectors.html">
+            ApplicationEngine.resolvedConnectors
+        </a>
+        함수를 사용하여 코드에서 포트 값을 가져올 수 있습니다.
+    </p>
+</chapter>
+<chapter title="엔진 설정" id="embedded-engine">
+    <snippet id="embedded-engine-configuration">
+        <p>
+            <code>embeddedServer</code> 함수를 사용하면 <code>configure</code> 파라미터를 통해 엔진 전용 옵션을 전달할 수 있습니다. 이 파라미터에는 모든 엔진에 공통적인 옵션이 포함되어 있으며,
+            <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/index.html">
+                ApplicationEngine.Configuration
+            </a>
+            클래스에 의해 노출됩니다.
+        </p>
+        <p>
+            아래 예시는 <code>Netty</code> 엔진을 사용하여 서버를 설정하는 방법을 보여줍니다.
+            <code>configure</code> 블록 내에서 호스트와 포트를 지정하기 위한 <code>connector</code>를 정의하고 다양한 서버 파라미터를 커스터마이징합니다.
+        </p>
+        <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(Netty, configure = {&#10;        connectors.add(EngineConnectorBuilder().apply {&#10;            host = &quot;127.0.0.1&quot;&#10;            port = 8080&#10;        })&#10;        connectionGroupSize = 2&#10;        workerGroupSize = 5&#10;        callGroupSize = 10&#10;        shutdownGracePeriod = 2000&#10;        shutdownTimeout = 3000&#10;    }) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+        <p>
+            <code>connectors.add()</code> 메서드는 지정된 호스트(<code>127.0.0.1</code>)와 포트(<code>8080</code>)로 커넥터(connector)를 정의합니다.
+        </p>
+        <p>이러한 옵션 외에도 다른 엔진 전용 속성을 설정할 수 있습니다.</p>
+        <chapter title="Netty" id="netty-code">
+            <p>
+                Netty 전용 옵션은
+                <a href="https://api.ktor.io/ktor-server-netty/io.ktor.server.netty/-netty-application-engine/-configuration/index.html">
+                    NettyApplicationEngine.Configuration
+                </a>
+                클래스에 의해 노출됩니다.
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.netty.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Netty, configure = {&#10;                            requestQueueLimit = 16&#10;                            shareWorkGroup = false&#10;                            configureBootstrap = {&#10;                                // ...&#10;                            }&#10;                            responseWriteTimeoutSeconds = 10&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="Jetty" id="jetty-code">
+            <p>
+                Jetty 전용 옵션은
+                <a href="https://api.ktor.io/ktor-server-jetty-jakarta/io.ktor.server.jetty.jakarta/-jetty-application-engine-base/-configuration/index.html">
+                    JettyApplicationEngineBase.Configuration
+                </a>
+                클래스에 의해 노출됩니다.
+            </p>
+            <p>
+                <a href="https://api.ktor.io/ktor-server-jetty-jakarta/io.ktor.server.jetty.jakarta/-jetty-application-engine-base/-configuration/configure-server.html">
+                    configureServer
+                </a>
+                블록 내에서 Jetty 서버를 설정할 수 있으며, 이 블록은
+                <a href="https://www.eclipse.org/jetty/javadoc/jetty-11/org/eclipse/jetty/server/Server.html">Server</a>
+                인스턴스에 대한 접근을 제공합니다.
+            </p>
+            <p>
+                <code>idleTimeout</code> 속성을 사용하여 연결이 닫히기 전까지 유휴 상태로 유지될 수 있는 시간을 지정합니다.
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.jetty.jakarta.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Jetty, configure = {&#10;                            configureServer = { // this: Server -&amp;gt;&#10;                                // ...&#10;                            }&#10;                            idleTimeout = 30.seconds&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="CIO" id="cio-code">
+            <p>CIO 전용 옵션은
+                <a href="https://api.ktor.io/ktor-server-cio/io.ktor.server.cio/-c-i-o-application-engine/-configuration/index.html">
+                    CIOApplicationEngine.Configuration
+                </a>
+                클래스에 의해 노출됩니다.
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.cio.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(CIO, configure = {&#10;                            connectionIdleTimeoutSeconds = 45&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="Tomcat" id="tomcat-code">
+            <p>Tomcat을 엔진으로 사용하는 경우,
+                <a href="https://api.ktor.io/ktor-server-tomcat-jakarta/io.ktor.server.tomcat.jakarta/-tomcat-application-engine/-configuration/configure-tomcat.html">
+                    configureTomcat
+                </a>
+                속성을 사용하여 설정할 수 있으며, 이 속성은
+                <a href="https://tomcat.apache.org/tomcat-10.1-doc/api/org/apache/catalina/startup/Tomcat.html">Tomcat</a>
+                인스턴스에 대한 접근을 제공합니다.
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.tomcat.jakarta.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Tomcat, configure = {&#10;                            configureTomcat = { // this: Tomcat -&amp;gt;&#10;                                // ...&#10;                            }&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+    </snippet>
+</chapter>
+<chapter title="사용자 정의 환경" id="embedded-custom">
+    <p>
+        아래 예시는
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/index.html">
+            ApplicationEngine.Configuration
+        </a>
+        클래스로 표현되는 사용자 정의 설정을 사용하여 여러 커넥터 엔드포인트로 서버를 실행하는 방법을 보여줍니다.
+    </p>
+    <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main() {&#10;    val appProperties = serverConfig {&#10;        module { module() }&#10;    }&#10;    embeddedServer(Netty, appProperties) {&#10;        envConfig()&#10;    }.start(true)&#10;}&#10;&#10;fun ApplicationEngine.Configuration.envConfig() {&#10;    connector {&#10;        host = &quot;0.0.0.0&quot;&#10;        port = 8080&#10;    }&#10;    connector {&#10;        host = &quot;127.0.0.1&quot;&#10;        port = 9090&#10;    }&#10;}"/>
+    <p>
+        전체 예시는
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server-multiple-connectors">
+            embedded-server-multiple-connectors
+        </a>를 참고하세요.
+    </p>
+    <tip>
+        <p>
+            사용자 정의 환경을 사용하여
+            <a href="#embedded-server">
+                HTTPS를 제공
+            </a>할 수도 있습니다.
+        </p>
+    </tip>
+</chapter>
+<chapter id="command-line" title="명령줄 설정">
+    <p>
+        Ktor를 사용하면 명령줄 인수를 사용하여 <code>embeddedServer</code>를 동적으로 설정할 수 있습니다. 이는 포트, 호스트 또는 타임아웃과 같은 설정을 런타임에 지정해야 하는 경우에 특히 유용할 수 있습니다.
+    </p>
+    <p>
+        이를 위해
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-command-line-config.html">
+            CommandLineConfig
+        </a>
+        클래스를 사용하여 명령줄 인수를 설정 객체로 파싱하고 설정 블록 내에서 전달합니다.
+    </p>
+    <code-block lang="kotlin" code="fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(&#10;        factory = Netty,&#10;        configure = {&#10;            val cliConfig = CommandLineConfig(args)&#10;            takeFrom(cliConfig.engineConfig)&#10;            loadCommonConfiguration(cliConfig.rootConfig.environment.config)&#10;        }&#10;    ) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+    <p>
+        이 예시에서는 <code>port</code> 및 <code>host</code>와 같은 엔진 설정 값을 재정의하기 위해 <code>Application.Configuration</code>의
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/take-from.html">
+            <code>takeFrom()</code>
+        </a>
+        함수를 사용합니다.
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/load-common-configuration.html">
+            <code>loadCommonConfiguration()</code>
+        </a>
+        함수는 타임아웃과 같은 루트 환경의 설정을 로드합니다.
+    </p>
+    <p>
+        서버를 실행하려면 다음과 같은 방식으로 인수를 지정합니다.
+    </p>
+    <code-block lang="shell" code="            ./gradlew run --args=&quot;-port=8080&quot;"/>
+    <tip>
+        정적 설정의 경우 설정 파일이나 환경 변수를 사용할 수 있습니다.
+        자세한 내용은
+        <a href="#command-line">
+            파일로 설정하기
+        </a>
+        를 참고하세요.
+    </tip>
+</chapter>
+</topic>

--- a/docs/ko/ktor/server-create-a-new-project.md
+++ b/docs/ko/ktor/server-create-a-new-project.md
@@ -1,0 +1,715 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="새로운 Ktor 프로젝트 생성, 열기 및 실행"
+       id="server-create-a-new-project"
+       help-id="server_create_a_new_project">
+    <show-structure for="chapter" depth="2"/>
+    <tldr>
+        <var name="example_name" value="tutorial-server-get-started"/>
+        <p>
+            <b>코드 예제</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+    </tldr>
+    <link-summary>
+        Ktor를 사용하여 서버 애플리케이션을 열고, 실행하고, 테스트하는 방법을 알아봅니다.
+    </link-summary>
+    <web-summary>
+        첫 번째 Ktor 서버 애플리케이션 구축을 시작해 보세요. 이 튜토리얼에서는 새로운 Ktor 프로젝트를 생성하고, 열고, 실행하는 방법을 배웁니다.
+    </web-summary>
+    <p>
+        이 튜토리얼에서는 첫 번째 Ktor 서버 프로젝트를 생성하고, 열고, 실행하는 방법을 배웁니다. 프로젝트가 실행되면 일련의 과제를 완료하여 Ktor에 익숙해질 수 있습니다.
+    </p>
+    <p>
+        이것은 Ktor로 서버 애플리케이션을 구축하기 위한 시작 단계인 일련의 튜토리얼 중 첫 번째입니다. 각 튜토리얼을 독립적으로 진행할 수 있지만, 다음 권장 순서를 따르는 것이 좋습니다:
+    </p>
+    <list type="decimal">
+        <li>새로운 Ktor 프로젝트 생성, 열기 및 실행</li>
+        <li><Links href="//server-requests-and-responses" summary="Task Manager 애플리케이션을 빌드하며 Ktor와 Kotlin을 사용한 라우팅, 요청 처리 및 매개변수의 기본 사항을 알아봅니다.">요청 처리 및 응답 생성</Links></li>
+        <li><Links href="//server-create-restful-apis" summary="JSON 파일을 생성하는 RESTful API 예제를 통해 Kotlin과 Ktor를 사용하여 백엔드 서비스를 빌드하는 방법을 알아봅니다.">JSON을 생성하는 RESTful API 만들기</Links></li>
+        <li><Links href="//server-create-website" summary="Ktor와 Thymeleaf 템플릿을 사용하여 Kotlin으로 웹사이트를 빌드하는 방법을 알아봅니다.">Thymeleaf 템플릿을 사용하여 웹사이트 만들기</Links></li>
+        <li><Links href="//server-create-websocket-application" summary="WebSocket의 기능을 활용하여 콘텐츠를 주고받는 방법을 알아봅니다.">WebSocket 애플리케이션 만들기</Links></li>
+        <li><Links href="//server-integrate-database" summary="Exposed SQL 라이브러리를 사용하여 Ktor 서비스를 데이터베이스 리포지토리에 연결하는 프로세스를 알아봅니다.">Exposed를 사용하여 데이터베이스 통합</Links></li>
+    </list>
+    <chapter id="create-project" title="새로운 Ktor 프로젝트 생성">
+        <p>
+            새로운 Ktor 프로젝트를 생성하는 가장 빠른 방법 중 하나는 <a href="#create-project-with-the-ktor-project-generator">웹 기반 Ktor 프로젝트 생성기를 사용</a>하는 것입니다.
+        </p>
+        <p>
+            또는 <a href="#create_project_with_intellij">IntelliJ IDEA Ultimate용 전용 Ktor 플러그인</a>이나 <a href="#create_project_with_ktor_cli_tool">Ktor CLI 도구</a>를 사용하여 프로젝트를 생성할 수 있습니다.
+        </p>
+        <chapter title="Ktor 프로젝트 생성기 사용"
+                 id="create-project-with-the-ktor-project-generator">
+            <p>
+                Ktor 프로젝트 생성기로 새로운 프로젝트를 생성하려면 아래 단계를 따르세요:
+            </p>
+            <procedure>
+                <step>
+                    <p><a href="https://start.ktor.io/">Ktor 프로젝트 생성기</a>로 이동합니다.</p>
+                </step>
+                <step>
+                    <p>
+                        <control>Project artifact</control> 필드에 프로젝트 아티팩트 이름으로 <Path>com.example.ktor-sample</Path>을 입력합니다.
+                        <img src="ktor_343_project_generator_new_project_artifact_name.png"
+                             alt="Project Artifact Name에 com.example.ktor-sample이 입력된 Ktor 프로젝트 생성기"
+                             border-effect="line"
+                             style="block"
+                             width="706"/>
+                    </p>
+                </step>
+                <step id="configure-project-step">
+                    <p>
+                        <control>Configure</control>를 클릭하여 설정 드롭다운 메뉴를 엽니다:
+                        <img src="ktor_343_project_generator_new_project_configure.png"
+                             style="block"
+                             alt="확장된 Ktor 프로젝트 설정 보기" border-effect="line" width="706"/>
+                    </p>
+                    <p>
+                        다음 설정을 사용할 수 있습니다:
+                    </p>
+                    <list>
+                        <li>
+                            <p>
+                                <control>Build System</control>:
+                                원하는 <Links href="//server-dependencies" summary="기존 Gradle/Maven 프로젝트에 Ktor 서버 종속성을 추가하는 방법을 알아봅니다.">빌드 시스템</Links>을 선택합니다.
+                                <emphasis>Gradle Kotlin</emphasis>,
+                                <emphasis>Gradle Groovy</emphasis>,
+                                <emphasis>Maven</emphasis>, 또는 <emphasis>Amper</emphasis> 중 하나를 선택할 수 있습니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Engine</control>:
+                                서버를 실행하는 데 사용할 <Links href="//server-engines" summary="네트워크 요청을 처리하는 엔진에 대해 알아봅니다.">엔진</Links>을 선택합니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Configuration</control>:
+                                서버 매개변수를 <Links href="//server-configuration-file" summary="구성 파일에서 다양한 서버 매개변수를 구성하는 방법을 알아봅니다.">YAML 또는 HOCON 파일</Links>에 지정할지, 아니면 <Links href="//server-configuration-code" summary="코드에서 다양한 서버 매개변수를 구성하는 방법을 알아봅니다.">코드</Links>에 직접 지정할지 선택합니다.
+                            </p>
+                            <warning>
+                                YAML 구성은 현재 Maven 기반 Ktor 프로젝트에서 지원되지 않습니다.
+                            </warning>
+                        </li>
+                    </list>
+                    <p>이 튜토리얼에서는 이러한 설정에 대해 기본값을 그대로 두어도 됩니다.</p>
+                </step>
+                <step>
+                    <p>
+                        <control>Done</control>을 클릭하여 구성을 저장하고 메뉴를 닫습니다.
+                    </p>
+                </step>
+                <step>
+                    <p>아래에서 프로젝트에 추가할 수 있는 <Links href="//server-plugins" summary="플러그인은 직렬화, 콘텐츠 인코딩, 압축 등과 같은 공통 기능을 제공합니다.">플러그인</Links> 세트를 확인할 수 있습니다. 플러그인은 인증, 직렬화 및 콘텐츠 인코딩, 압축, 쿠키 지원 등 Ktor 애플리케이션에서 공통 기능을 제공하는 구성 블록입니다.
+                    </p>
+                    <p>이 튜토리얼의 목적상, 지금 단계에서는 플러그인을 추가할 필요가 없습니다.</p>
+                </step>
+                <step>
+                    <p>
+                        <control>Download</control> 버튼을 클릭하여 Ktor 프로젝트를 생성하고 다운로드합니다.
+                        <img src="ktor_343_project_generator_new_project_download.png"
+                             alt="Ktor 프로젝트 생성기 다운로드 버튼"
+                             border-effect="line"
+                             style="block"
+                             width="706"/>
+                    </p>
+                </step>
+                <p>다운로드가 자동으로 시작됩니다.</p>
+            </procedure>
+            <p>이제 새로운 프로젝트를 생성했으므로, 이어서 <a href="#unpacking">Ktor 프로젝트를 압축 해제하고 실행</a>해 보겠습니다.</p>
+        </chapter>
+        <chapter title="IntelliJ IDEA Ultimate용 Ktor 플러그인 사용" id="create_project_with_intellij"
+                 collapsible="true">
+            <p>
+                이 섹션에서는 IntelliJ IDEA Ultimate용 <a href="https://plugins.jetbrains.com/plugin/16008-ktor">Ktor 플러그인</a>을 사용하여 프로젝트를 설정하는 방법을 설명합니다.
+            </p>
+            <p>
+                새로운 Ktor 프로젝트를 생성하려면 <a href="https://www.jetbrains.com/help/idea/run-for-the-first-time.html">IntelliJ IDEA를 열고</a> 다음 단계를 따르세요:
+            </p>
+            <procedure>
+                <step>
+                    <p>
+                        시작(Welcome) 화면에서 <control>New Project</control>를 클릭합니다.
+                    </p>
+                    <p>
+                        또는 메인 메뉴에서 <ui-path>File | New | Project</ui-path>를 선택합니다.
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        <control>New Project</control> 마법사의 왼쪽 목록에서 <control>Ktor</control>를 선택합니다.
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        오른쪽 창에서 다음 설정을 지정할 수 있습니다:
+                    </p>
+                    <img src="ktor_idea_new_project_settings.png" alt="Ktor 프로젝트 설정" width="706"
+                         border-effect="rounded"/>
+                    <list>
+                        <li>
+                            <p>
+                                <control>Name</control>: 프로젝트 이름을 지정합니다. 프로젝트 이름으로 <Path>ktor-sample</Path>을 입력합니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Location</control>: 프로젝트를 저장할 디렉토리를 지정합니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Website</control>: 패키지 이름을 생성하는 데 사용할 도메인을 지정합니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Artifact</control>: 이 필드에는 생성된 아티팩트 이름이 표시됩니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Engine</control>: 서버를 실행하는 데 사용할 <Links href="//server-engines" summary="네트워크 요청을 처리하는 엔진에 대해 알아봅니다.">엔진</Links>을 선택합니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Include samples</control>: 플러그인용 샘플 코드를 추가하려면 이 옵션을 활성화된 상태로 둡니다.
+                            </p>
+                        </li>
+                    </list>
+                </step>
+                <step>
+                    <p>
+                        <control>Advanced Settings</control>를 클릭하여 추가 설정 메뉴를 확장합니다:
+                    </p>
+                    <img src="ktor_idea_new_project_advanced_settings.png" alt="Ktor 프로젝트 고급 설정"
+                         width="706" border-effect="rounded"/>
+                    <p>
+                        다음 설정을 사용할 수 있습니다:
+                    </p>
+                    <list>
+                        <li>
+                            <p>
+                                <control>Build System</control>:
+                                원하는 <Links href="//server-dependencies" summary="기존 Gradle/Maven 프로젝트에 Ktor 서버 종속성을 추가하는 방법을 알아봅니다.">빌드 시스템</Links>을 선택합니다.
+                                <emphasis>Gradle Kotlin</emphasis>,
+                                <emphasis>Gradle Groovy</emphasis>,
+                                <emphasis>Maven</emphasis>, 또는 <emphasis>Amper</emphasis> 중 하나를 선택할 수 있습니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Ktor version</control>:
+                                필요한 Ktor 버전을 선택합니다.
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Configuration</control>:
+                                서버 매개변수를 <Links href="//server-configuration-file" summary="구성 파일에서 다양한 서버 매개변수를 구성하는 방법을 알아봅니다.">YAML 또는 HOCON 파일</Links>에 지정할지, 아니면 <Links href="//server-configuration-code" summary="코드에서 다양한 서버 매개변수를 구성하는 방법을 알아봅니다.">코드</Links>에 직접 지정할지 선택합니다.
+                            </p>
+                            <warning>
+                                YAML 구성은 현재 Maven 기반 Ktor 프로젝트에서 지원되지 않습니다.
+                            </warning>
+                        </li>
+                    </list>
+                    <p>이 튜토리얼의 목적상, 이러한 설정의 기본값을 그대로 두어도 됩니다.</p>
+                </step>
+                <step>
+                    <p>
+                        <control>Next</control>를 클릭하여 다음 페이지로 이동합니다.
+                    </p>
+                    <img src="ktor_idea_new_project_plugins_list.png" alt="Ktor 플러그인" width="706"
+                         border-effect="rounded"/>
+                    <p>
+                        이 페이지에서 Ktor 애플리케이션의 공통 기능(예: 인증, 직렬화 및 콘텐츠 인코딩, 압축, 쿠키 지원 등)을 제공하는 구성 블록인 <Links href="//server-plugins" summary="플러그인은 직렬화, 콘텐츠 인코딩, 압축 등과 같은 공통 기능을 제공합니다.">플러그인</Links> 세트를 선택할 수 있습니다.
+                    </p>
+                    <p>이 튜토리얼의 목적상, 지금 단계에서는 플러그인을 추가할 필요가 없습니다.</p>
+                </step>
+                <step>
+                    <p>
+                        <control>Create</control>를 클릭하고 IntelliJ IDEA가 프로젝트를 생성하고 종속성을 설치할 때까지 기다립니다.
+                    </p>
+                </step>
+            </procedure>
+            <p>
+                이제 새로운 프로젝트를 생성했으므로, 이어서 애플리케이션을 <a href="#open-explore-run">열고, 탐색하고, 실행</a>하는 방법을 알아봅니다.
+            </p>
+        </chapter>
+        <chapter title="Ktor CLI 도구 사용" id="create_project_with_ktor_cli_tool"
+                 collapsible="true">
+            <p>
+                이 섹션에서는 <a href="https://github.com/ktorio/ktor-cli">Ktor CLI 도구</a>를 사용하여 프로젝트를 설정하는 방법을 설명합니다.
+            </p>
+            <p>
+                새로운 Ktor 프로젝트를 생성하려면 원하는 터미널을 열고 다음 단계를 따르세요:
+            </p>
+            <procedure>
+                <step>
+                    다음 명령 중 하나를 사용하여 Ktor CLI 도구를 설치합니다:
+                    <Tabs>
+                        <TabItem title="macOS/Linux" id="macos-linux">
+                            <code-block lang="console" code="                                brew install ktor"/>
+                        </TabItem>
+                        <TabItem title="Windows" id="windows">
+                            <code-block lang="console" code="                                winget install JetBrains.KtorCLI"/>
+                        </TabItem>
+                    </Tabs>
+                </step>
+                <step>
+                    대화형 모드(interactive mode)에서 새로운 프로젝트를 생성하려면 다음 명령을 사용합니다:
+                    <code-block lang="console" code="                      ktor new"/>
+                </step>
+                <step>
+                    프로젝트 이름으로 <Path>ktor-sample</Path>을 입력합니다:
+                    <img src="server_create_cli_tool_name_dark.png"
+                         alt="대화형 모드에서 Ktor CLI 도구 사용하기"
+                         border-effect="rounded"
+                         style="block"
+                         width="706"/>
+                    <p>
+                        (선택 사항) 프로젝트 이름 아래의 <ui-path>Location</ui-path> 경로를 수정하여 프로젝트가 저장될 위치를 변경할 수도 있습니다.
+                    </p>
+                </step>
+                <step>
+                    <shortcut>Enter</shortcut>를 눌러 계속합니다.
+                </step>
+                <step>
+                    다음 단계에서는 프로젝트에 추가할 <Links href="//server-plugins" summary="플러그인은 직렬화, 콘텐츠 인코딩, 압축 등과 같은 공통 기능을 제공합니다.">플러그인</Links>을 검색하고 추가할 수 있습니다. 플러그인은 인증, 직렬화 및 콘텐츠 인코딩, 압축, 쿠키 지원 등 Ktor 애플리케이션에서 공통 기능을 제공하는 구성 블록입니다.
+                    <img src="server_create_cli_tool_add_plugins_dark.png"
+                         alt="Ktor CLI 도구를 사용하여 프로젝트에 플러그인 추가"
+                         border-effect="rounded"
+                         style="block"
+                         width="706"/>
+                    <p>이 튜토리얼의 목적상, 지금 단계에서는 플러그인을 추가할 필요가 없습니다.</p>
+                </step>
+                <step>
+                    <shortcut>CTRL+G</shortcut>를 눌러 프로젝트를 생성합니다.
+                    <p>
+                        또는 <control>CREATE PROJECT (CTRL+G)</control>를 선택하고 <shortcut>Enter</shortcut>를 눌러 프로젝트를 생성할 수 있습니다.
+                    </p>
+                </step>
+            </procedure>
+        </chapter>
+    </chapter>
+    <chapter title="Ktor 프로젝트 압축 해제 및 실행" id="unpacking">
+        <p>
+            이 섹션에서는 명령줄에서 프로젝트를 압축 해제하고, 빌드하고, 실행하는 방법을 알아봅니다. 아래 단계는 다음을 가정합니다:
+        </p>
+        <list type="bullet">
+            <li><Path>ktor-sample</Path>이라는 이름의 Gradle 프로젝트를 생성하고 다운로드했습니다.</li>
+            <li>이 프로젝트는 홈 디렉토리의 <Path>myprojects</Path> 폴더에 위치합니다.</li>
+        </list>
+        <p>필요한 경우 자신의 환경에 맞게 이름과 경로를 변경하세요.</p>
+        <p>원하는 명령줄 도구를 열고 다음 단계를 따르세요:</p>
+        <procedure>
+            <step>
+                <p>터미널 창에서 프로젝트를 다운로드한 폴더로 이동합니다:</p>
+                <code-block lang="console" code="                    cd ~/myprojects"/>
+            </step>
+            <step>
+                <p>동일한 이름의 폴더에 ZIP 아카이브를 압축 해제합니다:</p>
+                <Tabs>
+                    <TabItem title="macOS" group-key="macOS">
+                        <code-block lang="console" code="                            unzip ktor-sample.zip -d ktor-sample"/>
+                    </TabItem>
+                    <TabItem title="Windows" group-key="windows">
+                        <code-block lang="console" code="                            tar -xf ktor-sample.zip"/>
+                    </TabItem>
+                </Tabs>
+                <p>이제 디렉토리에 ZIP 아카이브와 압축이 해제된 폴더가 포함됩니다.</p>
+            </step>
+            <step>
+                <p>해당 디렉토리에서 새로 생성된 폴더로 이동합니다:</p>
+                <code-block lang="console" code="                    cd ktor-sample"/>
+            </step>
+            <step>
+                <p>macOS 및 UNIX 시스템에서는 Gradle 헬퍼 스크립트를 실행 가능하게 만들어야 시스템이 이를 실행 가능한 명령으로 인식합니다. 이를 위해 <code>chmod</code> 명령을 사용합니다:</p>
+                <Tabs>
+                    <TabItem title="macOS" group-key="macOS">
+                        <code-block lang="console" code="                            chmod +x ./gradlew"/>
+                    </TabItem>
+                </Tabs>
+            </step>
+            <step>
+                <p>프로젝트를 빌드하려면 다음 명령을 사용합니다:</p>
+                <Tabs>
+                    <TabItem title="macOS" group-key="macOS">
+                        <code-block lang="console" code="                            ./gradlew build"/>
+                    </TabItem>
+                    <TabItem title="Windows" group-key="windows">
+                        <code-block lang="console" code="                            gradlew build"/>
+                    </TabItem>
+                </Tabs>
+                <p>빌드가 성공하면 다음 단계로 넘어가 프로젝트를 실행합니다.</p>
+            </step>
+            <step>
+                <p>프로젝트를 실행하려면 다음 명령을 사용합니다:</p>
+                <Tabs>
+                    <TabItem title="macOS" group-key="macOS">
+                        <code-block lang="console" code="                            ./gradlew run"/>
+                    </TabItem>
+                    <TabItem title="Windows" group-key="windows">
+                        <code-block lang="console" code="                            gradlew run"/>
+                    </TabItem>
+                </Tabs>
+            </step>
+            <step>
+                <p>프로젝트가 실행 중인지 확인하려면 터미널 출력에 표시된 URL(<a href="http://0.0.0.0:8080">http://0.0.0.0:8080</a>)로 브라우저를 엽니다. 브라우저에 "Hello World!" 메시지가 표시되어야 합니다:</p>
+                <img src="server_get_started_ktor_sample_app_output.png" alt="생성된 Ktor 프로젝트의 출력 결과"
+                     border-effect="line" width="706"/>
+            </step>
+        </procedure>
+        <p>축하합니다! Ktor 프로젝트를 성공적으로 시작했습니다.</p>
+        <note>
+            기본 프로세스가 Ktor 애플리케이션을 실행하느라 사용 중이므로 명령줄이 응답하지 않을 것입니다. 애플리케이션을 종료하려면 <shortcut>CTRL+C</shortcut>를 누르세요.
+        </note>
+    </chapter>
+    <chapter title="IntelliJ IDEA에서 Ktor 프로젝트 열기, 탐색 및 실행" id="open-explore-run">
+        <chapter title="프로젝트 열기" id="open">
+            <p><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a>가 설치되어 있다면 명령줄에서 쉽게 프로젝트를 열 수 있습니다.</p>
+            <p>
+                프로젝트 폴더에 있는지 확인한 다음, <code>idea</code> 명령 뒤에 현재 폴더를 나타내는 마침표를 입력합니다:
+            </p>
+            <code-block lang="Bash" code="                idea ."/>
+            <p>
+                또는 수동으로 프로젝트를 열려면 IntelliJ IDEA를 실행합니다.
+            </p>
+            <p>
+                시작(Welcome) 화면이 나타나면 <control>Open</control>을 클릭합니다. 그렇지 않으면 메인 메뉴에서 <ui-path>File | Open</ui-path>으로 이동하여 <Path>ktor-sample</Path> 폴더를 선택해 엽니다.
+            </p>
+            <tip>
+                프로젝트 관리에 대한 자세한 내용은 <a href="https://www.jetbrains.com/help/idea/creating-and-managing-projects.html">IntelliJ IDEA 문서</a>를 참조하세요.
+            </tip>
+        </chapter>
+        <chapter title="프로젝트 탐색" id="explore">
+            <p>프로젝트를 열면 다음과 같은 구조를 볼 수 있습니다:</p>
+            <img src="tutorial_server_get_started_idea_project_view.png" alt="IDE에서 생성된 Ktor 프로젝트 뷰" width="706"/>
+            <p>
+                전체 레이아웃을 보려면 <control>Project</control> 뷰에서 각 폴더 옆의 확장 화살표를 클릭하여 폴더를 확장합니다.
+            </p>
+            <p>
+                애플리케이션 소스 코드는 <Path>src/main/kotlin</Path> 아래에 위치합니다. 기본적으로 <Path>Application.kt</Path>와 <Path>Routing.kt</Path>라는 두 개의 파일이 생성됩니다.
+            </p>
+            <img src="tutorial_server_get_started_idea_main_folder.png" alt="Ktor 프로젝트 src 폴더 구조" width="400"/>
+            <p>프로젝트 이름은 <Path>settings.gradle.kts</Path> 파일에 구성되어 있습니다:</p>
+            <code-block lang="kotlin" code="rootProject.name = &quot;ktor-sample&quot;"/>
+            <p>
+                구성 파일 및 기타 콘텐츠 종류는 <Path>src/main/resources</Path> 폴더 안에 위치합니다.
+            </p>
+            <img src="tutorial_server_get_started_idea_resources_folder.png" alt="Ktor 프로젝트 resources 폴더 구조"
+                 width="400"/>
+        </chapter>
+        <chapter title="프로젝트 실행" id="run">
+            <procedure>
+                <p>IntelliJ IDEA 내에서 프로젝트를 실행하려면:</p>
+                <step>
+                    <p>오른쪽 사이드바의 Gradle 아이콘(<img alt="IntelliJ IDEA Gradle 아이콘"
+                                                          src="intellij_idea_gradle_icon.svg" width="16" height="26"/>)을 클릭하여 <a href="https://www.jetbrains.com/help/idea/jetgradle-tool-window.html">Gradle 도구 창</a>을 엽니다.</p>
+                </step>
+                <step>
+                    <p>이 도구 창에서 <ui-path>Tasks | application</ui-path>으로 이동하여 <control>run</control> 태스크를 더블 클릭합니다.
+                    </p>
+                    <img src="tutorial_server_get_started_idea_gradle_run.png" alt="IntelliJ IDEA의 Gradle 탭"
+                         border-effect="line" width="450"/>
+                </step>
+                <step>
+                    <p>Ktor 애플리케이션이 IDE 하단의 <a href="https://www.jetbrains.com/help/idea/run-tool-window.html">Run 도구 창</a>에서 시작됩니다:</p>
+                    <img src="tutorial_server_get_started_idea_run_terminal.png" alt="터미널에서 실행 중인 프로젝트" width="706"/>
+                    <p>이전에 명령줄에 표시되었던 것과 동일한 메시지가 이제 <ui-path>Run</ui-path> 도구 창에 표시됩니다.
+                    </p>
+                </step>
+                <step>
+                    <p>프로젝트가 실행 중인지 확인하려면 지정된 URL(<a href="http://0.0.0.0:8080">http://0.0.0.0:8080</a>)로 브라우저를 엽니다.</p>
+                    <p>화면에 다시 한 번 "Hello World!" 메시지가 표시되어야 합니다:</p>
+                    <img src="server_get_started_ktor_sample_app_output.png" alt="브라우저 화면의 Hello World"
+                         width="706"/>
+                </step>
+            </procedure>
+            <p>
+                <ui-path>Run</ui-path> 도구 창을 통해 애플리케이션을 관리할 수 있습니다.
+            </p>
+            <list type="bullet">
+                <li>
+                    애플리케이션을 종료하려면 중지 버튼(<img src="intellij_idea_terminate_icon.svg"
+                                                                             style="inline" height="16" width="16"
+                                                                             alt="IntelliJ IDEA 중지 아이콘"/>)을 클릭합니다.
+                </li>
+                <li>
+                    프로세스를 재시작하려면 재실행 버튼(<img src="intellij_idea_rerun_icon.svg"
+                                                                        style="inline" height="16" width="16"
+                                                                        alt="IntelliJ IDEA 재실행 아이콘"/>)을 클릭합니다.
+                </li>
+            </list>
+            <p>
+                이러한 옵션에 대한 자세한 설명은 <a href="https://www.jetbrains.com/help/idea/run-tool-window.html#run-toolbar">IntelliJ IDEA Run 도구 창 문서</a>를 참조하세요.
+            </p>
+        </chapter>
+    </chapter>
+    <chapter title="추가 과제 시도해 보기" id="additional-tasks">
+        <p>다음은 시도해 볼 수 있는 몇 가지 추가 과제입니다:</p>
+        <list type="decimal">
+            <li><a href="#change-the-default-port">기본 포트 변경</a></li>
+            <li><a href="#add-a-new-http-endpoint">새로운 HTTP 엔드포인트 추가</a></li>
+            <li><a href="#configure-static-content">정적 콘텐츠 구성</a></li>
+            <li><a href="#write-an-integration-test">통합 테스트 작성</a></li>
+            <li><a href="#register-error-handlers">오류 핸들러 등록</a></li>
+        </list>
+        <p>
+            이 과제들은 서로 종속되어 있지는 않지만 난이도가 점차 높아집니다. 선언된 순서대로 시도하는 것이 단계적으로 학습하기 가장 쉬운 방법입니다. 단순화하고 중복을 피하기 위해 아래 설명은 과제를 순서대로 시도하는 것을 가정합니다.
+        </p>
+        <p>
+            코딩이 필요한 경우 코드와 해당 import를 모두 지정했습니다. IDE가 이러한 import를 자동으로 추가해 줄 수도 있습니다.
+        </p>
+        <chapter title="기본 포트 변경" id="change-the-default-port">
+            <chapter title="구성 파일에서 포트 변경" id="change-the-port-in-config">
+                <p>
+                    구성을 YAML 또는 HOCON 파일 내에 외부적으로 저장하도록 선택한 경우, <ui-path>Project</ui-path> 뷰에서 <Path>src/main/resources</Path> 폴더로 이동하여 다음 단계를 따르세요:
+                </p>
+                <procedure id="change-default-port-yaml-procedure">
+                    <step>
+                        구성 파일(<Path>application.yaml</Path> 또는 <Path>application.conf</Path>)을 엽니다. 다음과 같이 보여야 합니다:
+                        <Tabs>
+                            <TabItem title="application.yaml (YAML)" group-key="yaml">
+                                <code-block lang="yaml" code="ktor:&#10;  deployment:&#10;    port: 8080&#10;  application:&#10;    modules:&#10;      - com.example.RoutingKt.configureRouting"/>
+                            </TabItem>
+                            <TabItem title="application.conf (HOCON)" group-key="hocon">
+                                <code-block lang="generic" code="ktor {&#10;  deployment {&#10;    port = 8080&#10;    port = ${?PORT}&#10;  }&#10;  application {&#10;    modules = [&#10;      com.example.RoutingKt.configureRouting&#10;    ]&#10;  }&#10;}"/>
+                            </TabItem>
+                        </Tabs>
+                    </step>
+                    <step>
+                        파일의 <code>port</code> 값을 <code>9292</code>와 같이 원하는 다른 숫자로 변경합니다.
+                    </step>
+                    <step>
+                        <p>재실행 버튼(<img alt="IntelliJ IDEA 재실행 버튼 아이콘"
+                                                           src="intellij_idea_rerun_icon.svg" height="16" width="16"/>)을 클릭하여 애플리케이션을 재시작합니다.</p>
+                    </step>
+                    <step>
+                        <p>애플리케이션이 새로운 포트 번호에서 실행 중인지 확인하려면 새로운 URL(<a href="http://0.0.0.0:9292">http://0.0.0.0:9292</a>)로 브라우저를 열거나, <a href="https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html#creating-http-request-files">IntelliJ IDEA에서 새로운 HTTP Request 파일을 생성</a>할 수 있습니다:</p>
+                        <img src="tutorial_server_get_started_port_change.png"
+                             alt="IntelliJ IDEA에서 HTTP request 파일로 포트 변경 테스트" width="706"/>
+                    </step>
+                </procedure>
+            </chapter>
+            <chapter title="코드에서 포트 변경" id="change-the-port-in-code">
+                <p>
+                    <a href="#configure-project-step">새로운 Ktor 프로젝트를 생성할 때</a>, 구성을 코드에 저장하거나 YAML 또는 HOCON 파일 내에 외부적으로 저장하는 옵션이 있습니다.
+                </p>
+                <p>
+                    구성을 코드에 저장하도록 선택한 경우, <ui-path>Project</ui-path> 뷰에서 <Path>src/main/kotlin</Path> 폴더로 이동하여 다음 단계를 따르세요:
+                </p>
+                <procedure id="change-the-default-port-code-procedure">
+                    <step>
+                        <p><Path>main.kt</Path> 파일을 엽니다. 다음과 유사한 코드를 찾을 수 있습니다:
+                        </p>
+                        <code-block lang="kotlin" code="                            fun main(args: Array&lt;String&gt;) {&#10;                                embeddedServer(&#10;                                    factory = io.ktor.server.netty.Netty,&#10;                                    port = 8080,&#10;                                    host = &quot;0.0.0.0&quot;,&#10;                                    module = Application::rootModule&#10;                                ).start(wait = true)&#10;                            }"/>
+                    </step>
+                    <step>
+                        <p><code>embeddedServer()</code> 함수에서 <code>port</code> 매개변수를 <code>9292</code>와 같이 원하는 다른 숫자로 변경합니다.</p>
+                        <code-block lang="kotlin" code="                            fun main(args: Array&lt;String&gt;) {&#10;                                embeddedServer(&#10;                                    factory = io.ktor.server.netty.Netty,&#10;                                    port = 9292,&#10;                                    host = &quot;0.0.0.0&quot;,&#10;                                    module = Application::rootModule&#10;                                ).start(wait = true)&#10;                            }"/>
+                    </step>
+                    <step>
+                        <p>재실행 버튼(<img alt="IntelliJ IDEA 재실행 버튼 아이콘"
+                                                           src="intellij_idea_rerun_icon.svg" height="16" width="16"/>)을 클릭하여 애플리케이션을 재시작합니다.</p>
+                    </step>
+                    <step>
+                        <p>애플리케이션이 새로운 포트 번호에서 실행 중인지 확인하려면 새로운 URL(<a href="http://0.0.0.0:9292">http://0.0.0.0:9292</a>)로 브라우저를 열거나, <a href="https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html#creating-http-request-files">IntelliJ IDEA에서 새로운 HTTP Request 파일을 생성</a>할 수 있습니다:</p>
+                        <img src="tutorial_server_get_started_port_change.png"
+                             alt="IntelliJ IDEA에서 HTTP request 파일로 포트 변경 테스트" width="706"/>
+                    </step>
+                </procedure>
+            </chapter>
+        </chapter>
+        <chapter title="새로운 HTTP 엔드포인트 추가" id="add-a-new-http-endpoint">
+            <p>
+                <ui-path>Project</ui-path> 도구 창에서 <Path>src/main/kotlin</Path> 폴더로 이동하여 다음 단계를 따르세요:
+            </p>
+            <procedure>
+                <step>
+                    <p><Path>Routing.kt</Path> 파일을 엽니다. 다음과 같은 코드가 표시됩니다:
+                    </p>
+                    <code-block lang="Kotlin" validate="true" code="                        fun Application.configureRouting() {&#10;                            routing {&#10;                                get(&quot;/&quot;) {&#10;                                    call.respondText(&quot;Hello World!&quot;)&#10;                                }&#10;                            }&#10;                        }"/>
+                </step>
+                <step>
+                    <p>새로운 엔드포인트를 생성하려면 아래와 같이 추가 라우트를 삽입합니다:</p>
+                    <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        // ...&#10;&#10;        get(&quot;/test1&quot;) {&#10;            val text = &quot;&lt;h1&gt;Hello From Ktor&lt;/h1&gt;&quot;&#10;            val type = ContentType.parse(&quot;text/html&quot;)&#10;            call.respondText(text, type)&#10;        }&#10;    }&#10;}"/>
+                    <note><code>/test1</code> URL은 원하는 대로 변경할 수 있습니다.</note>
+                </step>
+                <step>
+                    <p>IDE가 자동으로 <code>ContentType</code>에 대한 import를 추가합니다:</p>
+                    <code-block lang="kotlin" code="                        import io.ktor.http.ContentType"/>
+                </step>
+                <step>
+                    <p>재실행 버튼(<img alt="IntelliJ IDEA 재실행 버튼 아이콘"
+                                                       src="intellij_idea_rerun_icon.svg" height="16" width="16"/>)을 클릭하여 애플리케이션을 재시작합니다.</p>
+                </step>
+                <step>
+                    <p>브라우저에서 새로운 URL(<a href="http://0.0.0.0:9292/test1">http://0.0.0.0:9292/test1</a>)을 요청합니다. 포트 번호는 <a href="#change-the-default-port">기본 포트 변경</a> 과제를 완료했는지 여부에 따라 달라집니다. 아래와 같은 출력이 표시되어야 합니다:</p>
+                    <img src="server_get_started_add_new_http_endpoint_output.png"
+                         alt="Hello from Ktor를 표시하는 브라우저 화면" width="706"/>
+                    <p>HTTP request 파일을 생성했다면 거기에서도 새로운 엔드포인트를 확인할 수 있습니다:</p>
+                    <code-block lang="http" code="                    GET http://0.0.0.0:9292&#10;&#10;                    ###&#10;&#10;                    GET http://0.0.0.0:9292/test1"/>
+                    <note>서로 다른 요청을 구분하려면 세 개의 해시 기호(<code>###</code>)가 포함된 줄이 필요합니다.</note>
+                </step>
+            </procedure>
+        </chapter>
+        <chapter title="정적 콘텐츠 구성" id="configure-static-content">
+            <p>
+                <ui-path>Project</ui-path> 도구 창에서 <Path>src/main/kotlin</Path> 폴더로 이동하여 다음 단계를 따르세요:
+            </p>
+            <procedure>
+                <step>
+                    <p><Path>Routing.kt</Path> 파일을 열고 라우팅 섹션에 다음 라우트를 추가합니다:</p>
+                    <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        staticResources(&quot;/content&quot;, &quot;mycontent&quot;)&#10;        // ...&#10;    }&#10;}"/>
+                    <p>이 줄의 의미는 다음과 같습니다:</p>
+                    <list type="bullet">
+                        <li><code>staticResources()</code>를 호출하면 애플리케이션에서 HTML 및 JavaScript 파일과 같은 표준 웹사이트 콘텐츠를 제공할 수 있게 됩니다. 이 콘텐츠는 브라우저 내에서 실행될 수 있지만, 서버의 관점에서는 정적(static)인 것으로 간주됩니다.
+                        </li>
+                        <li>URL <code>/content</code>는 이 콘텐츠를 가져오는 데 사용되는 경로를 지정합니다.
+                        </li>
+                        <li>경로 <code>mycontent</code>는 정적 콘텐츠가 위치할 폴더의 이름입니다. Ktor는 <code>resources</code> 디렉토리 내에서 이 폴더를 찾습니다.
+                        </li>
+                    </list>
+                </step>
+                <step>
+                    <p>IDE가 자동으로 추가하지 않는 경우 다음 import를 추가합니다.</p>
+                    <code-block lang="kotlin" code="                        import io.ktor.server.http.content.staticResources"/>
+                </step>
+                <step>
+                    <p><control>Project</control> 도구 창에서 <Path>src/main/resources</Path> 폴더를 마우스 오른쪽 버튼으로 클릭하고 <control>New | Directory</control>를 선택합니다.
+                    </p>
+                    <p>또는 <Path>src/main/resources</Path> 폴더를 선택하고 <shortcut>⌘Cmd+N</shortcut>(macOS) 또는 <shortcut>Ctrl+N</shortcut>(Windows/Linux)을 누른 다음 <control>Directory</control>를 클릭합니다.
+                    </p>
+                </step>
+                <step>
+                    <p>새 디렉토리 이름을 <code>mycontent</code>로 지정하고 <shortcut>↩Enter</shortcut>를 누릅니다.
+                    </p>
+                </step>
+                <step>
+                    <p>새로 생성된 폴더를 마우스 오른쪽 버튼으로 클릭하고 <control>New | File</control>을 클릭합니다.
+                    </p>
+                </step>
+                <step>
+                    <p>새 파일 이름을 <Path>sample.html</Path>로 지정하고 <shortcut>↩Enter</shortcut>를 누릅니다.
+                    </p>
+                </step>
+                <step>
+                    <p>새로 생성된 파일 페이지를 유효한 HTML로 채웁니다. 예:</p>
+                    <code-block lang="html" code="&lt;html lang=&quot;en&quot;&gt;&#10;    &lt;head&gt;&#10;        &lt;meta charset=&quot;UTF-8&quot; /&gt;&#10;        &lt;title&gt;My sample&lt;/title&gt;&#10;    &lt;/head&gt;&#10;    &lt;body&gt;&#10;        &lt;h1&gt;This page is built with:&lt;/h1&gt;&#10;        &lt;ol&gt;&#10;            &lt;li&gt;Ktor&lt;/li&gt;&#10;            &lt;li&gt;Kotlin&lt;/li&gt;&#10;            &lt;li&gt;HTML&lt;/li&gt;&#10;        &lt;/ol&gt;&#10;    &lt;/body&gt;&#10;&lt;/html&gt;"/>
+                </step>
+                <step>
+                    <p>재실행 버튼(<img alt="IntelliJ IDEA 재실행 버튼 아이콘"
+                                                       src="intellij_idea_rerun_icon.svg" height="16" width="16"/>)을 클릭하여 애플리케이션을 재시작합니다.</p>
+                </step>
+                <step>
+                    <p>브라우저에서 <a href="http://0.0.0.0:9292/content/sample.html">http://0.0.0.0:9292/content/sample.html</a>을 열면 샘플 페이지의 콘텐츠가 표시되어야 합니다:</p>
+                    <img src="server_get_started_configure_static_content_output.png"
+                         alt="브라우저에서의 정적 페이지 출력 결과" width="706"/>
+                </step>
+            </procedure>
+        </chapter>
+        <chapter title="통합 테스트 작성" id="write-an-integration-test">
+            <p>
+                Ktor는 <Links href="//server-testing" summary="특별한 테스팅 엔진을 사용하여 서버 애플리케이션을 테스트하는 방법을 알아봅니다.">통합 테스트 생성</Links> 기능을 제공하며, 생성된 프로젝트에는 이 기능이 번들로 포함되어 있습니다.
+            </p>
+            <p>이를 사용하려면 아래 단계를 따르세요:</p>
+            <procedure>
+                <step>
+                    <p>
+                        <Path>src/test/kotlin</Path> 폴더로 이동합니다.
+                    </p>
+                </step>
+                <step>
+                    <p><Path>ServerTest.kt</Path> 파일을 엽니다. 아래와 같은 코드가 표시됩니다:</p>
+                    <code-block lang="kotlin" code="class ServerTest {&#10;&#10;    @Test&#10;    fun `test root endpoint`() = testApplication {&#10;        // loads default configuration&#10;        configure()&#10;        // verify server root returns 200&#10;        assertEquals(HttpStatusCode.OK, client.get(&quot;/&quot;).status)&#10;    }&#10;&#10;}"/>
+                    <p><code>testApplication()</code> 함수는 Ktor의 새로운 인스턴스를 생성합니다. 이 인스턴스는 Netty와 같은 서버가 아닌 테스트 환경 내부에서 실행됩니다.</p>
+                    <p>그런 다음 <code>configure()</code> 함수를 사용하여 <code>embeddedServer()</code>에서 호출되는 것과 동일한 설정을 호출할 수 있습니다.</p>
+                    <p>마지막으로 내장된 <code>client</code> 객체와 JUnit assertion을 사용하여 샘플 요청을 보내고 응답을 확인할 수 있습니다.</p>
+                </step>
+            </procedure>
+            <p>
+                IntelliJ IDEA에서 테스트를 실행하는 일반적인 방법 중 하나를 사용하여 테스트를 실행할 수 있습니다. Ktor의 새로운 인스턴스를 실행하는 것이므로 테스트의 성공 또는 실패는 애플리케이션이 <code>0.0.0.0</code>에서 실행 중인지 여부에 의존하지 않습니다.
+            </p>
+            <p>
+                <a href="#add-a-new-http-endpoint">새로운 HTTP 엔드포인트 추가</a> 과제를 성공적으로 완료했다면 다음 테스트를 추가해 보세요:
+            </p>
+            <code-block lang="kotlin" code="    @Test&#10;    fun `test new endpoint`() = testApplication {&#10;        configure()&#10;&#10;        val response = client.get(&quot;/test1&quot;)&#10;&#10;        assertEquals(HttpStatusCode.OK, response.status)&#10;        assertEquals(&quot;html&quot;, response.contentType()?.contentSubtype)&#10;        assertContains(response.bodyAsText(), &quot;Hello From Ktor&quot;)&#10;    }"/>
+            <p>다음 추가 import를 추가합니다:</p>
+            <code-block lang="Kotlin" code="                import io.ktor.http.contentType&#10;                import io.ktor.client.statement.bodyAsText"/>
+        </chapter>
+        <chapter title="오류 핸들러 등록" id="register-error-handlers">
+            <p>
+                <Links href="//server-status-pages" summary="%plugin_name% 플러그인을 사용하면 Ktor 애플리케이션이 발생한 예외나 상태 코드에 따라 모든 실패 상태에 적절하게 응답할 수 있습니다.">StatusPages 플러그인</Links>을 사용하여 Ktor 애플리케이션에서 오류를 처리할 수 있습니다.
+            </p>
+            <tip>
+                이 플러그인은 기본적으로 프로젝트에 포함되어 있지 않습니다. Ktor 프로젝트 생성기 또는 IntelliJ IDEA의 프로젝트 마법사에서 프로젝트를 생성할 때 <ui-path>Plugins</ui-path> 섹션을 통해 추가할 수 있습니다.
+            </tip>
+            <p>
+                다음 단계에서는 플러그인을 수동으로 추가하고 구성하는 방법을 배웁니다. 이를 달성하기 위한 네 가지 단계가 있습니다:
+            </p>
+            <list type="decimal">
+                <li><a href="#add-dependency">Gradle 빌드 파일에 새로운 종속성을 추가합니다.</a></li>
+                <li><a href="#install-plugin-and-specify-handler">플러그인을 설치하고 예외 핸들러를 지정합니다.</a></li>
+                <li><a href="#write-sample-code">핸들러를 트리거하기 위한 샘플 코드를 작성합니다.</a></li>
+                <li><a href="#restart-and-invoke">샘플 코드를 재시작하고 호출합니다.</a></li>
+            </list>
+            <procedure title="새로운 종속성 추가" id="add-dependency">
+                <p><control>Project</control> 도구 창에서 프로젝트 루트 폴더로 이동하여 다음 단계를 따르세요:
+                </p>
+                <step>
+                    <p><Path>build.gradle.kts</Path> 파일을 열고 아래와 같이 새로운 종속성을 추가합니다:</p>
+                    <code-block lang="kotlin" code="dependencies {&#10;    implementation(ktorLibs.server.config.yaml)&#10;    implementation(ktorLibs.server.core)&#10;    implementation(ktorLibs.server.netty)&#10;    // Add new dependency&#10;    implementation(ktorLibs.server.statusPages)&#10;    implementation(libs.logback.classic)&#10;&#10;    testImplementation(kotlin(&quot;test&quot;))&#10;    testImplementation(ktorLibs.server.testHost)&#10;}"/>
+                </step>
+                <step>
+                    <p><shortcut>Shift+⌘Cmd+I</shortcut>(macOS) 또는 <shortcut>Ctrl+Shift+O</shortcut>(Windows/Linux)를 눌러 프로젝트를 다시 로드합니다.
+                    </p>
+                </step>
+            </procedure>
+            <procedure title="플러그인 설치 및 예외 핸들러 지정"
+                       id="install-plugin-and-specify-handler">
+                <step>
+                    <p><Path>Routing.kt</Path>의 <code>.configureRouting()</code> 메서드로 이동하여 다음 코드 줄을 추가합니다:</p>
+                    <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    install(StatusPages) {&#10;        exception&lt;IllegalStateException&gt; { call, cause -&gt;&#10;            call.respondText(&quot;App in illegal state as ${cause.message}&quot;)&#10;        }&#10;    }&#10;    routing {&#10;        // ...&#10;    }&#10;}"/>
+                    <p>이 줄들은 <code>StatusPages</code> 플러그인을 설치하고 <code>IllegalStateException</code> 유형의 예외가 발생했을 때 수행할 작업을 지정합니다.</p>
+                </step>
+                <step>
+                    <p>다음 import를 추가합니다:</p>
+                    <code-block lang="kotlin" code="                        import io.ktor.server.plugins.statuspages.StatusPages"/>
+                </step>
+            </procedure>
+            <p>
+                일반적으로 응답에 HTTP 오류 코드가 설정되지만, 이 과제의 목적을 위해 출력이 브라우저에 직접 표시되도록 했습니다.
+            </p>
+            <procedure title="핸들러 트리거를 위한 샘플 코드 작성" id="write-sample-code">
+                <step>
+                    <p><code>.configureRouting()</code> 메서드 내에서 아래와 같이 추가 라우트를 추가합니다:</p>
+                    <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    install(StatusPages) {&#10;        exception&lt;IllegalStateException&gt; { call, cause -&gt;&#10;            call.respondText(&quot;App in illegal state as ${cause.message}&quot;)&#10;        }&#10;    }&#10;    routing {&#10;        // ...&#10;&#10;        get(&quot;/error-test&quot;) {&#10;            throw IllegalStateException(&quot;Too Busy&quot;)&#10;        }&#10;    }&#10;}"/>
+                    <p>이제 URL이 <code>/error-test</code>인 엔드포인트를 추가했습니다. 이 엔드포인트가 트리거되면 핸들러에서 사용된 유형의 예외가 발생합니다.</p>
+                </step>
+            </procedure>
+            <procedure title="샘플 코드 재시작 및 호출" id="restart-and-invoke">
+                <step>
+                    <p>재실행 버튼(<img alt="IntelliJ IDEA 재실행 버튼 아이콘"
+                                                       src="intellij_idea_rerun_icon.svg" height="16" width="16"/>)을 클릭하여 애플리케이션을 재시작합니다.</p></step>
+                <step>
+                    <p>브라우저에서 <a href="http://0.0.0.0:9292/error-test">http://0.0.0.0:9292/error-test</a> URL로 이동합니다. 아래와 같이 오류 메시지가 표시되어야 합니다:</p>
+                    <img src="server_get_started_register_error_handler_output.png"
+                         alt="`App in illegal state as Too Busy` 메시지가 표시된 브라우저 화면" width="706"/>
+                </step>
+            </procedure>
+        </chapter>
+    </chapter>
+    <chapter title="다음 단계" id="next_steps">
+        <p>
+            추가 과제의 끝까지 마쳤다면 이제 Ktor 서버 구성, Ktor 플러그인 통합 및 새로운 라우트 구현에 대한 이해를 갖추게 된 것입니다. 하지만 이것은 시작에 불과합니다. Ktor의 기본 개념을 더 깊이 탐구하려면 이 가이드의 다음 튜토리얼로 계속 진행하세요.
+        </p>
+        <p>
+            다음으로는 <Links href="//server-requests-and-responses" summary="Task Manager 애플리케이션을 빌드하며 Ktor와 Kotlin을 사용한 라우팅, 요청 처리 및 매개변수의 기본 사항을 알아봅니다.">Task Manager 애플리케이션을 만들며 요청을 처리하고 응답을 생성하는 방법</Links>을 배웁니다.
+        </p>
+    </chapter>
+</topic>

--- a/docs/ko/ktor/server-create-and-configure.md
+++ b/docs/ko/ktor/server-create-and-configure.md
@@ -1,0 +1,132 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="서버 생성하기"
+       id="server-create-and-configure" help-id="start_server;create_server">
+    <show-structure for="chapter" depth="2"/>
+    <tldr>
+        <p>
+            <b>코드 예제</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">embedded-server</a>,
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">engine-main</a>,
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-yaml">engine-main-yaml</a>
+        </p>
+    </tldr>
+    <link-summary>
+        애플리케이션 배포 요구 사항에 따라 서버를 생성하는 방법을 알아봅니다.
+    </link-summary>
+    <p>
+        Ktor 애플리케이션을 생성하기 전에, 애플리케이션을 어떻게
+        <Links href="//server-deployment" summary="">
+            배포(deploy)
+        </Links>
+        할 것인지 고려해야 합니다:
+    </p>
+    <list>
+        <li>
+            <p>
+                <control><a href="#embedded">독립형 패키지(self-contained package)</a></control> 형태
+            </p>
+            <p>
+                이 경우, 네트워크 요청을 처리하는 데 사용되는 애플리케이션 <Links href="//server-engines" summary="네트워크 요청을 처리하는 엔진에 대해 알아봅니다.">엔진(engine)</Links>이 애플리케이션의 일부가 되어야 합니다.
+                애플리케이션은 엔진 설정, 연결 및 SSL 옵션에 대한 제어권을 갖습니다.
+            </p>
+        </li>
+        <li>
+            <p>
+                <control>
+                    <a href="#servlet">서블릿(servlet)</a>
+                </control> 형태
+            </p>
+            <p>
+                이 경우, Ktor 애플리케이션은 애플리케이션 생명주기와 연결 설정을 제어하는 서블릿 컨테이너(Tomcat 또는 Jetty 등) 내부에서 배포될 수 있습니다.
+            </p>
+        </li>
+    </list>
+    <chapter title="독립형 패키지" id="embedded">
+        <p>
+            Ktor 서버 애플리케이션을 독립형 패키지로 제공하려면 먼저 서버를 생성해야 합니다.
+            서버 설정에는 서버 <Links href="//server-engines" summary="네트워크 요청을 처리하는 엔진에 대해 알아봅니다.">엔진</Links>(Netty, Jetty 등),
+            다양한 엔진 전용 옵션, 호스트 및 포트 값 등 다양한 설정이 포함될 수 있습니다.
+            Ktor에서 서버를 생성하고 실행하는 두 가지 주요 접근 방식은 다음과 같습니다:
+        </p>
+        <list>
+            <li>
+                <p>
+                    <code>embeddedServer</code> 함수는
+                    <a href="#embedded-server">
+                        코드에서 서버 파라미터를 설정
+                    </a>
+                    하고 애플리케이션을 빠르게 실행할 수 있는 간단한 방법입니다.
+                </p>
+            </li>
+            <li>
+                <p>
+                    <code>EngineMain</code>은 서버 설정을 위한 더 많은 유연성을 제공합니다.
+                    <a href="#engine-main">
+                        파일에 서버 파라미터를 지정
+                    </a>
+                    할 수 있으며 애플리케이션을 다시 컴파일하지 않고도 설정을 변경할 수 있습니다.
+                    또한, 명령줄(command line)에서 애플리케이션을 실행하고 해당 명령줄 인수를 전달하여 필요한 서버 파라미터를 재정의(override)할 수 있습니다.
+                </p>
+            </li>
+        </list>
+        <chapter title="코드를 통한 설정" id="embedded-server">
+            <p>
+                <code>embeddedServer</code> 함수는
+                <Links href="//server-configuration-code" summary="코드에서 다양한 서버 파라미터를 설정하는 방법을 알아봅니다.">코드</Links>
+                에서 서버 파라미터를 설정하고 애플리케이션을 빠르게 실행하는 간단한 방법입니다. 아래의 코드 스니펫에서 이 함수는 서버를 시작하기 위해
+                <Links href="//server-engines" summary="네트워크 요청을 처리하는 엔진에 대해 알아봅니다.">엔진</Links>
+                과 포트를 파라미터로 받습니다. 다음 예제에서는 <code>Netty</code> 엔진을 사용하여 서버를 실행하고 <code>8080</code> 포트에서 수신 대기합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example&#10;&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    if (args.isEmpty()) {&#10;        println(&quot;Running basic server...&quot;)&#10;        println(&quot;Provide the 'configured' argument to run a configured server.&quot;)&#10;        runBasicServer()&#10;    }&#10;&#10;    when (args[0]) {&#10;        &quot;basic&quot; -&gt; runBasicServer()&#10;        &quot;configured&quot; -&gt; runConfiguredServer()&#10;        else -&gt; runServerWithCommandLineConfig(args)&#10;    }&#10;}&#10;&#10;fun runBasicServer() {&#10;    embeddedServer(Netty, port = 8080) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}&#10;&#10;fun runConfiguredServer() {&#10;    embeddedServer(Netty, configure = {&#10;        connectors.add(EngineConnectorBuilder().apply {&#10;            host = &quot;127.0.0.1&quot;&#10;            port = 8080&#10;        })&#10;        connectionGroupSize = 2&#10;        workerGroupSize = 5&#10;        callGroupSize = 10&#10;        shutdownGracePeriod = 2000&#10;        shutdownTimeout = 3000&#10;    }) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}&#10;&#10;fun runServerWithCommandLineConfig(args: Array&lt;String&gt;) {&#10;    embeddedServer(&#10;        factory = Netty,&#10;        configure = {&#10;            val cliConfig = CommandLineConfig(args)&#10;            takeFrom(cliConfig.engineConfig)&#10;            loadCommonConfiguration(cliConfig.rootConfig.environment.config)&#10;        }&#10;    ) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+            <p>
+                전체 예제는
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">
+                    embedded-server
+                </a>
+                를 참조하세요.
+            </p>
+        </chapter>
+        <chapter title="파일을 통한 설정" id="engine-main">
+            <p>
+                <code>EngineMain</code>은 선택한 엔진으로 서버를 시작하고 외부 <Links href="//server-configuration-file" summary="설정 파일에서 다양한 서버 파라미터를 설정하는 방법을 알아봅니다.">설정 파일</Links>(일반적으로 <Path>resource</Path> 디렉터리에 위치한 <Path>application.conf</Path> 또는 <Path>application.yaml</Path>)로부터 <Links href="//server-modules" summary="모듈을 사용하면 라우트를 그룹화하여 애플리케이션을 구조화할 수 있습니다.">애플리케이션 모듈</Links>을 로드합니다.
+            </p>
+            <p>
+                로드할 모듈을 지정하는 것 외에도, 설정 파일에는 포트, 호스트, SSL 설정과 같은 다양한 서버 파라미터를 포함할 수 있습니다. 예를 들어, 아래 설정은 서버 포트를 <code>8080</code>으로 설정합니다.
+            </p>
+            <Tabs>
+                <TabItem title="Application.kt" id="application-kt">
+                    <code-block lang="kotlin" code="package com.example&#10;&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit = io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, world!&quot;)&#10;        }&#10;    }&#10;}"/>
+                </TabItem>
+                <TabItem title="application.conf" id="application-conf">
+                    <code-block code="ktor {&#10;    deployment {&#10;        port = 8080&#10;    }&#10;    application {&#10;        modules = [ com.example.ApplicationKt.module ]&#10;    }&#10;}"/>
+                </TabItem>
+                <TabItem title="application.yaml" id="application-yaml">
+                    <code-block lang="yaml" code="ktor:&#10;    deployment:&#10;        port: 8080&#10;    application:&#10;        modules:&#10;            - com.example.ApplicationKt.module"/>
+                </TabItem>
+            </Tabs>
+            <note>
+                <code>EngineMain.main()</code>으로 서버를 즉시 시작하는 대신, <code>EngineMain.createServer()</code>를 사용하여 서버 인스턴스를 수동으로 생성할 수 있습니다. 자세한 내용은 <a href="#createServer"></a>를 참조하세요.
+            </note>
+            <p>
+                전체 예제는
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">
+                    engine-main
+                </a>
+                및
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-yaml">
+                    engine-main-yaml
+                </a>
+                을 참조하세요.
+            </p>
+        </chapter>
+    </chapter>
+    <chapter title="서블릿(Servlet)" id="servlet">
+        <p>
+            Ktor 애플리케이션은 Tomcat 및 Jetty를 포함한 서블릿 컨테이너 내부에서 실행 및 배포될 수 있습니다.
+            서블릿 컨테이너 내부에 배포하려면
+            <Links href="//server-war" summary="WAR 아카이브를 사용하여 서블릿 컨테이너 내에서 Ktor 애플리케이션을 실행하고 배포하는 방법을 알아봅니다.">WAR</Links>
+            아카이브를 생성한 다음, WAR를 지원하는 서버나 클라우드 서비스에 배포해야 합니다.
+        </p>
+    </chapter>
+</topic>

--- a/docs/ko/ktor/server-create-restful-apis.md
+++ b/docs/ko/ktor/server-create-restful-apis.md
@@ -1,0 +1,510 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Ktor를 사용하여 Kotlin에서 RESTful API를 생성하는 방법" id="server-create-restful-apis"
+       help-id="create-restful-apis">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <var name="example_name" value="tutorial-server-restful-api"/>
+    <p>
+        <b>코드 예제</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+    <p>
+        <b>사용된 플러그인</b>: <Links href="//server-routing" summary="Routing은 서버 애플리케이션에서 들어오는 요청을 처리하기 위한 핵심 플러그인입니다.">Routing</Links>,<Links href="//server-static-content" summary="스타일시트, 스크립트, 이미지 등과 같은 정적 콘텐츠를 제공하는 방법을 알아봅니다.">Static Content</Links>,
+        <Links href="//server-serialization" summary="ContentNegotiation 플러그인은 클라이언트와 서버 간의 미디어 유형 협상과 특정 형식의 콘텐츠 직렬화/역직렬화라는 두 가지 주요 목적을 수행합니다.">Content Negotiation</Links>, <a
+            href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>
+    </p>
+</tldr>
+<card-summary>
+    Ktor를 사용하여 RESTful API를 구축하는 방법을 알아봅니다. 이 튜토리얼은 실제 예제를 통해 설정, 라우팅 및 테스트를 다룹니다.
+</card-summary>
+<web-summary>
+    Ktor로 Kotlin RESTful API를 구축하는 방법을 배웁니다. 이 튜토리얼은 실제 예제를 통해 설정, 라우팅 및 테스트를 다룹니다. Kotlin 백엔드 개발자를 위한 이상적인 입문용 튜토리얼입니다.
+</web-summary>
+<link-summary>
+    Kotlin과 Ktor를 사용하여 JSON 파일을 생성하는 RESTful API 예제를 포함한 백엔드 서비스를 구축하는 방법을 알아봅니다.
+</link-summary>
+<p>
+    이 튜토리얼에서는 JSON 파일을 생성하는 RESTful API 예제를 통해 Kotlin과 Ktor를 사용하여 백엔드 서비스를 구축하는 방법을 설명합니다.
+</p>
+<p>
+    <Links href="//server-requests-and-responses" summary="작업 관리자 애플리케이션을 구축하며 Ktor를 사용한 Kotlin의 라우팅 기초, 요청 처리 및 파라미터에 대해 알아봅니다.">이전 튜토리얼</Links>에서는 유효성 검사, 에러 처리 및 유닛 테스트의 기초를 소개했습니다. 이번 튜토리얼에서는 이러한 주제를 확장하여 작업을 관리하는 RESTful 서비스를 만들어 보겠습니다.
+</p>
+<p>
+    다음 내용을 배우게 됩니다:
+</p>
+<list>
+    <li>JSON 직렬화(serialization)를 사용하는 RESTful 서비스 생성하기.</li>
+    <li><Links href="//server-serialization" summary="ContentNegotiation 플러그인은 클라이언트와 서버 간의 미디어 유형 협상과 특정 형식의 콘텐츠 직렬화/역직렬화라는 두 가지 주요 목적을 수행합니다.">Content Negotiation (콘텐츠 협상)</Links> 프로세스 이해하기.</li>
+    <li>Ktor 내에서 REST API를 위한 라우트 정의하기.</li>
+</list>
+<chapter title="사전 준비 사항" id="prerequisites">
+    <p>이 튜토리얼은 독립적으로 진행할 수 있지만, <Links href="//server-requests-and-responses" summary="작업 관리자 애플리케이션을 구축하며 Ktor를 사용한 Kotlin의 라우팅 기초, 요청 처리 및 파라미터에 대해 알아봅니다.">요청을 처리하고 응답을 생성하는 방법</Links>을 배우기 위해 이전 튜토리얼을 먼저 완료하는 것을 강력히 권장합니다.
+    </p>
+    <p><a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA</a>를 설치할 것을 권장하지만, 원하는 다른 IDE를 사용할 수도 있습니다.
+    </p>
+</chapter>
+<chapter title="Hello RESTful Task Manager" id="hello-restful-task-manager">
+    <p>이 튜토리얼에서는 기존의 Task Manager(작업 관리자)를 RESTful 서비스로 다시 작성해 보겠습니다. 이를 위해 여러 Ktor <Links href="//server-plugins" summary="플러그인은 직렬화, 콘텐츠 인코딩, 압축 등과 같은 공통 기능을 제공합니다.">플러그인</Links>을 사용합니다.</p>
+    <p>
+        기존 프로젝트에 수동으로 추가할 수도 있지만, 새 프로젝트를 생성한 다음 이전 튜토리얼의 코드를 점진적으로 추가하는 것이 더 간단합니다. 진행하면서 모든 코드를 다시 반복할 것이므로 이전 프로젝트를 가지고 있을 필요는 없습니다.
+    </p>
+    <procedure title="플러그인을 포함한 새 프로젝트 생성">
+        <step>
+            <p>
+                <a href="https://start.ktor.io/">Ktor Project Generator</a>로 이동합니다.
+            </p>
+        </step>
+        <step>
+            <p><control>Project artifact</control> 필드에 프로젝트 아티팩트 이름으로
+                <Path>com.example.ktor-rest-task-app</Path>를 입력합니다.
+                <img src="tutorial_creating_restful_apis_project_artifact.png"
+                     alt="Ktor Project Generator에서 프로젝트 아티팩트 이름 지정"
+                     style="block"
+                     border-effect="line"
+                     width="706"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                Plugins 섹션에서 <control>Add</control> 버튼을 클릭하여 다음 플러그인들을 검색하고 추가합니다:
+            </p>
+            <list type="bullet">
+                <li>Content Negotiation</li>
+                <li>kotlinx.serialization</li>
+                <li>Static Content</li>
+            </list>
+            <p>
+                <img src="ktor_project_generator_add_plugins.gif" alt="Ktor Project Generator에서 플러그인 추가하기"
+                     border-effect="line"
+                     style="block"
+                     width="706"/>
+                플러그인을 추가하면 프로젝트 설정 아래에 모든 플러그인이 나열되는 것을 볼 수 있습니다.
+                <img src="tutorial_creating_restful_apis_plugins_list.png"
+                     alt="Ktor Project Generator의 플러그인 목록"
+                     border-effect="line"
+                     style="block"
+                     width="706"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                <control>Download</control> 버튼을 클릭하여 Ktor 프로젝트를 생성하고 다운로드합니다.
+            </p>
+        </step>
+    </procedure>
+    <procedure title="시작 코드 추가" id="add-starter-code">
+        <step>
+            <p><a href="server-create-a-new-project.topic#open-explore-run">IntelliJ IDEA에서 Ktor 프로젝트 열기, 탐색 및 실행</a> 튜토리얼에서 설명한 대로 IntelliJ IDEA에서 프로젝트를 엽니다.</p>
+        </step>
+        <step>
+            <p>
+                <Path>src/main/kotlin</Path>으로 이동하여 <Path>model</Path>이라는 하위 패키지를 생성합니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>model</Path> 패키지 안에 새 <Path>Task.kt</Path> 파일을 생성합니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>Task.kt</Path> 파일을 열고 우선순위를 나타내는 <code>enum</code>과 작업을 나타내는 <code>class</code>를 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+            <p>
+                이전 튜토리얼에서는 확장 함수를 사용하여 <code>Task</code>를 HTML로 변환했습니다. 이번에는 <code>Task</code> 클래스에 <code>kotlinx.serialization</code> 라이브러리의 <a
+                    href="https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-serializable/"><code>Serializable</code></a> 타입 어노테이션이 추가되었습니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>Routing.kt</Path> 파일을 열고 기존 코드를 아래 구현으로 교체합니다:
+            </p>
+            <code-block lang="kotlin" code="                    package com.example&#10;&#10;                    import com.example.model.*&#10;                    import io.ktor.server.application.*&#10;                    import io.ktor.server.http.content.*&#10;                    import io.ktor.server.response.*&#10;                    import io.ktor.server.routing.*&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            staticResources(&quot;static&quot;, &quot;static&quot;)&#10;&#10;                            get(&quot;/tasks&quot;) {&#10;                                call.respond(&#10;                                    listOf(&#10;                                        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                                        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                                        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                                        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;                                    )&#10;                                )&#10;                            }&#10;                        }&#10;                    }"/>
+            <p>
+                이전 튜토리얼과 마찬가지로 URL <code>/tasks</code>에 대한 GET 요청 라우트를 만들었습니다. 이번에는 작업 목록을 수동으로 변환하는 대신 목록 자체를 반환하고 있습니다.
+            </p>
+        </step>
+        <step>
+            <p>IntelliJ IDEA에서 실행 버튼(<img src="intellij_idea_gutter_icon.svg"
+                          style="inline" height="16" width="16"
+                          alt="intelliJ IDEA 실행 아이콘"/>)을 클릭하여 애플리케이션을 시작합니다.</p>
+        </step>
+        <step>
+            <p>
+                브라우저에서 <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a>로 이동합니다. 아래와 같이 JSON 형식의 작업 목록을 볼 수 있습니다:
+            </p>
+        </step>
+        <img src="tutorial_creating_restful_apis_starter_code_preview.png"
+             alt="브라우저 화면에 표시된 JSON 데이터"
+             border-effect="rounded"
+             width="706"/>
+        <p>상당히 많은 작업이 우리 대신 수행되고 있습니다. 정확히 무슨 일이 일어나고 있는 걸까요?</p>
+    </procedure>
+</chapter>
+<chapter title="Content Negotiation(콘텐츠 협상) 이해하기" id="content-negotiation">
+    <chapter title="브라우저를 통한 Content Negotiation" id="via-browser">
+        <p>
+            프로젝트를 생성할 때 <Links href="//server-serialization" summary="ContentNegotiation 플러그인은 클라이언트와 서버 간의 미디어 유형 협상과 특정 형식의 콘텐츠 직렬화/역직렬화라는 두 가지 주요 목적을 수행합니다.">Content Negotiation</Links> 플러그인을 포함했습니다. 이 플러그인은 클라이언트가 렌더링할 수 있는 콘텐츠 유형을 확인하고, 이를 현재 서비스가 제공할 수 있는 콘텐츠 유형과 매칭합니다. 그래서 <format style="italic">Content Negotiation(콘텐츠 협상)</format>이라는 용어를 사용합니다.
+        </p>
+        <p>
+            HTTP에서 클라이언트는 <code>Accept</code> 헤더를 통해 자신이 렌더링할 수 있는 콘텐츠 유형을 알립니다. 이 헤더의 값은 하나 이상의 콘텐츠 유형입니다. 위의 경우 브라우저에 내장된 개발자 도구를 사용하여 이 헤더의 값을 확인할 수 있습니다.
+        </p>
+        <p>
+            다음 예시를 살펴보세요:
+        </p>
+        <code-block code="                text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"/>
+        <p><code>&#42;/&#42;</code>가 포함되어 있음에 유의하세요. 이 헤더는 HTML, XML 또는 이미지를 허용하지만, 그 외의 다른 모든 콘텐츠 유형도 허용하겠다는 신호입니다.</p>
+        <p>Content Negotiation 플러그인은 브라우저에 데이터를 다시 보낼 형식을 찾아야 합니다. 프로젝트의 생성된 코드 내부를 보면 <Path>src/main/kotlin</Path> 안에 <Path>Serialization.kt</Path>라는 파일이 있으며, 여기에는 다음 내용이 포함되어 있습니다:
+        </p>
+        <code-block lang="kotlin" code="fun Application.configureSerialization() {&#10;    install(ContentNegotiation) {&#10;        json()&#10;    }&#10;}"/>
+        <p>
+            이 코드는 <code>ContentNegotiation</code> 플러그인을 설치하고 <code>kotlinx.serialization</code> 플러그인을 구성합니다. 이렇게 하면 클라이언트가 요청을 보낼 때 서버가 JSON으로 직렬화된 객체를 다시 보낼 수 있습니다.
+        </p>
+        <p>
+            브라우저의 요청의 경우, <code>ContentNegotiation</code> 플러그인은 JSON만 반환할 수 있다는 것을 알고 있고, 브라우저는 수신된 모든 것을 표시하려고 시도합니다. 따라서 요청이 성공합니다.
+        </p>
+    </chapter>
+    <procedure title="JavaScript를 통한 Content Negotiation" id="via-javascript">
+        <p>
+            프로덕션 환경에서는 일반적으로 JSON을 브라우저에 직접 표시하지 않습니다. 대신 브라우저에서 실행되는 JavaScript 코드가 요청을 수행한 다음 반환된 데이터를 SPA(Single Page Application)의 일부로 표시합니다. 일반적으로 이러한 종류의 애플리케이션은 <a href="https://react.dev/">React</a>, <a href="https://angular.io/">Angular</a> 또는 <a href="https://vuejs.org/">Vue.js</a>와 같은 프레임워크를 사용하여 작성됩니다.
+        </p>
+        <step>
+            <p>
+                이를 시뮬레이션하기 위해 <Path>src/main/resources/static</Path> 내부의 <Path>index.html</Path> 페이지를 열고 기본 콘텐츠를 다음으로 교체합니다:
+            </p>
+            <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;A Simple SPA For Tasks&lt;/title&gt;&#10;    &lt;script type=&quot;application/javascript&quot;&gt;&#10;        function fetchAndDisplayTasks() {&#10;            fetchTasks()&#10;                .then(tasks =&gt; displayTasks(tasks))&#10;        }&#10;&#10;        function fetchTasks() {&#10;            return fetch(&#10;                &quot;/tasks&quot;,&#10;                {&#10;                    headers: { 'Accept': 'application/json' }&#10;                }&#10;            ).then(resp =&gt; resp.json());&#10;        }&#10;&#10;        function displayTasks(tasks) {&#10;            const tasksTableBody = document.getElementById(&quot;tasksTableBody&quot;)&#10;            tasks.forEach(task =&gt; {&#10;                const newRow = taskRow(task);&#10;                tasksTableBody.appendChild(newRow);&#10;            });&#10;        }&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Viewing Tasks Via JS&lt;/h1&gt;&#10;&lt;form action=&quot;javascript:fetchAndDisplayTasks()&quot;&gt;&#10;    &lt;input type=&quot;submit&quot; value=&quot;View The Tasks&quot;&gt;&#10;&lt;/form&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            <p>
+                이 페이지는 HTML 폼과 빈 테이블을 포함하고 있습니다. 폼을 제출하면 JavaScript 이벤트 핸들러가 <code>Accept</code> 헤더를 <code>application/json</code>으로 설정하여 <code>/tasks</code> 엔드포인트로 요청을 보냅니다. 반환된 데이터는 역직렬화되어 HTML 테이블에 추가됩니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                IntelliJ IDEA에서 재실행 버튼(<img src="intellij_idea_rerun_icon.svg"
+                                               style="inline" height="16" width="16"
+                                               alt="intelliJ IDEA 재실행 아이콘"/>)을 클릭하여 애플리케이션을 다시 시작합니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                URL <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a>로 이동합니다. <control>View The Tasks</control> 버튼을 클릭하여 데이터를 가져올 수 있습니다:
+            </p>
+            <img src="tutorial_creating_restful_apis_tasks_via_js.png"
+                 alt="HTML 테이블로 표시된 작업들과 버튼을 보여주는 브라우저 창"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="GET 라우트 추가하기" id="porting-get-routes">
+    <p>
+        이제 콘텐츠 협상 프로세스에 익숙해졌으니, <Links href="//server-requests-and-responses" summary="작업 관리자 애플리케이션을 구축하며 Ktor를 사용한 Kotlin의 라우팅 기초, 요청 처리 및 파라미터에 대해 알아봅니다.">이전 튜토리얼</Links>의 기능을 이 프로젝트로 옮겨 보겠습니다.
+    </p>
+    <chapter title="작업 레포지토리 재사용" id="task-repository">
+        <p>
+            작업 레포지토리는 수정 없이 재사용할 수 있으므로, 이를 먼저 수행하겠습니다.
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    <Path>model</Path> 패키지 안에 새 <Path>TaskRepository.kt</Path> 파일을 생성합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>TaskRepository.kt</Path>를 열고 아래 코드를 추가합니다:
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&#10;        tasks.add(task)&#10;    }&#10;}"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="GET 요청 라우트 재사용" id="get-requests">
+        <p>
+            레포지토리를 만들었으므로 GET 요청을 위한 라우트를 구현할 수 있습니다. 작업을 HTML로 변환하는 것을 더 이상 걱정할 필요가 없으므로 이전 코드를 단순화할 수 있습니다:
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    <Path>src/main/kotlin</Path>에 있는 <Path>Routing.kt</Path> 파일로 이동합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <code>Application.configureRouting()</code> 함수 내부의 <code>/tasks</code> 라우트 코드를 다음 구현으로 업데이트합니다:
+                </p>
+                <code-block lang="kotlin" code="                    package com.example&#10;&#10;                    import com.example.model.Priority&#10;                    import com.example.model.TaskRepository&#10;                    import io.ktor.http.*&#10;                    import io.ktor.server.application.*&#10;                    import io.ktor.server.http.content.*&#10;                    import io.ktor.server.response.*&#10;                    import io.ktor.server.routing.*&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            staticResources(&quot;static&quot;, &quot;static&quot;)&#10;&#10;                            //업데이트된 구현&#10;                            route(&quot;/tasks&quot;) {&#10;                                get {&#10;                                    val tasks = TaskRepository.allTasks()&#10;                                    call.respond(tasks)&#10;                                }&#10;&#10;                                get(&quot;/byName/{taskName}&quot;) {&#10;                                    val name = call.parameters[&quot;taskName&quot;]&#10;                                    if (name == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@get&#10;                                    }&#10;&#10;                                    val task = TaskRepository.taskByName(name)&#10;                                    if (task == null) {&#10;                                        call.respond(HttpStatusCode.NotFound)&#10;                                        return@get&#10;                                    }&#10;                                    call.respond(task)&#10;                                }&#10;                                get(&quot;/byPriority/{priority}&quot;) {&#10;                                    val priorityAsText = call.parameters[&quot;priority&quot;]&#10;                                    if (priorityAsText == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@get&#10;                                    }&#10;                                    try {&#10;                                        val priority = Priority.valueOf(priorityAsText)&#10;                                        val tasks = TaskRepository.tasksByPriority(priority)&#10;&#10;                                        if (tasks.isEmpty()) {&#10;                                            call.respond(HttpStatusCode.NotFound)&#10;                                            return@get&#10;                                        }&#10;                                        call.respond(tasks)&#10;                                    } catch (ex: IllegalArgumentException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+                <p>
+                    이제 서버는 다음과 같은 GET 요청에 응답할 수 있습니다:</p>
+                <list>
+                    <li><code>/tasks</code>는 레포지토리의 모든 작업을 반환합니다.</li>
+                    <li><code>/tasks/byName/{taskName}</code>은 지정된 <code>taskName</code>으로 필터링된 작업을 반환합니다.</li>
+                    <li><code>/tasks/byPriority/{priority}</code>는 지정된 <code>priority</code>로 필터링된 작업들을 반환합니다.</li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA에서 재실행 버튼(<img src="intellij_idea_rerun_icon.svg"
+                                                   style="inline" height="16" width="16"
+                                                   alt="intelliJ IDEA 재실행 아이콘"/>)을 클릭하여 애플리케이션을 다시 시작합니다.
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="기능 테스트하기" id="test-tasks-routes">
+        <procedure title="브라우저 사용하기">
+            <p>브라우저에서 이러한 라우트를 테스트할 수 있습니다. 예를 들어, <a
+                    href="http://0.0.0.0:8080/tasks/byPriority/Medium">http://0.0.0.0:8080/tasks/byPriority/Medium</a>으로 이동하면 <code>Medium</code> 우선순위를 가진 모든 작업이 JSON 형식으로 표시되는 것을 볼 수 있습니다:</p>
+            <img src="tutorial_creating_restful_apis_tasks_medium_priority.png"
+                 alt="브라우저 창에서 JSON 형식으로 표시된 Medium 우선순위 작업들"
+                 border-effect="rounded"
+                 width="706"/>
+            <p>
+                이러한 요청은 일반적으로 JavaScript에서 오기 때문에 더 세밀한 테스트가 바람직합니다. 이를 위해 <a
+                    href="https://learning.postman.com/docs/sending-requests/requests/">Postman</a>과 같은 전문 도구를 사용할 수 있습니다.
+            </p>
+        </procedure>
+        <procedure title="Postman 사용하기">
+            <step>
+                <p>Postman에서 URL이 <code>http://0.0.0.0:8080/tasks/byPriority/Medium</code>인 새 GET 요청을 만듭니다.</p>
+            </step>
+            <step>
+                <p>
+                    <ui-path>Headers</ui-path> 패널에서 <ui-path>Accept</ui-path> 헤더의 값을 <code>application/json</code>으로 설정합니다.
+                </p>
+            </step>
+            <step>
+                <p><control>Send</control>를 클릭하여 요청을 보내고 응답 뷰어에서 응답을 확인합니다.
+                </p>
+                <img src="tutorial_creating_restful_apis_tasks_medium_priority_postman.png"
+                     alt="Postman에서 JSON 형식의 Medium 우선순위 작업을 보여주는 GET 요청"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+        <procedure title="HTTP 요청 파일 사용하기">
+            <p>IntelliJ IDEA Ultimate에서는 HTTP 요청 파일에서 동일한 단계를 수행할 수 있습니다.</p>
+            <step>
+                <p>
+                    프로젝트 루트 디렉토리에 새 <Path>REST Task Manager.http</Path> 파일을 생성합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>REST Task Manager.http</Path> 파일을 열고 다음 GET 요청을 추가합니다:
+                </p>
+                <code-block lang="http" code="GET http://0.0.0.0:8080/tasks/byPriority/Medium&#10;Accept: application/json"/>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA 내에서 요청을 보내려면 옆에 있는 거터 아이콘(<img
+                        alt="intelliJ IDEA 거터 아이콘"
+                        src="intellij_idea_gutter_icon.svg"
+                        width="16" height="26"/>)을 클릭합니다.
+                </p>
+            </step>
+            <step>
+                <p>이것은 <Path>Services</Path> 도구 창에서 열리고 실행됩니다:
+                </p>
+                <img src="tutorial_creating_restful_apis_tasks_medium_priority_http_file.png"
+                     alt="HTTP 파일에서 JSON 형식의 Medium 우선순위 작업을 보여주는 GET 요청"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+        <note>
+            라우트를 테스트하는 또 다른 방법은 Kotlin Notebook 내에서 <a
+                href="https://khttp.readthedocs.io/en/latest/">khttp</a> 라이브러리를 사용하는 것입니다.
+        </note>
+    </chapter>
+</chapter>
+<chapter title="POST 요청을 위한 라우트 추가하기" id="add-a-route-for-post-requests">
+    <p>
+        이전 튜토리얼에서는 HTML 폼을 통해 작업을 생성했습니다. 하지만 이제 RESTful 서비스를 구축하고 있으므로 더 이상 그렇게 할 필요가 없습니다. 대신 대부분의 번거로운 작업을 대신 해줄 <code>kotlinx.serialization</code> 프레임워크를 활용할 것입니다.
+    </p>
+    <procedure>
+        <step>
+            <p>
+                <Path>src/main/kotlin</Path> 내부의 <Path>Routing.kt</Path> 파일을 엽니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                다음과 같이 <code>Application.configureRouting()</code> 함수에 새 POST 라우트를 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="                    //...&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            //...&#10;&#10;                            route(&quot;/tasks&quot;) {&#10;                                //...&#10;&#10;                                //다음 새 라우트 추가&#10;                                post {&#10;                                    try {&#10;                                        val task = call.receive&lt;Task&gt;()&#10;                                        TaskRepository.addTask(task)&#10;                                        call.respond(HttpStatusCode.Created)&#10;                                    } catch (ex: IllegalStateException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    } catch (ex: SerializationException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+            <p>
+                다음의 새 import 문들을 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="                    //...&#10;                    import com.example.model.Task&#10;                    import io.ktor.server.request.receive&#10;                    import kotlinx.serialization.SerializationException"/>
+            <p>
+                POST 요청이 <code>/tasks</code>로 전송되면, <code>kotlinx.serialization</code> 프레임워크가 요청 본문을 <code>Task</code> 객체로 변환하는 데 사용됩니다. 성공하면 작업이 레포지토리에 추가됩니다. 역직렬화 프로세스가 실패하면 서버는 <code>SerializationException</code>을 처리하고, 작업이 중복된 경우 <code>IllegalStateException</code>을 처리합니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                애플리케이션을 다시 시작합니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                Postman에서 이 기능을 테스트하려면 URL <code>http://0.0.0.0:8080/tasks</code>로 새 POST 요청을 만듭니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                <ui-path>Body</ui-path> 패널에 새 작업을 나타내는 다음 JSON 문서를 추가합니다:
+            </p>
+            <code-block lang="json" code="{&#10;    &quot;name&quot;: &quot;cooking&quot;,&#10;    &quot;description&quot;: &quot;Cook the dinner&quot;,&#10;    &quot;priority&quot;: &quot;High&quot;&#10;}"/>
+            <img src="tutorial_creating_restful_apis_add_task.png"
+                 alt="새 작업을 추가하기 위한 Postman의 POST 요청"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+        <step>
+            <p><control>Send</control>을 클릭하여 요청을 보냅니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a>로 GET 요청을 보내 작업이 추가되었는지 확인할 수 있습니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                IntelliJ IDEA Ultimate 내에서 HTTP 요청 파일에 다음 내용을 추가하여 동일한 단계를 수행할 수 있습니다:
+            </p>
+            <code-block lang="http" code="###&#10;&#10;POST http://0.0.0.0:8080/tasks&#10;Content-Type: application/json&#10;&#10;{&#10;    &quot;name&quot;: &quot;cooking&quot;,&#10;    &quot;description&quot;: &quot;Cook the dinner&quot;,&#10;    &quot;priority&quot;: &quot;High&quot;&#10;}"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="삭제 기능 지원 추가하기" id="remove-tasks">
+    <p>
+        서비스에 기본 작업들을 거의 다 추가했습니다. 이러한 작업들은 종종 CRUD(Create, Read, Update, and Delete) 작업으로 요약됩니다. 이제 삭제(Delete) 작업을 구현하겠습니다.
+    </p>
+    <procedure>
+        <step>
+            <p>
+                <Path>TaskRepository.kt</Path> 파일에서 <code>TaskRepository</code> 객체 내에 이름을 기반으로 작업을 제거하는 다음 메서드를 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="    fun removeTask(name: String): Boolean {&#10;        return tasks.removeIf { it.name == name }&#10;    }"/>
+        </step>
+        <step>
+            <p>
+                <Path>Routing.kt</Path> 파일을 열고 DELETE 요청을 처리할 엔드포인트를 <code>routing()</code> 함수에 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="                    fun Application.configureRouting() {&#10;                        //...&#10;&#10;                        routing {&#10;                            route(&quot;/tasks&quot;) {&#10;                                //...&#10;                                //다음 함수 추가&#10;                                delete(&quot;/{taskName}&quot;) {&#10;                                    val name = call.parameters[&quot;taskName&quot;]&#10;                                    if (name == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@delete&#10;                                    }&#10;&#10;                                    if (TaskRepository.removeTask(name)) {&#10;                                        call.respond(HttpStatusCode.NoContent)&#10;                                    } else {&#10;                                        call.respond(HttpStatusCode.NotFound)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+        </step>
+        <step>
+            <p>
+                애플리케이션을 다시 시작합니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                HTTP 요청 파일에 다음 DELETE 요청을 추가합니다:
+            </p>
+            <code-block lang="http" code="###&#10;&#10;DELETE http://0.0.0.0:8080/tasks/gardening"/>
+        </step>
+        <step>
+            <p>
+                IntelliJ IDEA 내에서 DELETE 요청을 보내려면 옆에 있는 거터 아이콘(<img
+                    alt="intelliJ IDEA 거터 아이콘"
+                    src="intellij_idea_gutter_icon.svg"
+                    width="16" height="26"/>)을 클릭합니다.
+            </p>
+        </step>
+        <step>
+            <p><Path>Services</Path> 도구 창에서 응답을 확인할 수 있습니다:
+            </p>
+            <img src="tutorial_creating_restful_apis_delete_task.png"
+                 alt="HTTP 요청 파일에서의 DELETE 요청"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="Ktor Client로 유닛 테스트 생성하기" id="create-unit-tests">
+    <p>
+        지금까지는 애플리케이션을 수동으로 테스트했지만, 이미 눈치채셨겠지만 이 방식은 시간이 많이 걸리고 규모를 확장하기 어렵습니다. 대신 내장된 <code>client</code> 객체를 사용하여 JSON을 가져오고 역직렬화하는 <Links href="//server-testing" summary="특수 테스트 엔진을 사용하여 서버 애플리케이션을 테스트하는 방법을 알아봅니다.">JUnit 테스트</Links>를 구현할 수 있습니다.
+    </p>
+    <procedure>
+        <step>
+            <p>
+                <Path>src/test/kotlin</Path> 안에 있는 <Path>ServerTest.kt</Path> 파일을 엽니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>ServerTest.kt</Path> 파일의 내용을 다음으로 교체합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example&#10;&#10;import com.example.model.Priority&#10;import com.example.model.Task&#10;import io.ktor.client.call.*&#10;import io.ktor.client.plugins.contentnegotiation.*&#10;import io.ktor.client.request.*&#10;import io.ktor.http.*&#10;import io.ktor.serialization.kotlinx.json.*&#10;import io.ktor.server.testing.*&#10;import kotlin.test.*&#10;&#10;class ApplicationTest {&#10;    @Test&#10;    fun tasksCanBeFoundByPriority() = testApplication {&#10;        configure()&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;        }&#10;&#10;        val response = client.get(&quot;/tasks/byPriority/Medium&quot;)&#10;        val results = response.body&lt;List&lt;Task&gt;&gt;()&#10;&#10;        assertEquals(HttpStatusCode.OK, response.status)&#10;&#10;        val expectedTaskNames = listOf(&quot;gardening&quot;, &quot;painting&quot;)&#10;        val actualTaskNames = results.map(Task::name)&#10;        assertContentEquals(expectedTaskNames, actualTaskNames)&#10;    }&#10;&#10;    @Test&#10;    fun invalidPriorityProduces400() = testApplication {&#10;        configure()&#10;        val response = client.get(&quot;/tasks/byPriority/Invalid&quot;)&#10;        assertEquals(HttpStatusCode.BadRequest, response.status)&#10;    }&#10;&#10;&#10;    @Test&#10;    fun unusedPriorityProduces404() = testApplication {&#10;        configure()&#10;        val response = client.get(&quot;/tasks/byPriority/Vital&quot;)&#10;        assertEquals(HttpStatusCode.NotFound, response.status)&#10;    }&#10;&#10;    @Test&#10;    fun newTasksCanBeAdded() = testApplication {&#10;        configure()&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;        }&#10;&#10;        val task = Task(&quot;swimming&quot;, &quot;Go to the beach&quot;, Priority.Low)&#10;        val response1 = client.post(&quot;/tasks&quot;) {&#10;            header(&#10;                HttpHeaders.ContentType,&#10;                ContentType.Application.Json&#10;            )&#10;&#10;            setBody(task)&#10;        }&#10;        assertEquals(HttpStatusCode.Created, response1.status)&#10;&#10;        val response2 = client.get(&quot;/tasks&quot;)&#10;        assertEquals(HttpStatusCode.OK, response2.status)&#10;&#10;        val taskNames = response2&#10;            .body&lt;List&lt;Task&gt;&gt;()&#10;            .map { it.name }&#10;&#10;        assertContains(taskNames, &quot;swimming&quot;)&#10;    }&#10;}"/>
+            <p>
+                서버에서 했던 것과 동일한 방식으로 <a href="client-create-and-configure.md#plugins">Plugins</a>에 <code>ContentNegotiation</code> 및 <code>kotlinx.serialization</code> 플러그인을 설치해야 함에 유의하세요.
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>build.gradle.kts</Path> 파일에 다음 종속성을 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="                    testImplementation(ktorLibs.client.contentNegotiation)"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="JsonPath로 유닛 테스트 생성하기" id="unit-tests-via-jsonpath">
+    <p>
+        Ktor 클라이언트나 유사한 라이브러리로 서비스를 테스트하는 것은 편리하지만, 품질 보증(QA) 관점에서는 단점이 있습니다. JSON을 직접 처리하지 않는 서버는 JSON 구조에 대한 가정이 확실하다고 확신할 수 없습니다.
+    </p>
+    <p>
+        예를 들어 다음과 같은 가정들입니다:
+    </p>
+    <list>
+        <li>실제로는 <code>object</code>가 사용되는데 값이 <code>array</code>에 저장되고 있다고 가정하는 경우.</li>
+        <li>속성이 실제로는 <code>strings</code>인데 <code>numbers</code>로 저장되고 있다고 가정하는 경우.</li>
+        <li>멤버가 선언된 순서대로 직렬화되지 않는데 순서대로 된다고 가정하는 경우.</li>
+    </list>
+    <p>
+        서비스를 여러 클라이언트가 사용할 예정이라면 JSON 구조에 대한 확신을 갖는 것이 중요합니다. 이를 위해 Ktor Client를 사용하여 서버에서 텍스트를 가져온 다음 <a href="https://mvnrepository.com/artifact/com.jayway.jsonpath/json-path">JSONPath</a> 라이브러리를 사용하여 이 콘텐츠를 분석합니다.</p>
+    <procedure>
+        <step>
+            <p><Path>build.gradle.kts</Path> 파일의 <code>dependencies</code> 블록에 JSONPath 라이브러리를 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="    testImplementation(&quot;com.jayway.jsonpath:json-path:2.9.0&quot;)"/>
+        </step>
+        <step>
+            <p>
+                <Path>src/test/kotlin</Path> 폴더로 이동하여 새 <Path>ApplicationJsonPathTest.kt</Path> 파일을 생성합니다.
+            </p>
+        </step>
+        <step>
+            <p>
+                <Path>ApplicationJsonPathTest.kt</Path> 파일을 열고 다음 내용을 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example&#10;&#10;import com.jayway.jsonpath.DocumentContext&#10;import com.jayway.jsonpath.JsonPath&#10;import io.ktor.client.*&#10;import com.example.model.Priority&#10;import io.ktor.client.request.*&#10;import io.ktor.client.statement.*&#10;import io.ktor.http.*&#10;import io.ktor.server.testing.*&#10;import kotlin.test.*&#10;&#10;&#10;class ApplicationJsonPathTest {&#10;    @Test&#10;    fun tasksCanBeFound() = testApplication {&#10;        configure()&#10;        val jsonDoc = client.getAsJsonPath(&quot;/tasks&quot;)&#10;&#10;        val result: List&lt;String&gt; = jsonDoc.read(&quot;$[*].name&quot;)&#10;        assertEquals(&quot;cleaning&quot;, result[0])&#10;        assertEquals(&quot;gardening&quot;, result[1])&#10;        assertEquals(&quot;shopping&quot;, result[2])&#10;    }&#10;&#10;    @Test&#10;    fun tasksCanBeFoundByPriority() = testApplication {&#10;        configure()&#10;        val priority = Priority.Medium&#10;        val jsonDoc = client.getAsJsonPath(&quot;/tasks/byPriority/$priority&quot;)&#10;&#10;        val result: List&lt;String&gt; =&#10;            jsonDoc.read(&quot;$[?(@.priority == '$priority')].name&quot;)&#10;        assertEquals(2, result.size)&#10;&#10;        assertEquals(&quot;gardening&quot;, result[0])&#10;        assertEquals(&quot;painting&quot;, result[1])&#10;    }&#10;&#10;    suspend fun HttpClient.getAsJsonPath(url: String): DocumentContext {&#10;        val response = this.get(url) {&#10;            accept(ContentType.Application.Json)&#10;        }&#10;        return JsonPath.parse(response.bodyAsText())&#10;    }&#10;}"/>
+            <p>
+                JsonPath 쿼리는 다음과 같이 작동합니다:
+            </p>
+            <list>
+                <li>
+                    <code>$[&#42;].name</code>은 "문서를 배열로 처리하고 각 항목의 name 속성 값을 반환하라"는 의미입니다.
+                </li>
+                <li>
+                    <code>$[?(@.priority == '$priority')].name</code>은 "우선순위가 제공된 값과 동일한 배열의 모든 항목에 대해 name 속성 값을 반환하라"는 의미입니다.
+                </li>
+            </list>
+            <p>
+                이와 같은 쿼리를 사용하여 반환된 JSON에 대한 이해가 올바른지 확인할 수 있습니다. 코드 리팩토링이나 서비스 재배포를 수행할 때, 현재 프레임워크에서의 역직렬화에 문제가 없더라도 직렬화 과정에서의 모든 변경 사항을 식별할 수 있습니다. 이를 통해 공개적으로 사용 가능한 API를 자신 있게 다시 배포할 수 있습니다.
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="다음 단계" id="next-steps">
+    <p>
+        축하합니다! 이제 Task Manager 애플리케이션을 위한 RESTful API 서비스를 성공적으로 완성했으며, Ktor Client와 JsonPath를 사용한 유닛 테스트의 세부 사항을 배웠습니다.</p>
+    <p>
+        <Links href="//server-create-website" summary="Kotlin과 Ktor, Thymeleaf 템플릿을 사용하여 웹사이트를 구축하는 방법을 알아봅니다.">다음 튜토리얼</Links>로 넘어가서 작성한 API 서비스를 재사용하여 웹 애플리케이션을 구축하는 방법을 배워보세요.
+    </p>
+</chapter>
+</topic>

--- a/docs/ko/ktor/server-create-website.md
+++ b/docs/ko/ktor/server-create-website.md
@@ -1,0 +1,405 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Kotlin과 Ktor로 웹사이트 만들기" id="server-create-website">
+    <show-structure for="chapter,procedure" depth="3"/>
+    <tldr>
+        <var name="example_name" value="tutorial-server-web-application"/>
+        <p>
+            <b>코드 예제</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+        <p>
+            <b>사용된 플러그인</b>: <Links href="//server-static-content" summary="스타일시트, 스크립트, 이미지 등과 같은 정적 콘텐츠를 제공하는 방법을 알아봅니다.">Static Content</Links>,
+            <Links href="//server-thymeleaf" summary="필수 의존성: io.ktor:%artifact_name%">Thymeleaf</Links>
+        </p>
+    </tldr>
+    <web-summary>
+        Ktor와 Kotlin으로 웹사이트를 구축하는 방법을 알아봅니다. 이 튜토리얼에서는 타임리프(Thymeleaf) 템플릿과 Ktor 라우트를 결합하여 서버 사이드에서 HTML 기반 사용자 인터페이스를 생성하는 방법을 보여줍니다.
+    </web-summary>
+    <card-summary>
+        Kotlin에서 Ktor와 타임리프(Thymeleaf) 템플릿을 사용하여 웹사이트를 구축하는 방법을 알아봅니다.
+    </card-summary>
+    <link-summary>
+        Kotlin에서 Ktor와 타임리프(Thymeleaf) 템플릿을 사용하여 웹사이트를 구축하는 방법을 알아봅니다.
+    </link-summary>
+    <p>
+        이 튜토리얼에서는 Kotlin과 <a href="https://www.thymeleaf.org/">타임리프(Thymeleaf)</a> 템플릿을 사용하여 Ktor로 상호작용 가능한 웹사이트를 구축하는 방법을 배웁니다.
+    </p>
+    <p>
+        <Links href="//server-create-restful-apis" summary="Kotlin과 Ktor를 사용하여 백엔드 서비스를 빌드하는 방법을 배우며, JSON 파일을 생성하는 RESTful API 예제를 다룹니다.">이전 튜토리얼</Links>에서는 JavaScript로 작성된 단일 페이지 애플리케이션(SPA)에서 사용할 RESTful 서비스를 만드는 방법을 배웠습니다. 이 방식은 매우 인기 있는 아키텍처이지만, 모든 프로젝트에 적합한 것은 아닙니다.
+    </p>
+    <p>
+        다음과 같이 모든 구현을 서버에 유지하고 클라이언트에는 마크업만 보내고 싶을 때가 많습니다:
+    </p>
+    <list>
+        <li>단순함 – 단일 코드베이스를 유지할 수 있습니다.</li>
+        <li>보안 – 공격자에게 힌트를 줄 수 있는 데이터나 코드가 브라우저에 배치되는 것을 방지합니다.</li>
+        <li>
+            지원 가능성 – 레거시 브라우저나 JavaScript가 비활성화된 브라우저를 포함하여 최대한 광범위한 클라이언트를 지원할 수 있습니다.
+        </li>
+    </list>
+    <p>
+        Ktor는 <Links href="//server-templating" summary="HTML/CSS 또는 JVM 템플릿 엔진으로 구축된 뷰를 사용하는 방법을 알아봅니다.">여러 서버 페이지 기술</Links>과 통합하여 이 접근 방식을 지원합니다.
+    </p>
+    <chapter title="사전 준비 사항" id="prerequisites">
+        <p>
+            이 튜토리얼은 독립적으로 진행할 수 있지만, RESTful API 생성 방법을 배우기 위해 <Links href="//server-create-restful-apis" summary="Kotlin과 Ktor를 사용하여 백엔드 서비스를 빌드하는 방법을 배우며, JSON 파일을 생성하는 RESTful API 예제를 다룹니다.">이전 튜토리얼</Links>을 먼저 완료하는 것을 강력히 권장합니다.
+        </p>
+        <p><a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA</a>를 설치하는 것을 권장하지만, 원하는 다른 IDE를 사용해도 무방합니다.
+        </p>
+    </chapter>
+    <chapter title="Hello Task Manager 웹 애플리케이션" id="hello-task-manager">
+        <p>
+            이 튜토리얼에서는 <Links href="//server-create-restful-apis" summary="Kotlin과 Ktor를 사용하여 백엔드 서비스를 빌드하는 방법을 배우며, JSON 파일을 생성하는 RESTful API 예제를 다룹니다.">이전 튜토리얼</Links>에서 만든 할 일 관리(Task Management) 애플리케이션을 웹 애플리케이션으로 전환해 보겠습니다. 이를 위해 여러 Ktor <Links href="//server-plugins" summary="플러그인은 직렬화, 콘텐츠 인코딩, 압축 등과 같은 공통 기능을 제공합니다.">플러그인</Links>을 사용합니다.
+        </p>
+        <p>
+            기존 프로젝트에 이러한 플러그인을 수동으로 추가할 수도 있지만, 새 프로젝트를 생성하고 이전 튜토리얼의 코드를 점진적으로 통합하는 것이 더 쉽습니다. 필요한 모든 코드를 과정 중에 제공하므로 이전 프로젝트를 따로 준비해 둘 필요는 없습니다.
+        </p>
+        <procedure title="플러그인을 포함한 초기 프로젝트 생성" id="create-project">
+            <step>
+                <p>
+                    <a href="https://start.ktor.io/">Ktor Project Generator</a>로 이동합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <control>Project artifact</control>
+                    필드에 프로젝트 아티팩트 이름으로
+                    <Path>com.example.ktor-task-web-app</Path>
+                    를 입력합니다.
+                    <img src="server_create_web_app_generator_project_artifact.png"
+                         alt="Ktor Project Generator 프로젝트 아티팩트 이름"
+                         style="block"
+                         border-effect="line" width="706"/>
+                </p>
+            </step>
+            <step>
+                <p> 다음 화면에서 <control>Add</control> 버튼을 클릭하여 다음 플러그인을 검색하고 추가합니다:
+                </p>
+                <list>
+                    <li>Static Content</li>
+                    <li>Thymeleaf</li>
+                </list>
+                <p>
+                    <img src="ktor_project_generator_add_plugins.gif"
+                         alt="Ktor Project Generator에서 플러그인 추가하기"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                    플러그인을 추가하면 프로젝트 설정 아래에 세 개의 플러그인이 모두 표시됩니다.
+                    <img src="server_create_web_app_generator_plugins.png"
+                         alt="Ktor Project Generator 플러그인 목록"
+                         style="block"
+                         border-effect="line" width="706"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    <control>Download</control>
+                    버튼을 클릭하여 Ktor 프로젝트를 생성하고 다운로드합니다.
+                </p>
+            </step>
+        </procedure>
+        <procedure title="스타터 코드 추가" id="add-starter-code">
+            <step>
+                IntelliJ IDEA 또는 원하는 IDE에서 프로젝트를 엽니다.
+            </step>
+            <step>
+                <Path>src/main/kotlin</Path>
+                으로 이동하여
+                <Path>model</Path>
+                이라는 하위 패키지를 생성합니다.
+            </step>
+            <step>
+                <Path>model</Path>
+                패키지 안에 새로운
+                <Path>Task.kt</Path>
+                파일을 생성합니다.
+            </step>
+            <step>
+                <p>
+                    <Path>Task.kt</Path>
+                    파일에 우선순위를 나타내는 <code>enum</code>과 할 일을 나타내는 <code>data class</code>를 추가합니다:
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+                <p>
+                    다시 한번 말씀드리지만, <code>Task</code> 객체를 생성하여 클라이언트가 표시할 수 있는 형식으로 전달하고자 합니다.
+                </p>
+                <p>
+                    다음 내용을 기억하실 것입니다:
+                </p>
+                <list>
+                    <li>
+                        <Links href="//server-requests-and-responses" summary="Kotlin과 Ktor를 사용하여 할 일 관리 애플리케이션을 빌드하면서 라우팅, 요청 처리 및 매개변수의 기초를 배웁니다.">요청 처리 및 응답 생성</Links>
+                        튜토리얼에서는 할 일을 HTML로 변환하기 위해 직접 작성한 확장 함수를 추가했습니다.
+                    </li>
+                    <li>
+                        <Links href="//server-create-restful-apis" summary="Kotlin과 Ktor를 사용하여 백엔드 서비스를 빌드하는 방법을 배우며, JSON 파일을 생성하는 RESTful API 예제를 다룹니다.">RESTful API 만들기</Links> 튜토리얼에서는
+                        <code>kotlinx.serialization</code> 라이브러리의 <code>Serializable</code> 타입을 <code>Task</code> 클래스에 어노테이션으로 추가했습니다.
+                    </li>
+                </list>
+                <p>
+                    이번 경우에는 할 일의 내용을 브라우저에 출력하는 서버 페이지를 만드는 것이 목표입니다.
+                </p>
+            </step>
+            <step>
+                <Path>src/main/kotlin</Path>
+                에 있는
+                <Path>Routing.kt</Path>
+                파일을 엽니다.
+            </step>
+            <step>
+                <p>
+                    <code>.configureRouting()</code> 함수에 아래와 같이 <code>/tasks</code> 라우트를 추가합니다:
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, World!&quot;)&#10;        }&#10;        get(&quot;/html-thymeleaf&quot;) {&#10;            call.respond(ThymeleafContent(&quot;index&quot;, mapOf(&quot;user&quot; to ThymeleafUser(1, &quot;user1&quot;))))&#10;        }&#10;        // 이 추가 라우트를 추가하세요&#10;        get(&quot;/tasks&quot;) {&#10;            val tasks = listOf(&#10;                Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;            )&#10;            call.respond(ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks)))&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;    }&#10;}"/>
+                <p>
+                    서버가 <code>/tasks</code>에 대한 요청을 받으면 할 일 목록을 생성한 다음 타임리프 템플릿으로 전달합니다. <code>ThymeleafContent</code> 타입은 트리거할 템플릿 이름과 페이지에서 접근할 수 있는 값들의 테이블을 인자로 받습니다.
+                </p>
+            </step>
+            <step>
+                <Path>src/main/kotlin</Path>
+                에 있는
+                <Path>Thymeleaf.kt</Path>
+                파일을 엽니다.
+            </step>
+            <step>
+                <p>다음과 같은 <code>.configureThymeleaf</code> 함수를 볼 수 있습니다:</p>
+                <code-block lang="kotlin" code="fun Application.configureThymeleaf() {&#10;    install(Thymeleaf) {&#10;        setTemplateResolver(ClassLoaderTemplateResolver().apply {&#10;            prefix = &quot;templates/thymeleaf/&quot;&#10;            suffix = &quot;.html&quot;&#10;            characterEncoding = &quot;utf-8&quot;&#10;        })&#10;    }&#10;}"/>
+                <p>
+                    타임리프 플러그인 초기화 시, Ktor는 서버 페이지를 찾기 위해
+                    <Path>templates/thymeleaf</Path>
+                    폴더 안을 살펴봅니다. 정적 콘텐츠와 마찬가지로 이 폴더가
+                    <Path>resources</Path>
+                    디렉토리 안에 있을 것으로 예상하며,
+                    <Path>.html</Path>
+                    접미사를 기대합니다.
+                </p>
+                <p>
+                    이 경우, <code>all-tasks</code>라는 이름은 다음 경로와 매핑됩니다:
+                    <code>src/main/resources/templates/thymeleaf/all-tasks.html</code>
+                </p>
+            </step>
+            <step>
+                <Path>src/main/resources</Path>
+                로 이동하여 새로운 <Path>templates/thymeleaf</Path>
+                디렉토리를 생성합니다.
+            </step>
+            <step>
+                <Path>src/main/resources/templates/thymeleaf</Path>
+                안에 새로운
+                <Path>all-tasks.html</Path>
+                파일을 생성합니다.
+            </step>
+            <step>
+                <p>
+                    <Path>all-tasks.html</Path>
+                    파일을 열고 아래 내용을 추가합니다:
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html &gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;All Current Tasks&lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;All Current Tasks&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr th:each=&quot;task: ${tasks}&quot;&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>IntelliJ IDEA에서 실행 버튼
+                    (<img src="intellij_idea_gutter_icon.svg"
+                          style="inline" height="16" width="16"
+                          alt="IntelliJ IDEA 실행 아이콘"/>)
+                    을 클릭하여 애플리케이션을 시작합니다.</p>
+            </step>
+            <step>
+                <p>
+                    브라우저에서 <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a>로 이동합니다. 아래와 같이 표에 모든 현재 할 일이 표시되는 것을 확인할 수 있습니다:
+                </p>
+                <img src="server_create_web_app_all_tasks.png"
+                     alt="할 일 목록을 표시하는 웹 브라우저 창" border-effect="rounded" width="706"/>
+                <p>
+                    모든 서버 페이지 프레임워크와 마찬가지로, 타임리프 템플릿은 정적 콘텐츠(브라우저로 전송됨)와 동적 콘텐츠(서버에서 실행됨)를 혼합하여 사용합니다. 만약 <a href="https://freemarker.apache.org/">Freemarker</a>와 같은 다른 프레임워크를 선택했더라도 약간 다른 구문으로 동일한 기능을 구현할 수 있었을 것입니다.
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="GET 라우트 추가하기" id="add-get-routes">
+        <p>이제 서버 페이지를 요청하는 과정에 익숙해졌으므로, 이전 튜토리얼의 기능을 이 프로젝트로 계속 옮겨보겠습니다.</p>
+        <p>
+            <control>Static Content</control>
+            플러그인을 포함했으므로, <Path>Routing.kt</Path> 파일에 다음 코드가 있을 것입니다:
+        </p>
+        <code-block lang="kotlin" code="            staticResources(&quot;/static&quot;, &quot;static&quot;)"/>
+        <p>
+            이는 예를 들어 <code>/static/index.html</code>에 대한 요청이 다음 경로의 콘텐츠를 제공함을 의미합니다:
+        </p>
+        <code>src/main/resources/static/index.html</code>
+        <p>
+            이 파일은 생성된 프로젝트에 이미 포함되어 있으므로, 추가하려는 기능의 홈 페이지로 사용할 수 있습니다.
+        </p>
+        <procedure title="인덱스 페이지 재사용">
+            <step>
+                <p>
+                    <Path>src/main/resources/static</Path>
+                    내의
+                    <Path>index.html</Path>
+                    파일을 열고 그 내용을 아래 구현으로 바꿉니다:
+                </p>
+                <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Task Manager Web Application&lt;/h1&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;&lt;a href=&quot;/tasks&quot;&gt;View all the tasks&lt;/a&gt;&lt;/h3&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;View tasks by priority&lt;/h3&gt;&#10;    &lt;form method=&quot;get&quot; action=&quot;/tasks/byPriority&quot;&gt;&#10;        &lt;select name=&quot;priority&quot;&gt;&#10;            &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;            &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;            &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;            &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;        &lt;/select&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;View a task by name&lt;/h3&gt;&#10;    &lt;form method=&quot;get&quot; action=&quot;/tasks/byName&quot;&gt;&#10;        &lt;input type=&quot;text&quot; name=&quot;name&quot; width=&quot;10&quot;&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;Create or edit a task&lt;/h3&gt;&#10;    &lt;form method=&quot;post&quot; action=&quot;/tasks&quot;&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;name&quot;&gt;Name: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;name&quot; name=&quot;name&quot; size=&quot;10&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;description&quot;&gt;Description: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;description&quot;&#10;                   name=&quot;description&quot; size=&quot;20&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;priority&quot;&gt;Priority: &lt;/label&gt;&#10;            &lt;select id=&quot;priority&quot; name=&quot;priority&quot;&gt;&#10;                &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;                &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;                &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;                &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;            &lt;/select&gt;&#10;        &lt;/div&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA에서 재실행 버튼(<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 재실행 아이콘"/>)을 클릭하여 애플리케이션을 다시 시작합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    브라우저에서 <a href="http://localhost:8080/static/index.html">http://localhost:8080/static/index.html</a>로 이동합니다. 할 일을 조회, 필터링 및 생성할 수 있는 링크 버튼과 세 개의 HTML 폼이 표시되어야 합니다:
+                </p>
+                <img src="server_create_web_app_tasks_form.png"
+                     alt="HTML 폼을 표시하는 웹 브라우저" border-effect="rounded" width="706"/>
+                <p>
+                    <code>name</code> 또는 <code>priority</code>로 할 일을 필터링할 때 GET 요청을 통해 HTML 폼을 전송한다는 점에 유의하세요. 이는 매개변수가 URL 뒤의 쿼리 스트링(query string)에 추가됨을 의미합니다.
+                </p>
+                <p>
+                    예를 들어 <code>Medium</code> 우선순위의 할 일을 검색하면 서버로 전송되는 요청은 다음과 같습니다:
+                </p>
+                <code>http://localhost:8080/tasks/byPriority?priority=Medium</code>
+            </step>
+        </procedure>
+        <procedure title="할 일 저장소 재사용" id="task-repository">
+            <p>
+                할 일 저장소(repository)는 이전 튜토리얼과 동일하게 유지할 수 있습니다.
+            </p>
+            <p>
+                <Path>model</Path>
+                패키지 안에 새로운
+                <Path>TaskRepository.kt</Path>
+                파일을 만들고 아래 코드를 추가합니다:
+            </p>
+            <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&#10;        tasks.add(task)&#10;    }&#10;}"/>
+        </procedure>
+        <procedure title="GET 요청 라우트 재사용" id="reuse-routes">
+            <p>
+                저장소를 만들었으므로 이제 GET 요청에 대한 라우트를 구현할 수 있습니다.
+            </p>
+            <step>
+                <Path>src/main/kotlin</Path>
+                의
+                <Path>Routing.kt</Path>
+                파일로 이동합니다.
+            </step>
+            <step>
+                <p>
+                    현재 버전의 <code>.configureRouting()</code>을 아래 구현으로 대체합니다:
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, World!&quot;)&#10;        }&#10;        get(&quot;/html-thymeleaf&quot;) {&#10;            call.respond(ThymeleafContent(&quot;index&quot;, mapOf(&quot;user&quot; to ThymeleafUser(1, &quot;user1&quot;))))&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;&#10;        route(&quot;/tasks&quot;) {&#10;            get {&#10;                val tasks = TaskRepository.allTasks()&#10;                call.respond(&#10;                    ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks))&#10;                )&#10;            }&#10;            get(&quot;/byName&quot;) {&#10;                val name = call.request.queryParameters[&quot;name&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                val task = TaskRepository.taskByName(name)&#10;                if (task == null) {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                    return@get&#10;                }&#10;                call.respond(&#10;                    ThymeleafContent(&quot;single-task&quot;, mapOf(&quot;task&quot; to task))&#10;                )&#10;            }&#10;            get(&quot;/byPriority&quot;) {&#10;                val priorityAsText = call.request.queryParameters[&quot;priority&quot;]&#10;                if (priorityAsText == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(priorityAsText)&#10;                    val tasks = TaskRepository.tasksByPriority(priority)&#10;&#10;&#10;                    if (tasks.isEmpty()) {&#10;                        call.respond(HttpStatusCode.NotFound)&#10;                        return@get&#10;                    }&#10;                    val data = mapOf(&#10;                        &quot;priority&quot; to priority,&#10;                        &quot;tasks&quot; to tasks&#10;                    )&#10;                    call.respond(ThymeleafContent(&quot;tasks-by-priority&quot;, data))&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    위 코드는 다음과 같이 요약할 수 있습니다:
+                </p>
+                <list>
+                    <li>
+                        <code>/tasks</code>에 대한 GET 요청 시, 서버는 저장소에서 모든 할 일을 가져와
+                        <Path>all-tasks</Path>
+                        템플릿을 사용하여 브라우저로 보낼 다음 뷰를 생성합니다.
+                    </li>
+                    <li>
+                        <code>/tasks/byName</code>에 대한 GET 요청 시, 서버는 <code>queryString</code>에서 <code>name</code> 매개변수를 가져와 일치하는 할 일을 찾고,
+                        <Path>single-task</Path>
+                        템플릿을 사용하여 브라우저로 보낼 다음 뷰를 생성합니다.
+                    </li>
+                    <li>
+                        <code>/tasks/byPriority</code>에 대한 GET 요청 시, 서버는 <code>queryString</code>에서 <code>priority</code> 매개변수를 가져와 일치하는 할 일들을 찾고,
+                        <Path>tasks-by-priority</Path>
+                        템플릿을 사용하여 브라우저로 보낼 다음 뷰를 생성합니다.
+                    </li>
+                </list>
+                <p>이 모든 것이 작동하려면 추가 템플릿을 추가해야 합니다.</p>
+            </step>
+            <step>
+                <Path>src/main/resources/templates/thymeleaf</Path>
+                로 이동하여 새로운
+                <Path>single-task.html</Path>
+                파일을 생성합니다.
+            </step>
+            <step>
+                <p>
+                    <Path>single-task.html</Path>
+                    파일을 열고 다음 내용을 추가합니다:
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html &gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;All Current Tasks&lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;The Selected Task&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Description&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Priority&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>동일한 폴더에
+                    <Path>tasks-by-priority.html</Path>
+                    라는 새 파일을 만듭니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>tasks-by-priority.html</Path>
+                    파일을 열고 다음 내용을 추가합니다:
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html&gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;Tasks By Priority &lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Tasks With Priority &lt;span th:text=&quot;${priority}&quot;&gt;&lt;/span&gt;&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&#10;        &lt;th&gt;Description&lt;/th&gt;&#10;        &lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr th:each=&quot;task: ${tasks}&quot;&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="POST 요청 지원 추가" id="add-post-requests">
+        <p>
+            다음으로, <code>/tasks</code>에 POST 요청 핸들러를 추가하여 다음 작업을 수행하겠습니다:
+        </p>
+        <list>
+            <li>폼 매개변수에서 정보를 추출합니다.</li>
+            <li>저장소를 사용하여 새 할 일을 추가합니다.</li>
+            <li>
+                <control>all-tasks</control>
+                템플릿을 재사용하여 할 일을 표시합니다.
+            </li>
+        </list>
+        <procedure>
+            <step>
+                <Path>src/main/kotlin</Path>
+                의
+                <Path>Routing.kt</Path>
+                파일로 이동합니다.
+            </step>
+            <step>
+                <p>
+                    <code>.configureRouting()</code> 메서드 내에 다음 <code>post</code> 요청 라우트를 추가합니다:
+                </p>
+                <code-block lang="kotlin" code="            post {&#10;                val formContent = call.receiveParameters()&#10;                val params = Triple(&#10;                    formContent[&quot;name&quot;] ?: &quot;&quot;,&#10;                    formContent[&quot;description&quot;] ?: &quot;&quot;,&#10;                    formContent[&quot;priority&quot;] ?: &quot;&quot;&#10;                )&#10;                if (params.toList().any { it.isEmpty() }) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@post&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(params.third)&#10;                    TaskRepository.addTask(&#10;                        Task(&#10;                            params.first,&#10;                            params.second,&#10;                            priority&#10;                        )&#10;                    )&#10;                    val tasks = TaskRepository.allTasks()&#10;                    call.respond(&#10;                        ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks))&#10;                    )&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                } catch (ex: IllegalStateException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }"/>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA에서 재실행 버튼(<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 재실행 아이콘"/>)을 클릭하여 애플리케이션을 다시 시작합니다.
+                </p>
+            </step>
+            <step>
+                브라우저에서 <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a>로 이동합니다.
+            </step>
+            <step>
+                <p>
+                    <control>Create or edit a task</control>
+                    폼에 새 할 일 상세 정보를 입력합니다.
+                </p>
+                <img src="server_create_web_app_new_task.png"
+                     alt="HTML 폼을 표시하는 웹 브라우저" border-effect="rounded" width="706"/>
+            </step>
+            <step>
+                <p><control>Submit</control>
+                    버튼을 클릭하여 폼을 제출합니다.
+                    그러면 전체 할 일 목록에 새 할 일이 추가된 것을 볼 수 있습니다:
+                </p>
+                <img src="server_create_web_app_new_task_added.png"
+                     alt="할 일 목록을 표시하는 웹 브라우저" border-effect="rounded" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="다음 단계" id="next-steps">
+        <p>
+            축하합니다! 할 일 관리자(Task Manager)를 웹 애플리케이션으로 다시 빌드하고 타임리프 템플릿 사용법을 배웠습니다.</p>
+        <p>
+            <Links href="//server-create-websocket-application" summary="콘텐츠를 주고받기 위해 웹소켓의 기능을 활용하는 방법을 알아봅니다.">다음 튜토리얼</Links>로 이동하여 웹소켓(Web Sockets)을 사용하는 방법을 알아보세요.
+        </p>
+    </chapter>
+</topic>

--- a/docs/ko/ktor/server-create-websocket-application.md
+++ b/docs/ko/ktor/server-create-websocket-application.md
@@ -1,0 +1,382 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="Ktor를 사용하여 Kotlin에서 WebSocket 애플리케이션 만들기" id="server-create-websocket-application">
+    <show-structure for="chapter" depth="2"/>
+    <tldr>
+        <var name="example_name" value="tutorial-server-websockets"/>
+        <p>
+            <b>코드 예제</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+        <p>
+            <b>사용된 플러그인</b>: <Links href="//server-static-content" summary="스타일시트, 스크립트, 이미지 등과 같은 정적 콘텐츠를 제공하는 방법을 알아봅니다.">Static Content</Links>,
+            <Links href="//server-serialization" summary="ContentNegotiation 플러그인은 클라이언트와 서버 간의 미디어 유형 협상과 특정 형식으로 콘텐츠를 직렬화/역직렬화하는 두 가지 주요 목적을 수행합니다.">Content Negotiation</Links>, <Links href="//server-websockets" summary="WebSockets 플러그인을 사용하면 서버와 클라이언트 간의 다방향 통신 세션을 만들 수 있습니다.">WebSockets in Ktor Server</Links>,
+            <a href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>
+        </p>
+    </tldr>
+    <card-summary>
+        WebSockets의 강력한 기능을 활용하여 콘텐츠를 주고받는 방법을 알아봅니다.
+    </card-summary>
+    <link-summary>
+        WebSockets의 강력한 기능을 활용하여 콘텐츠를 주고받는 방법을 알아봅니다.
+    </link-summary>
+    <web-summary>
+        Ktor와 Kotlin을 사용하여 WebSocket 애플리케이션을 구축하는 방법을 알아봅니다. 이 튜토리얼은 WebSockets를 통해 백엔드 서비스와 클라이언트를 연결하는 과정을 안내합니다.
+    </web-summary>
+    <p>
+        이 문서는 Ktor와 Kotlin을 사용하여 WebSocket 애플리케이션을 제작하는 과정을 안내합니다. 이 내용은 <Links href="//server-create-restful-apis" summary="Kotlin과 Ktor를 사용하여 JSON 파일을 생성하는 RESTful API 예제를 포함한 백엔드 서비스를 구축하는 방법을 알아봅니다.">RESTful API 만들기</Links> 튜토리얼에서 다룬 내용을 바탕으로 합니다.
+    </p>
+    <p>이 문서에서는 다음 내용을 학습하게 됩니다:</p>
+    <list>
+        <li>JSON 직렬화를 사용하는 서비스 만들기.</li>
+        <li>WebSocket 연결을 통해 콘텐츠 전송 및 수신.</li>
+        <li>여러 클라이언트에 동시에 콘텐츠 브로드캐스트.</li>
+    </list>
+    <chapter title="사전 준비 사항" id="prerequisites">
+        <p>이 튜토리얼을 독립적으로 진행할 수 있지만, <Links href="//server-serialization" summary="ContentNegotiation 플러그인은 클라이언트와 서버 간의 미디어 유형 협상과 특정 형식으로 콘텐츠를 직렬화/역직렬화하는 두 가지 주요 목적을 수행합니다.">콘텐츠 협상(Content Negotiation)</Links> 및 REST에 익숙해지기 위해 <Links href="//server-create-restful-apis" summary="Kotlin과 Ktor를 사용하여 JSON 파일을 생성하는 RESTful API 예제를 포함한 백엔드 서비스를 구축하는 방법을 알아봅니다.">RESTful API 만들기</Links> 튜토리얼을 먼저 완료하는 것을 권장합니다.
+        </p>
+        <p><a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA</a>를 설치하는 것을 권장하지만, 원하는 다른 IDE를 사용해도 좋습니다.
+        </p>
+    </chapter>
+    <chapter title="Hello WebSockets" id="hello-websockets">
+        <p>
+            이 튜토리얼에서는 WebSocket 연결을 통해 클라이언트와 <code>Task</code> 객체를 주고받는 기능을 추가하여 <Links href="//server-create-restful-apis" summary="Kotlin과 Ktor를 사용하여 JSON 파일을 생성하는 RESTful API 예제를 포함한 백엔드 서비스를 구축하는 방법을 알아봅니다.">RESTful API 만들기</Links> 튜토리얼에서 개발한 작업 관리자 서비스를 확장해 봅니다. 이를 위해 <Links href="//server-websockets" summary="WebSockets 플러그인을 사용하면 서버와 클라이언트 간의 다방향 통신 세션을 만들 수 있습니다.">WebSockets 플러그인</Links>을 추가해야 합니다. 기존 프로젝트에 수동으로 추가할 수도 있지만, 이 튜토리얼에서는 처음부터 새 프로젝트를 만들어 시작하겠습니다.
+        </p>
+        <chapter title="플러그인을 포함한 초기 프로젝트 생성" id="create=project">
+            <procedure>
+                <step>
+                    <p>
+                        <a href="https://start.ktor.io/">Ktor Project Generator</a>로 이동합니다.
+                    </p>
+                </step>
+                <step>
+                    <p><control>Project artifact</control> 필드에 프로젝트 아티팩트 이름으로
+                        <Path>com.example.ktor-websockets-task-app</Path>를 입력합니다.
+                        <img src="tutorial_server_websockets_project_artifact.png"
+                             alt="Ktor Project Generator에서 프로젝트 아티팩트 이름 지정"
+                             border-effect="line"
+                             style="block"
+                             width="706"/>
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        플러그인 섹션에서 <control>Add</control> 버튼을 클릭하여 다음 플러그인들을 검색하고 추가합니다:
+                    </p>
+                    <list type="bullet">
+                        <li>Content Negotiation</li>
+                        <li>kotlinx.serialization</li>
+                        <li>WebSockets</li>
+                        <li>Static Content</li>
+                    </list>
+                    <p>
+                        <img src="ktor_project_generator_add_plugins.gif"
+                             alt="Ktor Project Generator에서 플러그인 추가"
+                             border-effect="line"
+                             style="block"
+                             width="706"/>
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        플러그인을 추가하면 플러그인 섹션의 오른쪽 상단에 표시됩니다.
+                    </p>
+                    <p>프로젝트에 추가될 모든 플러그인 목록을 확인할 수 있습니다:
+                        <img src="tutorial_server_websockets_project_plugins.png"
+                             alt="Ktor Project Generator의 플러그인 목록"
+                             border-effect="line"
+                             style="block"
+                             width="706"/>
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        <control>Download</control> 버튼을 클릭하여 Ktor 프로젝트를 생성하고 다운로드합니다.
+                    </p>
+                </step>
+            </procedure>
+        </chapter>
+        <chapter title="시작 코드 추가" id="add-starter-code">
+            <p>다운로드가 완료되면 IntelliJ IDEA에서 프로젝트를 열고 다음 단계를 따르세요:</p>
+            <procedure>
+                <step>
+                    <Path>src/main/kotlin</Path>으로 이동하여 <Path>model</Path>이라는 새 서브패키지를 만듭니다.
+                </step>
+                <step>
+                    <p>
+                        <Path>model</Path> 패키지 안에 새 <Path>Task.kt</Path> 파일을 만듭니다.
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        <Path>Task.kt</Path> 파일을 열고 우선순위를 나타내는 <code>enum</code>과 작업을 나타내는 <code>data class</code>를 추가합니다:
+                    </p>
+                    <code-block lang="kotlin" code="package com.example.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+                    <p>
+                        <code>Task</code> 클래스는 <code>kotlinx.serialization</code> 라이브러리의 <code>@Serializable</code> 어노테이션이 붙어 있습니다. 이는 인스턴스를 JSON으로 상호 변환할 수 있음을 의미하며, 이를 통해 네트워크를 통해 내용을 전송할 수 있습니다.
+                    </p>
+                    <p>
+                        WebSockets 플러그인을 포함했으므로 제너레이터가 <Path>src/main/kotlin</Path> 내의 <Path>Routing.kt</Path> 파일에 <code>webSocket</code> 라우트를, 그리고 <Path>Websockets.kt</Path> 파일을 추가했을 것입니다.
+                    </p>
+                </step>
+                <step>
+                    <Path>Websockets.kt</Path> 파일을 열고 기존 <code>.configureWebsockets()</code> 함수를 다음 내용으로 교체합니다:
+                    <code-block lang="kotlin" code="                        fun Application.configureWebsockets() {&#10;                            install(WebSockets) {&#10;                                contentConverter = KotlinxWebsocketSerializationConverter(Json)&#10;                                pingPeriod = 15.seconds&#10;                                timeout = 15.seconds&#10;                                maxFrameSize = Long.MAX_VALUE&#10;                                masking = false&#10;                            }&#10;                        }"/>
+                    <list>
+                        <li>WebSockets 플러그인이 설치되고 표준 설정으로 구성됩니다.</li>
+                        <li><code>contentConverter</code> 속성이 설정되어, 플러그인이 <a
+                                    href="https://github.com/Kotlin/kotlinx.serialization"><code>kotlinx.serialization</code></a> 라이브러리를 통해 송수신되는 객체를 직렬화할 수 있게 합니다.
+                        </li>
+                    </list>
+                </step>
+                <step>
+                    <p>
+                        <Path>Routing.kt</Path> 파일을 열고 기존 <code>Application.configureRouting()</code> 함수를 아래 구현으로 교체합니다:
+                    </p>
+                    <code-block lang="kotlin" code="                    fun Application.configureRouting() {&#10;                        routing {&#10;                            webSocket(&quot;/tasks&quot;) {&#10;                                val tasks = listOf(&#10;                                    Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                                    Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                                    Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                                    Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;                                )&#10;&#10;                                for (task in tasks) {&#10;                                    sendSerialized(task)&#10;                                    delay(1000.milliseconds)&#10;                                }&#10;&#10;                                close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;                            }&#10;                            staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;                        }&#10;                    }"/>
+                    <list>
+                        <li>상대 URL이 <code>/tasks</code>인 단일 엔드포인트로 라우팅이 구성됩니다.</li>
+                        <li>요청을 받으면 작업 목록이 WebSocket 연결을 통해 직렬화되어 전송됩니다.</li>
+                        <li>모든 항목이 전송되면 서버는 연결을 닫습니다.</li>
+                    </list>
+                    <p>
+                        데모를 위해 작업을 전송하는 사이에 1초의 지연(delay)을 추가했습니다. 이를 통해 클라이언트에서 작업이 점진적으로 나타나는 것을 관찰할 수 있습니다. 이 지연이 없다면 이 예제는 이전 문서에서 개발한 <Links href="//server-create-restful-apis" summary="Kotlin과 Ktor를 사용하여 JSON 파일을 생성하는 RESTful API 예제를 포함한 백엔드 서비스를 구축하는 방법을 알아봅니다.">RESTful 서비스</Links> 및 <Links href="//server-create-website" summary="Kotlin과 Ktor 및 Thymeleaf 템플릿을 사용하여 웹사이트를 구축하는 방법을 알아봅니다.">웹 애플리케이션</Links>과 동일하게 보일 것입니다.
+                    </p>
+                    <p>
+                        이 반복 단계의 마지막 과정은 이 엔드포인트를 위한 클라이언트를 만드는 것입니다. <Links href="//server-static-content" summary="스타일시트, 스크립트, 이미지 등과 같은 정적 콘텐츠를 제공하는 방법을 알아봅니다.">Static Content</Links> 플러그인을 포함했으므로, Ktor 프로젝트 제너레이터가 <Path>src/main/resources/static</Path> 내에 <Path>index.html</Path> 파일을 추가했을 것입니다.
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        <Path>index.html</Path> 파일을 열고 기존 내용을 다음으로 바꿉니다:
+                    </p>
+                    <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;Using Ktor WebSockets&lt;/title&gt;&#10;    &lt;script&gt;&#10;        function readAndDisplayAllTasks() {&#10;            clearTable();&#10;&#10;            const serverURL = 'ws://0.0.0.0:8080/tasks';&#10;            const socket = new WebSocket(serverURL);&#10;&#10;            socket.onopen = logOpenToConsole;&#10;            socket.onclose = logCloseToConsole;&#10;            socket.onmessage = readAndDisplayTask;&#10;        }&#10;&#10;        function readAndDisplayTask(event) {&#10;            let task = JSON.parse(event.data);&#10;            logTaskToConsole(task);&#10;            addTaskToTable(task);&#10;        }&#10;&#10;        function logTaskToConsole(task) {&#10;            console.log(`Received ${task.name}`);&#10;        }&#10;&#10;        function logCloseToConsole() {&#10;            console.log(&quot;Web socket connection closed&quot;);&#10;        }&#10;&#10;        function logOpenToConsole() {&#10;            console.log(&quot;Web socket connection opened&quot;);&#10;        }&#10;&#10;        function tableBody() {&#10;            return document.getElementById(&quot;tasksTableBody&quot;);&#10;        }&#10;&#10;        function clearTable() {&#10;            tableBody().innerHTML = &quot;&quot;;&#10;        }&#10;&#10;        function addTaskToTable(task) {&#10;            tableBody().appendChild(taskRow(task));&#10;        }&#10;&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Viewing Tasks Via WebSockets&lt;/h1&gt;&#10;&lt;form action=&quot;javascript:readAndDisplayAllTasks()&quot;&gt;&#10;    &lt;input type=&quot;submit&quot; value=&quot;View The Tasks&quot;&gt;&#10;&lt;/form&gt;&#10;&lt;table rules=&quot;all&quot;&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+                    <p>
+                        이 페이지는 모든 최신 브라우저에서 사용할 수 있는 <a href="https://websockets.spec.whatwg.org//#websocket"><code>WebSocket</code> 유형</a>을 사용합니다. JavaScript에서 이 객체를 생성하고 생성자에 엔드포인트의 URL을 전달합니다. 그 후 <code>onopen</code>, <code>onclose</code>, <code>onmessage</code> 이벤트에 대한 이벤트 핸들러를 연결합니다. <code>onmessage</code> 이벤트가 트리거되면 문서 객체의 메서드를 사용하여 테이블에 행을 추가합니다.
+                    </p>
+                </step>
+                <step>
+                    <p>IntelliJ IDEA에서 실행 버튼
+                        (<img src="intellij_idea_gutter_icon.svg"
+                              style="inline" height="16" width="16"
+                              alt="intelliJ IDEA 실행 아이콘"/>)을 클릭하여 애플리케이션을 시작합니다.</p>
+                </step>
+                <step>
+                    <p>
+                        <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a>로 이동합니다. 버튼이 있는 폼과 빈 테이블이 나타날 것입니다:
+                    </p>
+                    <img src="tutorial_server_websockets_iteration_1.png"
+                         alt="하나의 버튼이 있는 HTML 폼을 표시하는 웹 브라우저 페이지"
+                         border-effect="rounded"
+                         width="706"/>
+                    <p>
+                        폼을 클릭하면 서버에서 작업이 로드되어 초당 한 개씩 나타납니다. 결과적으로 테이블이 점진적으로 채워집니다. 브라우저의 <control>개발자 도구</control>에서 <control>JavaScript 콘솔</control>을 열어 기록된 메시지를 확인할 수도 있습니다.
+                    </p>
+                    <img src="tutorial_server_websockets_iteration_1_click.gif"
+                         alt="버튼 클릭 시 리스트 항목을 표시하는 웹 브라우저 페이지"
+                         border-effect="rounded"
+                         width="706"/>
+                    <p>
+                        이제 서비스가 예상대로 작동합니다. WebSocket 연결이 열리고, 항목이 클라이언트로 전송된 다음 연결이 닫힙니다. 기저의 네트워킹에는 많은 복잡성이 수반되지만, Ktor가 기본적으로 이 모든 것을 처리해 줍니다.
+                    </p>
+                </step>
+            </procedure>
+        </chapter>
+    </chapter>
+    <chapter title="WebSocket 이해하기" id="understanding-websockets">
+        <p>
+            다음 단계로 넘어가기 전에 WebSockets의 기본 사항을 복습하는 것이 도움이 될 수 있습니다. 이미 WebSockets에 익숙하다면 바로 <a href="#improve-design">서비스 설계 개선</a> 단계로 넘어가도 좋습니다.
+        </p>
+        <p>
+            이전 튜토리얼에서 클라이언트는 HTTP 요청을 보내고 HTTP 응답을 받았습니다. 이는 잘 작동하며 인터넷이 확장 가능하고 탄력적으로 유지될 수 있게 합니다.
+        </p>
+        <p>그러나 다음과 같은 시나리오에는 적합하지 않습니다:</p>
+        <list>
+            <li>콘텐츠가 시간이 지남에 따라 점진적으로 생성되는 경우.</li>
+            <li>이벤트에 따라 콘텐츠가 빈번하게 변경되는 경우.</li>
+            <li>콘텐츠가 생성되는 동안 클라이언트가 서버와 상호 작용해야 하는 경우.</li>
+            <li>한 클라이언트가 보낸 데이터가 다른 클라이언트에 빠르게 전파되어야 하는 경우.</li>
+        </list>
+        <p>
+            이러한 시나리오의 예로는 주식 거래, 영화 및 콘서트 티켓 구매, 온라인 경매 입찰, 소셜 미디어의 채팅 기능 등이 있습니다. WebSockets는 이러한 상황을 처리하기 위해 개발되었습니다.
+        </p>
+        <p>
+            WebSocket 연결은 TCP를 통해 구축되며 장기간 유지될 수 있습니다. 이 연결은 <emphasis>전이중 통신(full duplex communication)</emphasis>을 제공합니다. 즉, 클라이언트가 서버로 메시지를 보내는 동시에 서버로부터 메시지를 받을 수 있습니다.
+        </p>
+        <p>
+            WebSocket API는 네 가지 이벤트(open, message, close, error)와 두 가지 동작(send, close)을 정의합니다. 이러한 기능에 접근하는 방법은 언어와 라이브러리에 따라 다를 수 있습니다. 예를 들어, Kotlin에서는 들어오는 메시지 시퀀스를 <a
+                href="https://kotlinlang.org/docs/flow.html"><code>Flow</code></a>로 소비할 수 있습니다.
+        </p>
+    </chapter>
+    <chapter title="설계 개선" id="improve-design">
+        <p>다음으로, 더 고급 예제를 구현하기 위해 기존 코드를 리팩토링해 보겠습니다.</p>
+        <procedure>
+            <step>
+                <p>
+                    <Path>model</Path> 패키지에 새 <Path>TaskRepository.kt</Path> 파일을 만듭니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>TaskRepository.kt</Path>를 열고 <code>TaskRepository</code> 객체를 추가합니다:
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&#10;        tasks.add(task)&#10;    }&#10;&#10;    fun removeTask(name: String): Boolean {&#10;        return tasks.removeIf { it.name == name }&#10;    }&#10;}"/>
+                <p>이 코드는 이전 튜토리얼에서 보았던 것과 비슷할 것입니다.</p>
+            </step>
+            <step>
+                <Path>src/main/kotlin</Path>으로 이동하여 <Path>Routing.kt</Path> 파일을 엽니다.
+            </step>
+            <step>
+                <p>
+                    이제 <code>TaskRepository</code>를 활용하여 <code>Application.configureRouting()</code>의 라우팅을 단순화할 수 있습니다:
+                </p>
+                <code-block lang="kotlin" code="                    routing {&#10;                        webSocket(&quot;/tasks&quot;) {&#10;                            for (task in TaskRepository.allTasks()) {&#10;                                sendSerialized(task)&#10;                                delay(1000.milliseconds)&#10;                            }&#10;                            close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;                        }&#10;                        // ...&#10;                    }"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="WebSocket을 통해 메시지 전송" id="send-messages">
+        <p>
+            WebSocket의 강력함을 보여주기 위해 다음과 같은 새 엔드포인트를 만들어 보겠습니다:
+        </p>
+        <list>
+            <li>
+                클라이언트가 시작할 때 기존의 모든 작업을 수신합니다.
+            </li>
+            <li>
+                클라이언트가 작업을 생성하고 전송할 수 있습니다.
+            </li>
+            <li>
+                한 클라이언트가 작업을 전송하면 다른 모든 클라이언트가 알림을 받습니다.
+            </li>
+        </list>
+        <procedure>
+            <step>
+                <p>
+                    <Path>Routing.kt</Path> 파일에서 현재 <code>.configureRouting()</code> 메서드를 아래 구현으로 교체합니다:
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        val sessions =&#10;            Collections.synchronizedList&lt;WebSocketServerSession&gt;(ArrayList())&#10;&#10;        webSocket(&quot;/tasks&quot;) {&#10;            sendAllTasks()&#10;            close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;        }&#10;&#10;        webSocket(&quot;/tasks2&quot;) {&#10;            sessions.add(this)&#10;            sendAllTasks()&#10;&#10;            while(true) {&#10;                ensureActive()&#10;                val newTask = receiveDeserialized&lt;Task&gt;()&#10;                TaskRepository.addTask(newTask)&#10;                for(session in sessions) {&#10;                    session.sendSerialized(newTask)&#10;                }&#10;            }&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;    }&#10;}&#10;&#10;private suspend fun DefaultWebSocketServerSession.sendAllTasks() {&#10;    for (task in TaskRepository.allTasks()) {&#10;        sendSerialized(task)&#10;        delay(1000.milliseconds)&#10;    }&#10;}"/>
+                <p>이 코드를 통해 다음 작업을 수행했습니다:</p>
+                <list>
+                    <li>
+                        기존의 모든 작업을 전송하는 기능을 헬퍼 메서드로 리팩토링했습니다.
+                    </li>
+                    <li>
+                        <code>routing {}</code> 블록에서 모든 클라이언트를 추적하기 위해 스레드로부터 안전한 <code>session</code> 객체 리스트를 생성했습니다.
+                    </li>
+                    <li>
+                        상대 URL이 <code>/tasks2</code>인 새 엔드포인트를 추가했습니다. 클라이언트가 이 엔드포인트에 연결하면 해당 <code>session</code> 객체가 리스트에 추가됩니다. 그런 다음 서버는 새 작업을 수신하기 위해 대기하는 무한 루프에 진입합니다. 새 작업을 수신하면 서버는 이를 저장소에 저장하고 현재 클라이언트를 포함한 모든 클라이언트에게 복사본을 보냅니다.
+                    </li>
+                </list>
+                <p>
+                    이 기능을 테스트하기 위해 <Path>index.html</Path>의 기능을 확장하는 새 페이지를 만들겠습니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>src/main/resources/static</Path> 내에 <Path>wsClient.html</Path>이라는 새 HTML 파일을 만듭니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>wsClient.html</Path>을 열고 다음 내용을 추가합니다:
+                </p>
+                <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;WebSocket Client&lt;/title&gt;&#10;    &lt;script&gt;&#10;        let serverURL;&#10;        let socket;&#10;&#10;        function setupSocket() {&#10;            serverURL = 'ws://0.0.0.0:8080/tasks2';&#10;            socket = new WebSocket(serverURL);&#10;&#10;            socket.onopen = logOpenToConsole;&#10;            socket.onclose = logCloseToConsole;&#10;            socket.onmessage = readAndDisplayTask;&#10;        }&#10;&#10;        function readAndDisplayTask(event) {&#10;            let task = JSON.parse(event.data);&#10;            logTaskToConsole(task);&#10;            addTaskToTable(task);&#10;        }&#10;&#10;        function logTaskToConsole(task) {&#10;            console.log(`Received ${task.name}`);&#10;        }&#10;&#10;        function logCloseToConsole() {&#10;            console.log(&quot;Web socket connection closed&quot;);&#10;        }&#10;&#10;        function logOpenToConsole() {&#10;            console.log(&quot;Web socket connection opened&quot;);&#10;        }&#10;&#10;        function tableBody() {&#10;            return document.getElementById(&quot;tasksTableBody&quot;);&#10;        }&#10;&#10;        function addTaskToTable(task) {&#10;            tableBody().appendChild(taskRow(task));&#10;        }&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;&#10;        function getFormValue(name) {&#10;            return document.forms[0][name].value&#10;        }&#10;&#10;        function buildTaskFromForm() {&#10;            return {&#10;                name: getFormValue(&quot;newTaskName&quot;),&#10;                description: getFormValue(&quot;newTaskDescription&quot;),&#10;                priority: getFormValue(&quot;newTaskPriority&quot;)&#10;            }&#10;        }&#10;&#10;        function logSendingToConsole(data) {&#10;            console.log(&quot;About to send&quot;,data);&#10;        }&#10;&#10;        function sendTaskViaSocket(data) {&#10;            socket.send(JSON.stringify(data));&#10;        }&#10;&#10;        function sendTaskToServer() {&#10;            let data = buildTaskFromForm();&#10;            logSendingToConsole(data);&#10;            sendTaskViaSocket(data);&#10;            //prevent form submission&#10;            return false;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body onload=&quot;setupSocket()&quot;&gt;&#10;&lt;h1&gt;Viewing Tasks Via WebSockets&lt;/h1&gt;&#10;&lt;table rules=&quot;all&quot;&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;Create a new task&lt;/h3&gt;&#10;    &lt;form onsubmit=&quot;return sendTaskToServer()&quot;&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskName&quot;&gt;Name: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;newTaskName&quot;&#10;                   name=&quot;newTaskName&quot; size=&quot;10&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskDescription&quot;&gt;Description: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;newTaskDescription&quot;&#10;                   name=&quot;newTaskDescription&quot; size=&quot;20&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskPriority&quot;&gt;Priority: &lt;/label&gt;&#10;            &lt;select id=&quot;newTaskPriority&quot; name=&quot;newTaskPriority&quot;&gt;&#10;                &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;                &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;                &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;                &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;            &lt;/select&gt;&#10;        &lt;/div&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+                <p>
+                    이 새 페이지에는 사용자가 새 작업 정보를 입력할 수 있는 HTML 폼이 도입되었습니다. 폼을 제출하면 <code>sendTaskToServer()</code> 이벤트 핸들러가 호출됩니다. 이는 폼 데이터로 JavaScript 객체를 빌드하고 WebSocket 객체의 <code>.send()</code> 메서드를 사용하여 서버로 전송합니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    IntelliJ IDEA에서 재실행 버튼(<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="intelliJ IDEA 재실행 아이콘"/>)을 클릭하여 애플리케이션을 다시 시작합니다.
+                </p>
+            </step>
+            <step>
+                <p>이 기능을 테스트하려면 두 개의 브라우저를 나란히 열고 다음 단계를 따르세요.</p>
+                <list type="decimal">
+                    <li>
+                        브라우저 A에서 <a href="http://0.0.0.0:8080/static/wsClient.html">http://0.0.0.0:8080/static/wsClient.html</a>로 이동합니다. 기본 작업들이 표시되는지 확인합니다.
+                    </li>
+                    <li>
+                        브라우저 A에서 새 작업을 추가합니다. 해당 페이지의 테이블에 새 작업이 나타나야 합니다.
+                    </li>
+                    <li>
+                        브라우저 B에서 <a href="http://0.0.0.0:8080/static/wsClient.html">http://0.0.0.0:8080/static/wsClient.html</a>로 이동합니다. 기본 작업과 브라우저 A에서 추가한 새 작업이 모두 표시되어야 합니다.
+                    </li>
+                    <li>
+                        어느 한 브라우저에서 작업을 추가합니다. 양쪽 페이지 모두에 새 항목이 나타나는지 확인합니다.
+                    </li>
+                </list>
+                <img src="tutorial_server_websockets_iteration_2_test.gif"
+                     alt="HTML 폼을 통해 새 작업을 생성하는 것을 보여주는 두 개의 나란히 놓인 웹 브라우저 페이지"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="자동화된 테스트 추가" id="add-automated-tests">
+        <p>
+            QA 프로세스를 효율화하고 빠르고 재현 가능하며 자동화하기 위해 Ktor의 내장된 <Links href="//server-testing" summary="특수 테스트 엔진을 사용하여 서버 애플리케이션을 테스트하는 방법을 알아봅니다.">자동화 테스트 지원</Links>을 사용할 수 있습니다. 다음 단계를 따르세요:
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    Ktor Client 내에서 <Links href="//server-serialization" summary="ContentNegotiation 플러그인은 클라이언트와 서버 간의 미디어 유형 협상과 특정 형식으로 콘텐츠를 직렬화/역직렬화하는 두 가지 주요 목적을 수행합니다.">Content Negotiation</Links> 지원을 구성할 수 있도록 <Path>build.gradle.kts</Path>에 다음 의존성을 추가합니다:
+                </p>
+                <code-block lang="kotlin" code="    testImplementation(ktorLibs.client.contentNegotiation)"/>
+            </step>
+            <step>
+                <p>
+                    <p>IntelliJ IDEA에서 편집기 오른쪽에 있는 Gradle 알림 아이콘
+                        (<img alt="intelliJ IDEA gradle 아이콘"
+                              src="intellij_idea_gradle_icon.svg" width="16" height="26"/>)을 클릭하여 Gradle 변경 사항을 로드합니다.</p>
+                </p>
+            </step>
+            <step>
+                <p>
+                    <Path>src/test/kotlin</Path>으로 이동하여 <Path>ServerTest.kt</Path> 파일을 엽니다.
+                </p>
+            </step>
+            <step>
+                <p>
+                    생성된 테스트 클래스를 아래 구현으로 교체합니다:
+                </p>
+                <code-block lang="kotlin" code="import com.example.model.Priority&#10;import com.example.model.Task&#10;import io.ktor.client.plugins.contentnegotiation.ContentNegotiation&#10;import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession&#10;import io.ktor.client.plugins.websocket.WebSockets&#10;import io.ktor.client.plugins.websocket.converter&#10;import io.ktor.client.plugins.websocket.webSocket&#10;import io.ktor.serialization.deserialize&#10;import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter&#10;import io.ktor.serialization.kotlinx.json.json&#10;import io.ktor.server.testing.testApplication&#10;import kotlinx.coroutines.flow.consumeAsFlow&#10;import kotlinx.coroutines.flow.map&#10;import kotlinx.coroutines.flow.scan&#10;import kotlinx.serialization.json.Json&#10;import kotlin.test.Test&#10;import kotlin.test.assertEquals&#10;&#10;class ServerTest {&#10;    @Test&#10;    fun testRoot() = testApplication {&#10;        configure()&#10;&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;            install(WebSockets) {&#10;                contentConverter =&#10;                    KotlinxWebsocketSerializationConverter(Json)&#10;            }&#10;        }&#10;&#10;        val expectedTasks = listOf(&#10;            Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;            Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;            Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;            Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;        )&#10;        var actualTasks = emptyList&lt;Task&gt;()&#10;&#10;        client.webSocket(&quot;/tasks&quot;) {&#10;            consumeTasksAsFlow().collect { allTasks -&gt;&#10;                actualTasks = allTasks&#10;            }&#10;        }&#10;&#10;        assertEquals(expectedTasks.size, actualTasks.size)&#10;        expectedTasks.forEachIndexed { index, task -&gt;&#10;            assertEquals(task, actualTasks[index])&#10;        }&#10;    }&#10;&#10;    private fun DefaultClientWebSocketSession.consumeTasksAsFlow() = incoming&#10;        .consumeAsFlow()&#10;        .map {&#10;            converter!!.deserialize&lt;Task&gt;(it)&#10;        }&#10;        .scan(emptyList&lt;Task&gt;()) { list, task -&gt;&#10;            list + task&#10;        }&#10;}"/>
+                <p>
+                    이 설정을 통해 다음을 수행합니다:
+                </p>
+                <list>
+                    <li>
+                        서비스가 테스트 환경 내에서 실행되도록 구성하고, JSON 직렬화 및 WebSockets를 포함하여 프로덕션 환경과 동일한 기능을 활성화합니다.
+                    </li>
+                    <li>
+                        <Links href="//client-create-and-configure" summary="Ktor 클라이언트를 생성하고 구성하는 방법을 알아봅니다.">Ktor Client</Links> 내에서 콘텐츠 협상 및 WebSocket 지원을 구성합니다. 이게 없으면 클라이언트는 WebSocket 연결을 사용할 때 객체를 JSON으로 직렬화/역직렬화하는 방법을 알 수 없습니다.
+                    </li>
+                    <li>
+                        서비스가 반환할 것으로 기대하는 <code>Tasks</code> 목록을 선언합니다.
+                    </li>
+                    <li>
+                        <code>client</code> 객체의 <code>.webSocket</code> 함수를 사용하여 <code>/tasks</code>로 요청을 보냅니다.
+                    </li>
+                    <li>
+                        들어오는 작업을 <code>Flow</code>로 소비하여 리스트에 점진적으로 추가합니다.
+                    </li>
+                    <li>
+                        모든 작업을 수신하면 일반적인 방식으로 <code>expectedTasks</code>와 <code>actualTasks</code>를 비교합니다.
+                    </li>
+                </list>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="다음 단계" id="next-steps">
+        <p>
+            수고하셨습니다! WebSocket 통신과 Ktor Client를 사용한 자동화 테스트를 통합함으로써 작업 관리자 서비스를 크게 개선했습니다.
+        </p>
+        <p>
+            <Links href="//server-integrate-database" summary="Exposed SQL 라이브러리를 사용하여 Ktor 서비스를 데이터베이스 저장소에 연결하는 프로세스를 알아봅니다.">다음 튜토리얼</Links>로 이동하여 Exposed 라이브러리를 사용하여 서비스가 관계형 데이터베이스와 원활하게 상호 작용하는 방법을 알아보세요.
+        </p>
+    </chapter>
+</topic>

--- a/docs/ko/ktor/server-dependencies.md
+++ b/docs/ko/ktor/server-dependencies.md
@@ -1,0 +1,221 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   title="서버 의존성 추가하기"
+   id="server-dependencies" help-id="Gradle">
+<show-structure for="chapter" depth="2"/>
+<link-summary>기존 Gradle/Maven 프로젝트에 Ktor 서버 의존성을 추가하는 방법을 알아봅니다.</link-summary>
+<p>
+    이 주제에서는 기존 Gradle/Maven 프로젝트에 Ktor 서버에 필요한 의존성을 추가하는 방법을 보여줍니다.
+</p>
+<chapter title="저장소 구성하기" id="repositories">
+    <p>
+        Ktor 의존성을 추가하기 전에 이 프로젝트의 저장소를 구성해야 합니다.
+    </p>
+    <list>
+        <li>
+            <p>
+                <control>프로덕션 (Production)</control>
+            </p>
+            <p>
+                Ktor의 프로덕션 릴리스는 Maven 중앙 저장소(Maven central repository)에서 사용할 수 있습니다.
+                다음과 같이 빌드 스크립트에 이 저장소를 선언할 수 있습니다.
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                            repositories {&#10;                                mavenCentral()&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                            repositories {&#10;                                mavenCentral()&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <note>
+                        <p>
+                            프로젝트가 <a href="https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#super-pom">Super POM</a>에서 중앙 저장소를 상속받으므로 <Path>pom.xml</Path> 파일에 Maven 중앙 저장소를 추가할 필요가 없습니다.
+                        </p>
+                    </note>
+                </TabItem>
+            </Tabs>
+        </li>
+        <li>
+            <p>
+                <control>얼리 액세스 프로그램 (EAP)</control>
+            </p>
+            <p>
+                Ktor의 <a href="https://ktor.io/eap/">EAP</a> 버전에 접근하려면 <a href="https://redirector.kotlinlang.org/maven/ktor-eap/io/ktor/">Space 저장소</a>를 참조해야 합니다.
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                            repositories {&#10;                                maven {&#10;                                    url = uri(&quot;https://redirector.kotlinlang.org/maven/ktor-eap&quot;)&#10;                                }&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                            repositories {&#10;                                maven {&#10;                                    url &quot;https://redirector.kotlinlang.org/maven/ktor-eap&quot;&#10;                                }&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <code-block lang="XML" code="                            &lt;repositories&gt;&#10;                                &lt;repository&gt;&#10;                                    &lt;id&gt;ktor-eap&lt;/id&gt;&#10;                                    &lt;url&gt;https://redirector.kotlinlang.org/maven/ktor-eap&lt;/url&gt;&#10;                                &lt;/repository&gt;&#10;                            &lt;/repositories&gt;"/>
+                </TabItem>
+            </Tabs>
+            <p>
+                Ktor EAP에는 <a href="https://redirector.kotlinlang.org/maven/dev">Kotlin 개발 저장소 (dev repository)</a>가 필요할 수 있습니다.
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                            repositories {&#10;                                maven {&#10;                                    url = uri(&quot;https://redirector.kotlinlang.org/maven/dev&quot;)&#10;                                }&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                            repositories {&#10;                                maven {&#10;                                    url &quot;https://redirector.kotlinlang.org/maven/dev&quot;&#10;                                }&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <code-block lang="XML" code="                            &lt;repositories&gt;&#10;                                &lt;repository&gt;&#10;                                    &lt;id&gt;ktor-eap&lt;/id&gt;&#10;                                    &lt;url&gt;https://redirector.kotlinlang.org/maven/dev&lt;/url&gt;&#10;                                &lt;/repository&gt;&#10;                            &lt;/repositories&gt;"/>
+                </TabItem>
+            </Tabs>
+        </li>
+    </list>
+</chapter>
+<chapter title="의존성 추가하기" id="add-ktor-dependencies">
+    <chapter title="핵심 의존성" id="core-dependencies">
+        <p>
+            모든 Ktor 애플리케이션에는 최소한 다음 의존성이 필요합니다.
+        </p>
+        <list>
+            <li>
+                <p>
+                    <code>ktor-server-core</code>: 핵심 Ktor 기능이 포함되어 있습니다.
+                </p>
+            </li>
+            <li>
+                <p>
+                    <Links href="//server-engines" summary="네트워크 요청을 처리하는 엔진에 대해 알아봅니다.">엔진 (engine)</Links>에 대한 의존성 (예: <code>ktor-server-netty</code>).
+                </p>
+            </li>
+        </list>
+        <p>
+            다양한 플랫폼을 위해 Ktor는 <code>ktor-server-core-jvm</code> 또는 <code>ktor-server-netty-jvm</code>과 같이 <code>-jvm</code>과 같은 접미사가 붙은 플랫폼별 아티팩트(artifact)를 제공합니다.
+            Gradle은 지정된 플랫폼에 적합한 아티팩트를 자동으로 확인하는 반면, Maven은 이 기능을 지원하지 않습니다.
+            즉, Maven의 경우 플랫폼별 접미사를 수동으로 추가해야 합니다.
+            기본 Ktor 애플리케이션의 <code>dependencies</code> 블록은 다음과 같을 수 있습니다.
+        </p>
+        <Tabs group="languages">
+            <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                <code-block lang="Kotlin" code="                        dependencies {&#10;                            implementation(&quot;io.ktor:ktor-server-core:%ktor_version%&quot;)&#10;                            implementation(&quot;io.ktor:ktor-server-netty:%ktor_version%&quot;)&#10;                        }"/>
+            </TabItem>
+            <TabItem title="Gradle (Groovy)" group-key="groovy">
+                <code-block lang="Groovy" code="                        dependencies {&#10;                            implementation &quot;io.ktor:ktor-server-core:%ktor_version%&quot;&#10;                            implementation &quot;io.ktor:ktor-server-netty:%ktor_version%&quot;&#10;                        }"/>
+            </TabItem>
+            <TabItem title="Maven" group-key="maven">
+                <code-block lang="XML" code="                        &lt;dependencies&gt;&#10;                            &lt;dependency&gt;&#10;                                &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                                &lt;artifactId&gt;ktor-server-core-jvm&lt;/artifactId&gt;&#10;                                &lt;version&gt;%ktor_version%&lt;/version&gt;&#10;                            &lt;/dependency&gt;&#10;                            &lt;dependency&gt;&#10;                                &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                                &lt;artifactId&gt;ktor-server-netty-jvm&lt;/artifactId&gt;&#10;                                &lt;version&gt;%ktor_version%&lt;/version&gt;&#10;                            &lt;/dependency&gt;&#10;                        &lt;/dependencies&gt;"/>
+            </TabItem>
+        </Tabs>
+    </chapter>
+    <chapter title="로깅 의존성" id="logging-dependency">
+        <p>
+            Ktor는 다양한 로깅 프레임워크(예: Logback 또는 Log4j)의 퍼사드(facade)로 SLF4J API를 사용하며, 애플리케이션 이벤트를 로그로 남길 수 있게 해줍니다.
+            필요한 아티팩트를 추가하는 방법을 알아보려면 <a href="server-logging.md#add_dependencies">로거 의존성 추가하기</a>를 참조하세요.
+        </p>
+    </chapter>
+    <chapter title="플러그인 의존성" id="plugin-dependencies">
+        <p>
+            Ktor 기능을 확장하는 <Links href="//server-plugins" summary="플러그인은 직렬화, 콘텐츠 인코딩, 압축 등과 같은 공통 기능을 제공합니다.">플러그인</Links>에는 추가 의존성이 필요할 수 있습니다.
+            해당 주제에서 더 자세히 알아볼 수 있습니다.
+        </p>
+    </chapter>
+</chapter>
+<var name="target_module" value="server"/>
+<chapter title="Ktor 버전 일관성 보장" id="ensure-version-consistency">
+    <chapter id="using-gradle-plugin" title="Ktor Gradle 플러그인 사용하기">
+        <p>
+            <a href="https://github.com/ktorio/ktor-build-plugins">Ktor Gradle 플러그인</a>을 적용하면
+            Ktor BOM 의존성이 암시적으로 추가되어 모든 Ktor 의존성이 동일한 버전인지 확인할 수 있습니다.
+            이 경우 Ktor 아티팩트에 의존할 때 더 이상 버전을 지정할 필요가 없습니다.
+        </p>
+        <Tabs group="languages">
+            <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                <code-block lang="Kotlin" code="                        plugins {&#10;                            // ...&#10;                            id(&quot;io.ktor.plugin&quot;) version &quot;%ktor_version%&quot;&#10;                        }&#10;                        dependencies {&#10;                            implementation(&quot;io.ktor:ktor-%target_module%-core&quot;)&#10;                            // ...&#10;                        }"/>
+            </TabItem>
+            <TabItem title="Gradle (Groovy)" group-key="groovy">
+                <code-block lang="Groovy" code="                        plugins {&#10;                            // ...&#10;                            id &quot;io.ktor.plugin&quot; version &quot;%ktor_version%&quot;&#10;                        }&#10;                        dependencies {&#10;                            implementation &quot;io.ktor:ktor-%target_module%-core&quot;&#10;                            // ...&#10;                        }"/>
+            </TabItem>
+        </Tabs>
+    </chapter>
+    <chapter id="using-version-catalog" title="게시된 버전 카탈로그 사용하기">
+        <p>
+            게시된 버전 카탈로그(version catalog)를 사용하여 Ktor 의존성 선언을 중앙 집중화할 수도 있습니다.
+            이 접근 방식은 다음과 같은 이점을 제공합니다.
+        </p>
+        <list id="published-version-catalog-benefits">
+            <li>
+                자체 카탈로그에서 Ktor 버전을 수동으로 선언할 필요가 없습니다.
+            </li>
+            <li>
+                모든 Ktor 모듈을 단일 네임스페이스 아래에 노출합니다.
+            </li>
+        </list>
+        <p>
+            카탈로그를 선언하려면 <Path>settings.gradle.kts</Path>에서 원하는 이름으로 버전 카탈로그를 생성합니다.
+        </p>
+        <code-block lang="kotlin" code="                dependencyResolutionManagement {&#10;                    versionCatalogs {&#10;                        create(&quot;ktorLibs&quot;) {&#10;                            from(&quot;io.ktor:ktor-version-catalog:%ktor_version%&quot;)&#10;                        }&#10;                    }&#10;                }"/>
+        <p>
+            그런 다음 모듈의 <Path>build.gradle.kts</Path>에서 카탈로그 이름을 참조하여 의존성을 추가할 수 있습니다.
+        </p>
+        <code-block lang="kotlin" code="                dependencies {&#10;                    implementation(ktorLibs.%target_module%.core)&#10;                    // ...&#10;                }"/>
+    </chapter>
+</chapter>
+<chapter title="애플리케이션 실행을 위한 엔트리 포인트 생성" id="create-entry-point">
+    <p>
+        Gradle/Maven을 사용하여 Ktor 서버를 <Links href="//server-run" summary="Ktor 서버 애플리케이션을 실행하는 방법을 알아봅니다.">실행</Links>하는 방식은 <Links href="//server-create-and-configure" summary="애플리케이션 배포 요구 사항에 따라 서버를 생성하는 방법을 알아봅니다.">서버를 생성</Links>하는 방식에 따라 다릅니다.
+        다음 방법 중 하나로 애플리케이션의 메인 클래스를 지정할 수 있습니다.
+    </p>
+    <list>
+        <li>
+            <p>
+                <a href="#embedded-server">embeddedServer</a>를 사용하는 경우 다음과 같이 메인 클래스를 지정합니다.
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                            application {&#10;                                mainClass.set(&quot;com.example.ApplicationKt&quot;)&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                            application {&#10;                                mainClass = &quot;com.example.ApplicationKt&quot;&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <code-block lang="XML" code="                            &lt;properties&gt;&#10;                                &lt;main.class&gt;com.example.ApplicationKt&lt;/main.class&gt;&#10;                            &lt;/properties&gt;"/>
+                </TabItem>
+            </Tabs>
+        </li>
+        <li>
+            <p>
+                <a href="#engine-main">EngineMain</a>을 사용하는 경우 이를 메인 클래스로 구성해야 합니다.
+                Netty의 경우 다음과 같습니다.
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                            application {&#10;                                mainClass.set(&quot;io.ktor.server.netty.EngineMain&quot;)&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                            application {&#10;                                mainClass = &quot;io.ktor.server.netty.EngineMain&quot;&#10;                            }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <code-block lang="XML" code="                            &lt;properties&gt;&#10;                                &lt;main.class&gt;io.ktor.server.netty.EngineMain&lt;/main.class&gt;&#10;                            &lt;/properties&gt;"/>
+                </TabItem>
+            </Tabs>
+        </li>
+    </list>
+    <note>
+        <p>
+            애플리케이션을 Fat JAR로 패키징하려는 경우, 해당 플러그인을 구성할 때 서버를 생성하는 방식도 고려해야 합니다.
+            다음 주제에서 더 자세히 알아보세요.
+        </p>
+        <list>
+            <li>
+                <p>
+                    <Links href="//server-fatjar" summary="Ktor Gradle 플러그인을 사용하여 실행 가능한 fat JAR을 만들고 실행하는 방법을 알아봅니다.">Ktor Gradle 플러그인을 사용하여 fat JAR 생성하기</Links>
+                </p>
+            </li>
+            <li>
+                <p>
+                    <Links href="//maven-assembly-plugin" summary="샘플 프로젝트: tutorial-server-get-started-maven">Maven Assembly 플러그인을 사용하여 fat JAR 생성하기</Links>
+                </p>
+            </li>
+        </list>
+    </note>
+</chapter>
+</topic>

--- a/docs/ko/ktor/server-development-mode.md
+++ b/docs/ko/ktor/server-development-mode.md
@@ -1,0 +1,76 @@
+<topic xmlns="" xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="server-development-mode" title="개발 모드"
+       help-id="development_mode;development-mode">
+    <show-structure for="chapter" depth="2"/>
+    <p>
+        Ktor는 개발을 위해 특화된 특별한 모드를 제공합니다. 이 모드를 사용하면 다음과 같은 기능들을 활용할 수 있습니다.
+    </p>
+    <list>
+        <li>서버를 재시작하지 않고 애플리케이션 클래스를 다시 로드하기 위한 <Links href="//server-auto-reload" summary="Learn how to use Auto-reload to reload application classes on code changes.">자동 리로드(Auto-reload)</Links>.
+        </li>
+        <li><a href="#pipelines">파이프라인(pipelines)</a> 디버깅을 위한 확장 정보(스택 트레이스 포함).
+        </li>
+        <li><emphasis>5**</emphasis> 서버 오류가 발생한 경우 <Links href="//server-status-pages" summary="%plugin_name% allows Ktor applications to respond appropriately to any failure state based on a thrown exception or status code.">응답 페이지(response page)</Links>에 표시되는 확장 디버깅 정보.
+        </li>
+    </list>
+    <note>
+        <p>
+            개발 모드는 성능에 영향을 미치므로 운영 환경(production)에서는 사용해서는 안 됩니다.
+        </p>
+    </note>
+    <chapter title="개발 모드 활성화하기" id="enable">
+        <p>
+            애플리케이션 설정 파일, 전용 시스템 속성 또는 환경 변수를 사용하는 등 다양한 방법으로 개발 모드를 활성화할 수 있습니다.
+        </p>
+        <chapter title="설정 파일" id="application-conf">
+            <p>
+                <Links href="//server-configuration-file" summary="Learn how to configure various server parameters in a configuration file.">설정 파일</Links>에서 개발 모드를 활성화하려면 <code>development</code> 옵션을 <code>true</code>로 설정하세요.
+            </p>
+            <Tabs group="config">
+                <TabItem title="application.conf" group-key="hocon">
+                    <code-block code="                        ktor {&#10;                            development = true&#10;                        }"/>
+                </TabItem>
+                <TabItem title="application.yaml" group-key="yaml">
+                    <code-block lang="yaml" code="                        ktor:&#10;                            development: true"/>
+                </TabItem>
+            </Tabs>
+        </chapter>
+        <chapter title="'io.ktor.development' 시스템 속성" id="system-property">
+            <p>
+                <code>io.ktor.development</code> <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">시스템 속성</a>을 사용하면 애플리케이션을 실행할 때 개발 모드를 활성화할 수 있습니다.
+            </p>
+            <p>
+                IntelliJ IDEA를 사용하여 애플리케이션을 개발 모드로 실행하려면, <code>-D</code> 플래그와 함께 <code>io.ktor.development</code>를 <a href="https://www.jetbrains.com/help/idea/run-debug-configuration-kotlin.html#1">VM 옵션</a>에 전달하세요.
+            </p>
+            <code-block code="                -Dio.ktor.development=true"/>
+            <p>
+                <Links href="//server-dependencies" summary="Learn how to add Ktor Server dependencies to an existing Gradle/Maven project.">Gradle</Links> 태스크를 사용하여 애플리케이션을 실행하는 경우, 다음 두 가지 방법 중 하나로 개발 모드를 활성화할 수 있습니다.
+            </p>
+            <list>
+                <li>
+                    <p>
+                        <code>build.gradle.kts</code> 파일의 <code>ktor</code> 블록을 구성합니다.
+                    </p>
+                    <code-block lang="Kotlin" code="                        ktor {&#10;                            development = true&#10;                        }"/>
+                </li>
+                <li>
+                    <p>
+                        Gradle CLI 플래그를 전달하여 단일 실행에 대해 개발 모드를 활성화합니다.
+                    </p>
+                    <code-block lang="bash" code="                          ./gradlew run -Pio.ktor.development=true"/>
+                </li>
+            </list>
+            <tip>
+                <p>
+                    <code>-ea</code> 플래그를 사용하여 개발 모드를 활성화할 수도 있습니다.
+                    단, <code>-D</code> 플래그로 전달된 <code>io.ktor.development</code> 시스템 속성이 <code>-ea</code>보다 우선순위를 가집니다.
+                </p>
+            </tip>
+        </chapter>
+        <chapter title="'io.ktor.development' 환경 변수" id="environment-variable">
+            <p>
+                <a href="#native">네이티브 클라이언트(Native client)</a>의 개발 모드를 활성화하려면 <code>io.ktor.development</code> 환경 변수를 사용하세요.
+            </p>
+        </chapter>
+    </chapter>
+</topic>

--- a/docs/ktor/FAQ.md
+++ b/docs/ktor/FAQ.md
@@ -1,0 +1,162 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="常见问题解答"
+       id="FAQ">
+    <chapter title="Ktor 的正确发音是什么？" id="pronounce">
+        <p>
+            <emphasis>/keɪ-tor/</emphasis>
+        </p>
+    </chapter>
+    <chapter title='“Ktor”这个名字代表什么？' id="name-meaning">
+        <p>
+            Ktor 这个名字源于缩写 <code>ctor</code>（构造函数），并将第一个字母替换为代表 Kotlin 的 “K”。
+        </p>
+    </chapter>
+    <chapter title="如何提问、报告错误、联系你们、进行贡献或提供反馈等？" id="feedback">
+        <p>
+            请访问 <a href="https://ktor.io/support/">Support</a> 页面以详细了解可用的支持渠道。
+            <a href="https://github.com/ktorio/ktor/blob/main/CONTRIBUTING.md">How to contribute</a> 指南介绍了您可以为 Ktor 做出贡献的方式。
+        </p>
+    </chapter>
+    <chapter title="CIO 是什么意思？" id="cio">
+        <p>
+            CIO 代表
+            <emphasis>基于协程的 I/O（Coroutine-based I/O）</emphasis>
+            。
+            通常我们将其称为一个使用 Kotlin 和协程（Coroutines）来实现 IETF RFC 或其他协议逻辑的引擎，且不依赖于外部基于 JVM 的库。
+        </p>
+    </chapter>
+    <chapter title="如何修复未解析（红色显示）的 Ktor 导入？" id="ktor-artifact">
+        <p>
+            请确保已在构建脚本中添加了相应的 <Links href="//server-dependencies" summary="了解如何向现有的 Gradle/Maven 项目中添加 Ktor Server 依赖项。">Ktor 构件</Links>。
+        </p>
+    </chapter>
+    <chapter
+            title="Ktor 是否提供捕获 IPC 信号（例如 SIGTERM 或 SIGINT）的方法，以便优雅地处理服务器停机？"
+            id="sigterm">
+        <p>
+            如果您正在运行 <a href="#engine-main">EngineMain</a>，它将自动处理。
+            否则，您需要手动处理。
+            您可以使用 JVM 提供的 <code>Runtime.getRuntime().addShutdownHook</code> 设施。
+        </p>
+    </chapter>
+    <chapter title="在代理之后如何获取客户端 IP？" id="proxy-ip">
+        <p>
+            如果代理提供了正确的标头，并且安装了 <Links href="//server-forward-headers" summary="所需依赖项：io.ktor:%artifact_name%">ForwardedHeader</Links> 插件，则 <code>call.request.origin</code> 属性会提供有关原始调用者（代理）的<a href="#request_information">连接信息</a>。
+        </p>
+    </chapter>
+    <chapter title="如何测试 main 分支上的最新提交？" id="bleeding-edge">
+        <p>
+            您可以从 <code>jetbrains.space</code> 获取 Ktor 每夜构建版本。
+            详情请参阅 <a href="https://ktor.io/eap/">抢先体验计划</a>。
+        </p>
+    </chapter>
+    <chapter title="如何确认我使用的是哪个版本的 Ktor？" id="ktor-version-used">
+        <p>
+            您可以使用 <Links href="//server-default-headers" summary="所需依赖项：io.ktor:%artifact_name%">DefaultHeaders</Links> 插件，它会发送一个包含 Ktor 版本的 <code>Server</code> 响应标头，例如：
+        </p>
+        <code-block code="            Server: ktor-server-core/%ktor_version%"/>
+    </chapter>
+    <chapter title="我的路由没有被执行。我该如何调试它？" id="route-not-executing">
+        <p>
+            Ktor 提供了一种跟踪机制来帮助排查路由决策。
+            请查看 <a href="#trace_routes">Tracing routes</a> 章节。
+        </p>
+    </chapter>
+    <chapter title="如何解决 'Response has already been sent' 错误？" id="response-already-sent">
+        <p>
+            这意味着您、或者某个插件或拦截器已经调用过 <code>call.respond&#42; </code> 函数，而您正试图再次调用它。
+        </p>
+    </chapter>
+    <chapter title="如何订阅 Ktor 事件？" id="ktor-events">
+        <p>
+            请参阅 <Links href="//server-events" summary="">Application monitoring</Links> 页面了解更多信息。
+        </p>
+    </chapter>
+    <chapter title="如何解决 'No configuration setting found for key ktor'？" id="cannot-find-application-conf">
+        <p>
+            这意味着 Ktor 无法找到 <Links href="//server-configuration-file" summary="了解如何在配置文件中配置各种服务器参数。">配置文件</Links>。
+            请确保 <code>resources</code> 文件夹中存在配置文件，并且该 <code>resources</code> 文件夹已被正确标记。
+            可以考虑使用 <a href="https://start.ktor.io/">Ktor 项目生成器</a> 或 <a href="https://plugins.jetbrains.com/plugin/16008-ktor">IntelliJ IDEA Ultimate 的 Ktor 插件</a> 来创建一个可以运行的项目作为基础。有关更多信息，请参阅 <Links href="//server-create-a-new-project" summary="了解如何使用 Ktor 创建、打开、运行和测试服务器应用程序。">创建、打开并运行新的 Ktor 项目</Links>。
+        </p>
+    </chapter>
+    <chapter title="我可以在 Android 上使用 Ktor 吗？" id="android-support">
+        <p>
+            是的，已知 Ktor 服务器和客户端可以在 Android 5 (API 21) 或更高版本上运行，至少在使用 Netty 引擎时是这样。
+        </p>
+    </chapter>
+    <chapter title="为什么 'CURL -I' 返回 '404 Not Found'？" id="curl-head-not-found">
+        <p>
+            <code>CURL -I</code> 是 <code>CURL --head</code> 的别名，执行的是 <code>HEAD</code> 请求。
+            默认情况下，Ktor 不会为 <code>GET</code> 处理程序处理 <code>HEAD</code> 请求。
+            要启用此功能，请安装 <Links href="//server-autoheadresponse" summary="%plugin_name% 能够为每个定义了 GET 的路由自动响应 HEAD 请求。">AutoHeadResponse</Links> 插件。
+        </p>
+    </chapter>
+    <chapter title="使用 'HttpsRedirect' 插件时如何解决无限重定向问题？" id="infinite-redirect">
+        <p>
+            最可能的原因是您的后端位于反向代理或负载均衡器之后，而这些中间件正在向您的后端发起普通的 HTTP 请求，因此 Ktor 后端中的 <code>HttpsRedirect</code> 插件认为这是一个普通的 HTTP 请求并响应重定向。
+        </p>
+        <p>
+            通常，反向代理会发送一些描述原始请求的标头（例如它是否为 HTTPS，或原始 IP 地址），可以使用 <Links href="//server-forward-headers" summary="所需依赖项：io.ktor:%artifact_name%">ForwardedHeader</Links> 插件来解析这些标头，以便 <Links href="//server-https-redirect" summary="所需依赖项：io.ktor:%artifact_name%">HttpsRedirect</Links> 插件知道原始请求是 HTTPS。
+        </p>
+    </chapter>
+    <chapter title="如何在 Windows 上安装 'curl' 以在 Kotlin/Native 上使用相应的引擎？" id="native-curl">
+        <p>
+            <a href="#curl">Curl</a> 客户端引擎需要安装 <code>curl</code> 库。
+            在 Windows 上，您可以考虑使用 MinGW/MSYS2 的 <code>curl</code> 二进制文件。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    按照 <a href="https://www.msys2.org/">MinGW/MSYS2</a> 中的说明安装 MinGW/MSYS2。
+                </p>
+            </step>
+            <step>
+                <p>
+                    使用以下命令安装 <code>libcurl</code>：
+                </p>
+                <code-block lang="shell" code="                    pacman -S mingw-w64-x86_64-curl"/>
+            </step>
+            <step>
+                <p>
+                    如果您将 MinGW/MSYS2 安装到了默认位置，请将
+                    <Path>C:\\msys64\\mingw64\\bin\\</Path>
+                    添加到 <code>PATH</code> 环境变量中。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="如何解决 'NoTransformationFoundException'？" id="no-transformation-found-exception">
+        <p>
+            <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.call/-no-transformation-found-exception/index.html">NoTransformationFoundException</a>
+            表示无法为<i>接收到的正文</i>找到合适的转换，即无法将<b>生成的（resulted）</b>类型转换为客户端<b>预期的（expected）</b>类型。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    检查请求中的 <code>Accept</code> 标头是否指定了所需的内容类型，以及服务器响应中的 <code>Content-Type</code> 标头是否与客户端预期的类型匹配。
+                </p>
+            </step>
+            <step>
+                <p>
+                    为您正在处理的特定内容类型注册必要的内容转换。
+                </p>
+                <p>
+                    您可以在客户端使用 <a href="https://ktor.io/docs/serialization-client.html">ContentNegotiation</a> 插件。
+                    此插件允许您指定如何针对不同的内容类型对数据进行序列化和反序列化。
+                </p>
+                <code-block lang="kotlin" code="                    val client = HttpClient(CIO) {&#10;                        install(ContentNegotiation) {&#10;                            json() // 示例：注册 JSON 内容转换&#10;                            // 根据需要为其他内容类型添加更多转换&#10;                        }&#10;                    }"/>
+            </step>
+            <step>
+                <p>
+                    确保安装了所有需要的插件。可能缺失的功能包括：
+                </p>
+                <list type="bullet">
+                    <li>客户端 <a href="https://ktor.io/docs/websocket-client.html">WebSockets</a> 和服务器端 <a href="https://ktor.io/docs/websocket.html">WebSockets</a></li>
+                    <li>客户端 <a href="https://ktor.io/docs/serialization-client.html">ContentNegotiation</a> 和服务器端 <a href="https://ktor.io/docs/server-serialization.html">ContentNegotiation</a></li>
+                    <li><a href="https://ktor.io/docs/compression.html">Compression</a></li>
+                </list>
+            </step>
+        </procedure>
+    </chapter>
+</topic>

--- a/docs/ktor/client-create-new-application.md
+++ b/docs/ktor/client-create-new-application.md
@@ -1,0 +1,323 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="创建客户端应用程序"
+       id="client-create-new-application"
+       help-id="getting_started_ktor_client;client-getting-started;client-get-started;client-create-a-new-application">
+    <show-structure for="chapter" depth="2"/>
+    <tldr>
+        <var name="example_name" value="tutorial-client-get-started"/>
+        <p>
+            <b>代码示例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+    </tldr>
+    <link-summary>
+        创建您的第一个用于发送请求并接收响应的客户端应用程序。
+    </link-summary>
+    <p>
+        Ktor 包含一个多平台异步 HTTP 客户端，允许您<Links href="//client-requests" summary="了解如何进行请求并指定各种请求参数：请求 URL、HTTP 方法、标头和请求正文。">发送请求</Links>并<Links href="//client-responses" summary="了解如何接收响应、获取响应正文以及获取响应参数。">处理响应</Links>，
+        并通过<Links href="//client-plugins" summary="了解如何使用客户端插件添加通用功能，例如日志记录、序列化和身份验证。">插件</Links>扩展其功能，例如<Links href="//client-auth" summary="Auth 插件用于在客户端应用程序中处理身份验证和授权。">身份验证</Links>、
+        <Links href="//client-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及在发送请求和接收响应时以特定格式序列化/反序列化内容。">JSON 序列化</Links>等。
+    </p>
+    <p>
+        在本教程中，我们将向您展示如何创建第一个发送请求并打印响应的 Ktor 客户端应用程序。
+    </p>
+    <chapter title="前提条件" id="prerequisites">
+        <p>
+            在开始本教程之前，请<a href="https://www.jetbrains.com/help/idea/installation-guide.html">安装 IntelliJ IDEA Community 或 Ultimate</a>。
+        </p>
+    </chapter>
+    <chapter title="创建新项目" id="new-project">
+        <p>
+            您可以手动在现有项目中<Links href="//client-create-and-configure" summary="了解如何创建和配置 Ktor 客户端。">创建并配置</Links> Ktor 客户端，不过，从头开始的一种便捷方式是使用 IntelliJ IDEA 内置的 Kotlin 插件生成新项目。
+        </p>
+        <p>
+            要创建一个新的 Kotlin 项目，请<a href="https://www.jetbrains.com/help/idea/run-for-the-first-time.html">打开 IntelliJ IDEA</a> 并按照以下步骤操作：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    在欢迎界面中，点击 <control>New Project</control>。
+                </p>
+                <p>
+                    或者，从主菜单中选择 <ui-path>File | New | Project</ui-path>。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在
+                    <control>New Project</control>
+                    向导中，从左侧列表中选择
+                    <control>Kotlin</control>。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在右侧窗格中，指定以下设置：
+                </p>
+                <img src="client_get_started_new_project.png" alt="IntelliJ IDEA 中的新 Kotlin 项目窗口"
+                     border-effect="rounded"
+                     width="706"/>
+                <list id="kotlin_app_settings">
+                    <li>
+                        <p>
+                            <control>Name</control>
+                            ：指定项目名称。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Location</control>
+                            ：指定项目的目录。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Build system</control>
+                            ：确保已选择
+                            <control>Gradle</control>。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Gradle DSL</control>
+                            ：选择
+                            <control>Kotlin</control>。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Add sample code</control>
+                            ：选中此选项可在生成的项目中包含示例代码。
+                        </p>
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    点击
+                    <control>Create</control>
+                    并等待 IntelliJ IDEA 生成项目并安装依赖项。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="添加依赖项" id="add-dependencies">
+        <p>
+            让我们添加 Ktor 客户端所需的依赖项。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    打开
+                    <Path>gradle.properties</Path>
+                    文件并添加以下行以指定 Ktor 版本：
+                </p>
+                <code-block lang="kotlin" code="                    ktor_version=%ktor_version%"/>
+                <note id="eap-note">
+                    <p>
+                        要使用 Ktor 的 EAP 版本，您需要添加 <a href="#repositories">Space 仓库</a>。
+                    </p>
+                </note>
+            </step>
+            <step>
+                <p>
+                    打开
+                    <Path>build.gradle.kts</Path>
+                    文件并将以下构件添加到 dependencies 块中：
+                </p>
+                <code-block lang="kotlin" code="val ktor_version: String by project&#10;&#10;dependencies {&#10;    implementation(&quot;io.ktor:ktor-client-core:$ktor_version&quot;)&#10;    implementation(&quot;io.ktor:ktor-client-cio:$ktor_version&quot;)&#10;}"/>
+                <list>
+                    <li><code>ktor-client-core</code> 是提供主要客户端功能的核心依赖项。
+                    </li>
+                    <li>
+                        <code>ktor-client-cio</code> 是处理网络请求的<Links href="//client-engines" summary="了解处理网络请求的引擎。">引擎</Links>依赖项。
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    点击
+                    <Path>build.gradle.kts</Path>
+                    文件右上角的
+                    <control>Load Gradle Changes</control>
+                    图标以安装新添加的依赖项。
+                </p>
+                <img src="client_get_started_load_gradle_changes_name.png" alt="加载 Gradle 更改" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="创建客户端" id="create-client">
+        <p>
+            要添加客户端实现，请导航至
+            <Path>src/main/kotlin</Path>
+            并按照以下步骤操作：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    打开
+                    <Path>Main.kt</Path>
+                    文件并用以下实现替换现有代码：
+                </p>
+                <code-block lang="kotlin" code="                    import io.ktor.client.*&#10;                    import io.ktor.client.engine.cio.*&#10;&#10;                    fun main() {&#10;                        val client = HttpClient(CIO)&#10;                    }"/>
+                <p>
+                    在 Ktor 中，客户端由 <a
+                        href="https://api.ktor.io/ktor-client-core/io.ktor.client/-http-client/index.html">HttpClient</a>
+                    类表示。
+                </p>
+            </step>
+            <step>
+                <p>
+                    使用 <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.request/get.html"><code>HttpClient.get()</code></a> 方法来<Links href="//client-requests" summary="了解如何进行请求并指定各种请求参数：请求 URL、HTTP 方法、标头和请求正文。">发送 GET 请求</Links>。
+                    <Links href="//client-responses" summary="了解如何接收响应、获取响应正文以及获取响应参数。">响应</Links>将作为 <code>HttpResponse</code> 类对象接收。
+                </p>
+                <code-block lang="kotlin" code="                    import io.ktor.client.*&#10;                    import io.ktor.client.engine.cio.*&#10;                    import io.ktor.client.request.*&#10;                    import io.ktor.client.statement.*&#10;&#10;                    fun main() {&#10;                        val client = HttpClient(CIO)&#10;                        val response: HttpResponse = client.get(&quot;https://ktor.io/&quot;)&#10;                    }"/>
+                <p>
+                    添加上述代码后，IDE 会对 <code>get()</code> 函数显示以下错误：
+                    <emphasis>Suspend function 'get' should be called only from a coroutine or another suspend
+                        function
+                    </emphasis>（Suspend 函数 'get' 只能从协程或其他 suspend 函数中调用）。
+                </p>
+                <img src="client_get_started_suspend_error.png" alt="Suspend 函数错误" width="706"/>
+                <p>
+                    要修复此错误，您需要使 <code>main()</code> 函数成为 suspending。
+                </p>
+                <tip>
+                    要详细了解如何调用 <code>suspend</code> 函数，请参阅<a
+                        href="https://kotlinlang.org/docs/coroutines-basics.html">协程基础知识</a>。
+                </tip>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，点击定义旁边的灯泡图标并选择
+                    <control>Make main suspend</control>。
+                </p>
+                <img src="client_get_started_suspend_error_fix.png" alt="使 main 成为 suspend" width="706"/>
+            </step>
+            <step>
+                <p>
+                    使用 <code>println()</code> 函数打印服务器返回的<a href="#status">状态码</a>，并使用 <code>close()</code> 函数关闭流并释放与其关联的所有资源。
+                    <Path>Main.kt</Path>
+                    文件应如下所示：
+                </p>
+                <code-block lang="kotlin" code="import io.ktor.client.*&#10;import io.ktor.client.engine.cio.*&#10;import io.ktor.client.request.*&#10;import io.ktor.client.statement.*&#10;&#10;suspend fun main() {&#10;    val client = HttpClient(CIO)&#10;    val response: HttpResponse = client.get(&quot;https://ktor.io/&quot;)&#10;    println(response.status)&#10;    client.close()&#10;}"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="运行您的应用程序" id="make-request">
+        <p>
+            要运行您的应用程序，请导航至
+            <Path>Main.kt</Path>
+            文件并按照以下步骤操作：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，点击 <code>main()</code> 函数旁边的装订区域图标，然后选择
+                    <control>Run 'MainKt'</control>。
+                </p>
+                <img src="client_get_started_run_main.png" alt="运行应用" width="706"/>
+            </step>
+            <step>
+                等待 IntelliJ IDEA 运行应用程序。
+            </step>
+            <step>
+                <p>
+                    您将在 IDE 底部的
+                    <control>Run</control>
+                    窗格中看到显示的输出。
+                </p>
+                <img src="client_get_started_run_output_with_warning.png" alt="服务器响应" width="706"/>
+                <p>
+                    虽然服务器返回了 <code>200 OK</code> 消息，但您还会看到一条错误消息，指出 SLF4J 无法定位
+                    <code>StaticLoggerBinder</code> 类，默认使用无操作 (NOP) 日志记录器实现。这实际上意味着日志记录已被禁用。
+                </p>
+                <p>
+                    您现在已经拥有了一个可以运行的客户端应用程序。但是，要修复此警告并能够通过日志调试 HTTP 调用，还需要执行<a href="#enable-logging">额外步骤</a>。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="启用日志" id="enable-logging">
+        <p>
+            由于 Ktor 在 JVM 上使用 SLF4J 抽象层进行日志记录，要启用日志记录，您需要<a href="#jvm">提供一个日志框架</a>，例如
+            <a href="https://logback.qos.ch/">Logback</a>。
+        </p>
+        <procedure id="enable-logging-procedure">
+            <step>
+                <p>
+                    在
+                    <Path>gradle.properties</Path>
+                    文件中，指定日志框架的版本：
+                </p>
+                <code-block lang="kotlin" code="                    logback_version=%logback_version%"/>
+            </step>
+            <step>
+                <p>
+                    打开
+                    <Path>build.gradle.kts</Path>
+                    文件并将以下构件添加到 dependencies 块中：
+                </p>
+                <code-block lang="kotlin" code="                    //...&#10;                    val logback_version: String by project&#10;&#10;                    dependencies {&#10;                        //...&#10;                        implementation(&quot;ch.qos.logback:logback-classic:$logback_version&quot;)&#10;                    }"/>
+            </step>
+            <step>
+                点击
+                <control>Load Gradle Changes</control>
+                图标以安装新添加的依赖项。
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，点击重新运行按钮（<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 重新运行图标"/>）以重启应用程序。
+                </p>
+            </step>
+            <step>
+                <p>
+                    您应该不再看到错误，但同样的 <code>200 OK</code> 消息仍将显示在 IDE 底部的
+                    <control>Run</control>
+                    窗格中。
+                </p>
+                <img src="client_get_started_run_output.png" alt="服务器响应" width="706"/>
+                <p>
+                    至此，您已启用了日志功能。要开始看到日志，您需要添加日志配置。
+                </p>
+            </step>
+            <step>
+                <p>导航至
+                    <Path>src/main/resources</Path>
+                    并创建一个新的
+                    <Path>logback.xml</Path>
+                    文件，其内容如下：
+                </p>
+                <code-block lang="xml" ignore-vars="true" code="                    &lt;configuration&gt;&#10;                        &lt;appender name=&quot;APPENDER&quot; class=&quot;ch.qos.logback.core.ConsoleAppender&quot;&gt;&#10;                            &lt;encoder&gt;&#10;                                &lt;pattern&gt;%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n&lt;/pattern&gt;&#10;                            &lt;/encoder&gt;&#10;                        &lt;/appender&gt;&#10;                        &lt;root level=&quot;trace&quot;&gt;&#10;                            undefined&#10;                        &lt;/root&gt;&#10;                    &lt;/configuration&gt;"/>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，点击重新运行按钮（<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 重新运行图标"/>）以重启应用程序。
+                </p>
+            </step>
+            <step>
+                <p>
+                    您现在应该能够在
+                    <control>Run</control>
+                    窗格中打印的响应上方看到跟踪日志：
+                </p>
+                <img src="client_get_started_run_output_with_logs.png" alt="服务器响应" width="706"/>
+            </step>
+        </procedure>
+        <tip>
+            Ktor 通过 <Links href="//client-logging" summary="所需依赖项：io.ktor:ktor-client-logging">Logging</Links> 插件提供了一种简单直接的方法来为 HTTP 调用添加日志，而添加配置文件则允许您在复杂的应用程序中微调日志行为。
+        </tip>
+    </chapter>
+    <chapter title="后续步骤" id="next-steps">
+        <p>
+            要更好地理解并扩展此配置，请探索如何<Links href="//client-create-and-configure" summary="了解如何创建和配置 Ktor 客户端。">创建并配置 Ktor 客户端</Links>。
+        </p>
+    </chapter>
+</topic>

--- a/docs/ktor/client-server-sent-events.md
+++ b/docs/ktor/client-server-sent-events.md
@@ -1,0 +1,178 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="client-server-sent-events" title="Ktor Client 中的 Server-Sent Events" help-id="sse_client">
+    <show-structure for="chapter" depth="2"/>
+    <primary-label ref="client-plugin"/>
+    <tldr>
+        <var name="example_name" value="client-sse"/>
+        <p>
+            <b>代码示例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+    </tldr>
+    <link-summary>
+        SSE 插件允许客户端通过 HTTP 连接接收来自服务器的基于事件的更新。
+    </link-summary>
+    <p>
+        Server-Sent Events (SSE) 是一项允许服务器通过 HTTP 连接持续向客户端推送事件的技术。它在服务器需要发送基于事件的更新而无需客户端反复轮询服务器的情况下特别有用。
+    </p>
+    <p>
+        Ktor 支持的 SSE 插件提供了一种在服务器和客户端之间创建单向连接的简便方法。
+    </p>
+    <tip>
+        <p>要了解更多关于服务器端支持的 SSE 插件的信息，请参阅
+            <Links href="//server-server-sent-events" summary="SSE 插件允许服务器通过 HTTP 连接向客户端发送基于事件的更新。">SSE 服务器插件</Links>。
+        </p>
+    </tip>
+    <chapter title="添加依赖项" id="add_dependencies">
+        <p>
+            <code>SSE</code> 仅需要 <Links href="//client-dependencies" summary="了解如何向现有项目添加客户端依赖项。">ktor-client-core</Links> 构件，不需要任何特定的依赖项。
+        </p>
+    </chapter>
+    <chapter title="安装 SSE" id="install_plugin">
+        <p>
+            要安装 <code>SSE</code> 插件，请在 <a href="#configure-client">客户端配置块</a> 内将其传递给 <code>install</code> 函数：
+        </p>
+        <code-block lang="kotlin" code="            import io.ktor.client.*&#10;            import io.ktor.client.engine.cio.*&#10;            import io.ktor.client.plugins.sse.*&#10;&#10;            //...&#10;            val client = HttpClient(CIO) {&#10;                install(SSE)&#10;            }"/>
+    </chapter>
+    <chapter title="配置 SSE 插件" id="configure">
+        <p>
+            您可以选择在 <code>install</code> 块中通过设置 <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-s-s-e-config/index.html">SSEConfig</a> 类支持的属性来配置 SSE 插件。
+        </p>
+        <chapter title="SSE 重连" id="sse-reconnect">
+            <p>
+                要启用自动重连，请将 <code>maxReconnectionAttempts</code> 设置为大于 <code>0</code> 的值。您还可以使用 <code>reconnectionTime</code> 配置尝试之间的延迟：
+            </p>
+            <code-block lang="kotlin" code="                install(SSE) {&#10;                    maxReconnectionAttempts = 4&#10;                    reconnectionTime = 2.seconds&#10;                }"/>
+            <p>
+                如果与服务器的连接丢失，客户端将在尝试重连之前等待指定的 <code>reconnectionTime</code>。它将尝试最多 <code>maxReconnectionAttempts</code> 次来重新建立连接。
+            </p>
+        </chapter>
+        <chapter title="过滤事件" id="filter-events">
+            <p>
+                在以下示例中，SSE 插件安装到 HTTP 客户端，并配置为在传入流中包含仅包含注释的事件以及仅包含 <code>retry</code> 字段的事件：
+            </p>
+            <code-block lang="kotlin" code="        install(SSE) {&#10;            showCommentEvents()&#10;            showRetryEvents()&#10;        }"/>
+        </chapter>
+        <chapter title="响应缓冲" id="response-buffering">
+            <p>
+                SSE 响应本质上是流式的，这使得捕获完整正文变得不切实际。您可以启用诊断缓冲区，以便在 SSE 流失败时安全地检索响应正文。缓冲区仅包含已处理的数据（不会从网络重新读取），旨在用于失败情况下的日志记录和错误分析。
+            </p>
+            <code-block lang="kotlin" code="                install(SSE) {&#10;                    bufferPolicy = SSEBufferPolicy.LastEvents(10)&#10;                }"/>
+            <p>
+                您还可以按调用配置缓冲区：
+            </p>
+            <code-block lang="kotlin" code="                client.sse(url, {&#10;                    bufferPolicy(SSEBufferPolicy.All)&#10;                }) {&#10;                    // ...&#10;                }"/>
+            <chapter title="缓冲策略" id="buffer-policies">
+                <p>
+                    <code>SSEBufferPolicy</code> 类型提供了几种存储已处理 SSE 数据的策略。这些策略控制内存中保留多少流数据，并在发生错误时使其可用。
+                </p>
+                <deflist>
+                    <def id="buffer-off">
+                        <title><code>Off</code>（默认）</title>
+                        不缓冲。
+                    </def>
+                    <def id="buffer-lastlines">
+                        <title><code>LastLines(n)</code></title>
+                        保留最后 n 行。
+                    </def>
+                    <def id="buffer-lastevent">
+                        <title><code>LastEvent</code></title>
+                        保留最后一个完成的 SSE 事件。
+                    </def>
+                    <def id="buffer-lastevents">
+                        <title><code>LastEvents(n)</code></title>
+                        保留最后 n 个完成的 SSE 事件。
+                    </def>
+                    <def id="buffer-all">
+                        <title><code>All</code></title>
+                        保留到目前为止所有已处理的事件。
+                        <note>对于长期存续的流，请谨慎使用。</note>
+                    </def>
+                </deflist>
+                <p>
+                    失败时，您可以使用 <code>response?.bodyAsText()</code> 访问缓冲区，而无需从网络重新读取。
+                </p>
+            </chapter>
+        </chapter>
+    </chapter>
+    <chapter title="处理 SSE 会话" id="handle-sse-sessions">
+        <p>
+            客户端的 SSE 会话由 <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session/index.html"><code>ClientSSESession</code></a> 接口表示。该接口公开了允许您接收来自服务器的服务器发送事件的 API。
+        </p>
+        <chapter title="访问 SSE 会话" id="access-sse-session">
+            <p><code>HttpClient</code> 允许您通过以下方式之一访问 SSE 会话：</p>
+            <list>
+                <li>
+                    <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/sse.html"><code>sse()</code></a> 函数创建 SSE 会话并允许您对其执行操作。
+                </li>
+                <li>
+                    <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/sse-session.html"><code>sseSession()</code></a> 函数允许您打开一个 SSE 会话。
+                </li>
+            </list>
+            <p>要指定 URL 端点，您可以从两个选项中进行选择：</p>
+            <list>
+                <li>使用 <code>urlString</code> 形参将整个 URL 指定为字符串。</li>
+                <li>分别使用 <code>schema</code>、<code>host</code>、<code>port</code> 和 <code>path</code> 形参来指定协议方案、域名、端口号和路径名。</li>
+            </list>
+            <code-block lang="kotlin" code="                runBlocking {&#10;                    client.sse(host = &amp;quot;127.0.0.1&amp;quot;, port = 8080, path = &amp;quot;/events&amp;quot;) {&#10;                        // this: ClientSSESession&#10;                    }&#10;                }"/>
+            <note>
+                <code>ClientSSESession</code> 和 <code>ClientSSESessionWithDeserialization</code> 实例仅在会话期间有效。当 <code>serverSentEvents { ... }</code> 块完成或连接关闭时，它们的作用域会自动取消。
+            </note>
+            <p>此外，还有以下形参可用于配置连接：</p>
+            <deflist>
+                <def id="reconnectionTime-param">
+                    <title><code>reconnectionTime</code></title>
+                    设置重连延迟。
+                </def>
+                <def id="showCommentEvents-param">
+                    <title><code>showCommentEvents</code></title>
+                    指定是否在传入流中显示仅包含注释的事件。
+                </def>
+                <def id="showRetryEvents-param">
+                    <title><code>showRetryEvents</code></title>
+                    指定是否在传入流中显示仅包含 <code>retry</code> 字段的事件。
+                </def>
+                <def id="deserialize-param">
+                    <title><code>deserialize</code></title>
+                    一个反序列化函数，用于将 <code>TypedServerSentEvent</code> 的 <code>data</code> 字段转换为对象。更多信息请参阅 <a href="#deserialization">反序列化</a>。
+                </def>
+            </deflist>
+        </chapter>
+        <chapter title="SSE 会话块" id="sse-session-block">
+            <p>
+                在 lambda 实参中，您可以访问 <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session/index.html"><code>ClientSSESession</code></a> 上下文。该块中提供以下属性：
+            </p>
+            <deflist>
+                <def id="call">
+                    <title><code>call</code></title>
+                    发起会话的相关 <code>HttpClientCall</code>。
+                </def>
+                <def id="incoming">
+                    <title><code>incoming</code></title>
+                    传入的服务器发送事件流。
+                </def>
+            </deflist>
+            <p>
+                下面的示例创建了一个具有 <code>events</code> 端点的新 SSE 会话，通过 <code>incoming</code> 属性读取事件并打印接收到的 <a href="https://api.ktor.io/ktor-sse/io.ktor.sse/-server-sent-event/index.html"><code>ServerSentEvent</code></a>。
+            </p>
+            <code-block lang="kotlin" code="fun main() {&#10;    val client = HttpClient {&#10;        install(SSE) {&#10;            showCommentEvents()&#10;            showRetryEvents()&#10;        }&#10;    }&#10;    runBlocking {&#10;        client.sse(host = &quot;0.0.0.0&quot;, port = 8080, path = &quot;/events&quot;) {&#10;            while (true) {&#10;                incoming.collect { event -&gt;&#10;                    println(&quot;Event from server:&quot;)&#10;                    println(event)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>有关完整示例，请参阅 <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-sse">client-sse</a>。</p>
+        </chapter>
+        <chapter title="反序列化" id="deserialization">
+            <p>
+                SSE 插件支持将服务器发送事件反序列化为类型安全的 Kotlin 对象。当处理来自服务器的结构化数据时，此功能特别有用。
+            </p>
+            <p>
+                要启用反序列化，请在 SSE 访问函数上使用 <code>deserialize</code> 形参提供自定义反序列化函数，并使用 <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session-with-deserialization/index.html"><code>ClientSSESessionWithDeserialization</code></a> 类来处理反序列化后的事件。
+            </p>
+            <p>
+                以下是使用 <code>kotlinx.serialization</code> 反序列化 JSON 数据的示例：
+            </p>
+            <code-block lang="Kotlin" code="        client.sse({&#10;            url(&quot;http://localhost:8080/serverSentEvents&quot;)&#10;        }, deserialize = {&#10;                typeInfo, jsonString -&gt;&#10;            val serializer = Json.serializersModule.serializer(typeInfo.kotlinType!!)&#10;            Json.decodeFromString(serializer, jsonString)!!&#10;        }) { // `this` is `ClientSSESessionWithDeserialization`&#10;            incoming.collect { event: TypedServerSentEvent&lt;String&gt; -&gt;&#10;                when (event.event) {&#10;                    &quot;customer&quot; -&gt; {&#10;                        val customer: Customer? = deserialize&lt;Customer&gt;(event.data)&#10;                    }&#10;                    &quot;product&quot; -&gt; {&#10;                        val product: Product? = deserialize&lt;Product&gt;(event.data)&#10;                    }&#10;                }&#10;            }&#10;        }"/>
+            <p>有关完整示例，请参阅 <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-sse">client-sse</a>。</p>
+        </chapter>
+    </chapter>
+</topic>

--- a/docs/ktor/client-websockets.md
+++ b/docs/ktor/client-websockets.md
@@ -1,0 +1,151 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="client-websockets" title="Ktor Client 中的 WebSockets">
+    <show-structure for="chapter" depth="3"/>
+    <primary-label ref="client-plugin"/>
+    <var name="example_name" value="client-websockets"/>
+    <var name="artifact_name" value="ktor-client-websockets"/>
+    <tldr>
+        <p>
+            <b>所需依赖</b>：<code>io.ktor:ktor-client-websockets</code>
+        </p>
+        <p>
+            <b>代码示例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+    </tldr>
+    <link-summary>
+        Websockets 插件允许您在服务器和客户端之间创建多路通信会话。
+    </link-summary>
+    WebSocket 是一种协议，它通过单个 TCP 连接在用户的浏览器和服务器之间提供全双工通信会话。它对于创建需要与服务器进行实时数据传输的应用程序特别有用。
+    Ktor 在服务器端和客户端都支持 WebSocket 协议。
+    <p>客户端的 Websockets 插件允许您处理与服务器交换消息的 WebSocket 会话。</p>
+    <note>
+        <p>并非所有引擎都支持 WebSockets。有关受支持引擎的概览，请参阅<a href="client-engines.md#limitations">限制</a>。</p>
+    </note>
+    <tip>
+        <p>要了解服务器端的 WebSocket 支持，请参阅 <Links href="//server-websockets" summary="Websockets 插件允许您在服务器和客户端之间创建多路通信会话。">Ktor Server 中的 WebSockets</Links>。</p>
+    </tip>
+    <chapter title="添加依赖项" id="add_dependencies">
+        <p>要使用 <code>WebSockets</code>，您需要在构建脚本中包含 <code>%artifact_name%</code> 构件：</p>
+        <Tabs group="languages">
+            <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                <code-block lang="Kotlin" code="                    implementation(&quot;io.ktor:%artifact_name%:$ktor_version&quot;)"/>
+            </TabItem>
+            <TabItem title="Gradle (Groovy)" group-key="groovy">
+                <code-block lang="Groovy" code="                    implementation &quot;io.ktor:%artifact_name%:$ktor_version&quot;"/>
+            </TabItem>
+            <TabItem title="Maven" group-key="maven">
+                <code-block lang="XML" code="                    &lt;dependency&gt;&#10;                        &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                        &lt;artifactId&gt;%artifact_name%-jvm&lt;/artifactId&gt;&#10;                        &lt;version&gt;${ktor_version}&lt;/version&gt;&#10;                    &lt;/dependency&gt;"/>
+            </TabItem>
+        </Tabs>
+        <tip>
+            要了解更多关于 Ktor 客户端所需构件的信息，请参阅 <Links href="//client-dependencies" summary="了解如何向现有项目添加客户端依赖项。">添加客户端依赖项</Links>。
+        </tip>
+    </chapter>
+    <chapter title="安装 WebSockets" id="install_plugin">
+        <p>要安装 <code>WebSockets</code> 插件，请在 <a href="#configure-client">客户端配置块</a> 内部将其传递给 <code>install</code> 函数：</p>
+        <code-block lang="kotlin" code="            import io.ktor.client.*&#10;            import io.ktor.client.engine.cio.*&#10;            import io.ktor.client.plugins.websocket.*&#10;&#10;            //...&#10;            val client = HttpClient(CIO) {&#10;                install(WebSockets)&#10;            }"/>
+    </chapter>
+    <chapter title="配置" id="configure_plugin">
+        <p>（可选）您可以通过在 <code>install</code> 块内传递 
+            <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/-web-sockets/-config/index.html">WebSockets.Config</a> 支持的属性来配置插件。
+        </p>
+        <deflist>
+            <def id="maxFrameSize">
+                <title><code>maxFrameSize</code></title>
+                设置可以接收或发送的最大 <code>Frame</code> 大小。
+            </def>
+            <def id="contentConverter">
+                <title><code>contentConverter</code></title>
+                设置用于序列化/反序列化的转换器。
+            </def>
+            <def id="pingIntervalMillis">
+                <title><code>pingIntervalMillis</code></title>
+                以 <code>Long</code> 格式指定 ping 之间的时间间隔。
+            </def>
+            <def id="pingInterval">
+                <title><code>pingInterval</code></title>
+                以 <code>Duration</code> 格式指定 ping 之间的时间间隔。
+            </def>
+        </deflist>
+        <warning>
+            <p><code>pingInterval</code> 和 <code>pingIntervalMillis</code> 属性不适用于 OkHttp 引擎。要为 OkHttp 设置 ping 间隔，您可以使用 <a href="#okhttp">引擎配置</a>：
+            </p>
+            <code-block lang="kotlin" code="                import io.ktor.client.engine.okhttp.OkHttp&#10;&#10;                val client = HttpClient(OkHttp) {&#10;                    engine {&#10;                        preconfigured = OkHttpClient.Builder()&#10;                            .pingInterval(20, TimeUnit.SECONDS)&#10;                            .build()&#10;                    }&#10;                }"/>
+        </warning>
+        <p>
+            在以下示例中，WebSockets 插件配置了 20 秒（<code>20_000</code> 毫秒）的 ping 间隔，以自动发送 ping 帧并保持 WebSocket 连接处于活动状态：
+        </p>
+        <code-block lang="kotlin" code="    val client = HttpClient(CIO) {&#10;        install(WebSockets) {&#10;            pingIntervalMillis = 20_000&#10;        }&#10;    }"/>
+    </chapter>
+    <chapter title="使用 WebSocket 会话" id="working-wtih-session">
+        <p>客户端的 WebSocket 会话由 
+            <a href="https://api.ktor.io/ktor-websockets/io.ktor.websocket/-default-web-socket-session/index.html">DefaultClientWebSocketSession</a>
+            接口表示。该接口公开了允许您发送和接收 WebSocket 帧以及关闭会话的 API。
+        </p>
+        <chapter title="访问 WebSocket 会话" id="access-session">
+            <p>
+                <code>HttpClient</code> 提供了两种访问 WebSocket 会话的主要方式：
+            </p>
+            <list>
+                <li>
+                    <p><a
+                            href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/web-socket.html">webSocket()</a>
+                        函数接受 <code>DefaultClientWebSocketSession</code> 作为块参数。</p>
+                    <code-block lang="kotlin" code="                        runBlocking {&#10;                            client.webSocket(&#10;                                method = HttpMethod.Get,&#10;                                host = &quot;127.0.0.1&quot;,&#10;                                port = 8080,&#10;                                path = &quot;/echo&quot;&#10;                            ) {&#10;                                // this: DefaultClientWebSocketSession&#10;                            }&#10;                        }"/>
+                </li>
+                <li>
+                    <a
+                        href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/web-socket-session.html">webSocketSession()</a>
+                    函数返回 <code>DefaultClientWebSocketSession</code> 实例，并允许您在 <code>runBlocking</code> 或 <code>launch</code> 作用域之外访问会话。
+                </li>
+            </list>
+        </chapter>
+        <chapter title="处理 WebSocket 会话" id="handle-session">
+            <p>在函数块内，您可以为指定的路径定义处理程序。块内提供以下函数和属性：</p>
+            <deflist>
+                <def id="send">
+                    <title><code>send()</code></title>
+                    使用 <code>send()</code> 函数向服务器发送文本内容。
+                </def>
+                <def id="outgoing">
+                    <title><code>outgoing</code></title>
+                    使用 <code>outgoing</code> 属性访问用于发送 WebSocket 帧的通道。帧由 <code>Frame</code> 类表示。
+                </def>
+                <def id="incoming">
+                    <title><code>incoming</code></title>
+                    使用 <code>incoming</code> 属性访问用于接收 WebSocket 帧的通道。帧由 <code>Frame</code> 类表示。
+                </def>
+                <def id="close">
+                    <title><code>close()</code></title>
+                    使用 <code>close()</code> 函数发送带有指定原因的关闭帧。
+                </def>
+            </deflist>
+        </chapter>
+        <chapter title="帧类型" id="frame-types">
+            <p>
+                您可以检查 WebSocket 帧的类型并进行相应处理。一些常见的帧类型包括：
+            </p>
+            <list>
+                <li><code>Frame.Text</code> 表示文本帧。使用
+                    <code>Frame.Text.readText()</code> 读取其内容。
+                </li>
+                <li><code>Frame.Binary</code> 表示二进制帧。使用 <code>Frame.Binary.readBytes()</code>
+                    读取其内容。
+                </li>
+                <li><code>Frame.Close</code> 表示关闭帧。使用 <code>Frame.Close.readReason()</code>
+                    获取会话关闭的原因。
+                </li>
+            </list>
+        </chapter>
+        <chapter title="示例" id="example">
+            <p>下面的示例创建了 <code>echo</code> WebSocket 端点，并展示了如何向服务器发送消息以及从服务器接收消息。</p>
+            <code-block lang="kotlin"
+                        include-symbol="main" code="package com.example&#10;&#10;import io.ktor.client.*&#10;import io.ktor.client.engine.cio.*&#10;import io.ktor.client.plugins.websocket.*&#10;import io.ktor.http.*&#10;import io.ktor.websocket.*&#10;import kotlinx.coroutines.*&#10;import java.util.*&#10;&#10;fun main() {&#10;    val client = HttpClient(CIO) {&#10;        install(WebSockets) {&#10;            pingIntervalMillis = 20_000&#10;        }&#10;    }&#10;    runBlocking {&#10;        client.webSocket(method = HttpMethod.Get, host = &quot;127.0.0.1&quot;, port = 8080, path = &quot;/echo&quot;) {&#10;            while(true) {&#10;                val othersMessage = incoming.receive() as? Frame.Text&#10;                println(othersMessage?.readText())&#10;                val myMessage = Scanner(System.`in`).next()&#10;                if(myMessage != null) {&#10;                    send(myMessage)&#10;                }&#10;            }&#10;        }&#10;    }&#10;    client.close()&#10;}"/>
+            <p>有关完整示例，请参阅 <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-websockets">client-websockets</a>。</p>
+        </chapter>
+    </chapter>
+</topic>

--- a/docs/ktor/docker-compose.md
+++ b/docs/ktor/docker-compose.md
@@ -1,0 +1,122 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="docker-compose" title="Docker Compose">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <p>
+        <control>初始项目</control>
+        ：<a
+            href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-db-integration">tutorial-server-db-integration</a>
+    </p>
+    <p>
+        <control>最终项目</control>
+        ：<a
+            href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-docker-compose">tutorial-server-docker-compose</a>
+    </p>
+</tldr>
+<p>在本主题中，我们将向您展示如何在 <a href="https://docs.docker.com/compose/">Docker Compose</a> 下运行 Ktor 服务器应用程序。我们将使用在 <Links href="//server-integrate-database" summary="通过 Exposed SQL 库了解将 Ktor 服务连接到数据库仓库的过程。">集成数据库</Links> 教程中创建的项目，该项目使用 <a href="https://github.com/JetBrains/Exposed">Exposed</a> 连接到 <a href="https://www.postgresql.org/docs/">PostgreSQL</a> 数据库，其中数据库和 Web 应用程序分别运行。</p>
+<chapter title="准备应用程序" id="prepare-app">
+    <chapter title="提取数据库设置" id="extract-db-settings">
+        <p>
+            在 <a href="server-integrate-database.topic#config-db-connection">配置数据库连接</a> 教程中创建的项目使用硬编码属性来建立数据库连接。</p>
+        <p>
+            让我们将 PostgreSQL 数据库的连接设置提取到 <Links href="//server-configuration-file" summary="了解如何在配置文件中配置各种服务器参数。">自定义配置组</Links>。
+        </p>
+        <procedure>
+            <step>
+                <p>打开 <Path>src/main/resources</Path> 中的 <Path>application.yaml</Path> 文件，并在 <code>ktor</code> 组之外添加 <code>storage</code> 组，如下所示：
+                </p>
+                <code-block lang="yaml" code="ktor:&#10;  application:&#10;    modules:&#10;      - com.example.ApplicationKt.module&#10;  deployment:&#10;    port: 8080&#10;storage:&#10;  driverClassName: &quot;org.postgresql.Driver&quot;&#10;  jdbcURL: &quot;jdbc:postgresql://localhost:5432/ktor_tutorial_db&quot;&#10;  user: &quot;postgres&quot;&#10;  password: &quot;password&quot;"/>
+                <p>这些设置稍后将在 <a href="#configure-docker">
+                    <Path>compose.yml</Path>
+                </a> 文件中进行配置。
+                </p>
+            </step>
+            <step>
+                <p>
+                    打开 <Path>src/main/kotlin/com/example/plugins/</Path> 中的 <Path>Databases.kt</Path> 文件，并更新 <code>configureDatabases()</code> 函数，以从配置文件加载存储设置：
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureDatabases(config: ApplicationConfig) {&#10;    val url = config.property(&quot;storage.jdbcURL&quot;).getString()&#10;    val user = config.property(&quot;storage.user&quot;).getString()&#10;    val password = config.property(&quot;storage.password&quot;).getString()&#10;&#10;    Database.connect(&#10;        url,&#10;        user = user,&#10;        password = password&#10;    )&#10;}"/>
+                <p>
+                    <code>configureDatabases()</code> 函数现在接受 <code>ApplicationConfig</code>，并使用 <code>config.property</code> 加载自定义设置。
+                </p>
+            </step>
+            <step>
+                <p>
+                    打开 <Path>src/main/kotlin/com/example/</Path> 中的 <Path>Application.kt</Path> 文件，并将 <code>environment.config</code> 传递给 <code>configureDatabases()</code>，以便在应用程序启动时加载连接设置：
+                </p>
+                <code-block lang="kotlin" code="fun Application.module() {&#10;    val repository = PostgresTaskRepository()&#10;&#10;    configureSerialization(repository)&#10;    configureDatabases(environment.config)&#10;    configureRouting()&#10;}"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="配置 Ktor 插件" id="configure-ktor-plugin">
+        <p>为了在 Docker 上运行，应用程序需要将所有必需的文件部署到容器。根据您使用的构建系统，有不同的插件可以实现这一点：</p>
+        <list>
+            <li><Links href="//server-fatjar" summary="了解如何使用 Ktor Gradle 插件创建并运行可执行的 fat JAR。">使用 Ktor Gradle 插件创建 fat JAR</Links></li>
+            <li><Links href="//maven-assembly-plugin" summary="示例项目：tutorial-server-get-started-maven">使用 Maven Assembly 插件创建 fat JAR</Links></li>
+        </list>
+        <p>在我们的示例中，<Path>build.gradle.kts</Path> 文件中已应用了 Ktor 插件。
+        </p>
+        <code-block lang="kotlin" code="plugins {&#10;    application&#10;    kotlin(&quot;jvm&quot;)&#10;    id(&quot;io.ktor.plugin&quot;) version &quot;3.5.1&quot;&#10;    id(&quot;org.jetbrains.kotlin.plugin.serialization&quot;) version &quot;2.2.20&quot;&#10;}"/>
+    </chapter>
+</chapter>
+<chapter title="配置 Docker" id="configure-docker">
+    <chapter title="准备 Docker 镜像" id="prepare-docker-image">
+        <p>
+            要将应用程序 Docker 化，请在项目的根目录中创建一个新的 <Path>Dockerfile</Path>，并插入以下内容：
+        </p>
+        <code-block lang="Docker" code="# Stage 1: Cache Gradle dependencies&#10;FROM gradle:latest AS cache&#10;RUN mkdir -p /home/gradle/cache_home&#10;ENV GRADLE_USER_HOME=/home/gradle/cache_home&#10;COPY build.gradle.* gradle.properties /home/gradle/app/&#10;COPY gradle /home/gradle/app/gradle&#10;WORKDIR /home/gradle/app&#10;RUN gradle dependencies --no-daemon&#10;&#10;# Stage 2: Build Application&#10;FROM gradle:latest AS build&#10;COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle&#10;COPY --chown=gradle:gradle . /home/gradle/src&#10;WORKDIR /home/gradle/src&#10;# Build the fat JAR, Gradle also supports shadow&#10;# and boot JAR by default.&#10;RUN gradle buildFatJar --no-daemon&#10;&#10;# Stage 3: Create the Runtime Image&#10;FROM amazoncorretto:22 AS runtime&#10;EXPOSE 8080&#10;RUN mkdir /app&#10;COPY --from=build /home/gradle/src/build/libs/*.jar /app/ktor-docker-sample.jar&#10;ENTRYPOINT [&quot;java&quot;,&quot;-jar&quot;,&quot;/app/ktor-docker-sample.jar&quot;]"/>
+        <tip>
+            有关此多阶段构建工作原理的更多信息，请参阅 <a href="docker.md#prepare-docker">准备 Docker 镜像</a>。
+        </tip>
+        <p>
+         本示例使用的是 Amazon Corretto Docker 镜像，但您可以将其替换为任何其他合适的替代品，例如：
+        </p>
+        <list>
+          <li><a href="https://hub.docker.com/_/eclipse-temurin">Eclipse Temurin</a></li>
+          <li><a href="https://hub.docker.com/_/ibm-semeru-runtimes">IBM Semeru</a></li>
+          <li><a href="https://hub.docker.com/_/ibmjava">IBM Java</a></li>
+          <li><a href="https://hub.docker.com/_/sapmachine">SAP Machine JDK</a></li>
+        </list>
+    </chapter>
+    <chapter title="配置 Docker Compose" id="configure-docker-compose">
+        <p>在项目的根目录中，创建一个新的 <Path>compose.yml</Path> 文件并添加以下内容：
+        </p>
+        <code-block lang="yaml" code="services:&#10;  web:&#10;    build: .&#10;    ports:&#10;      - &quot;8080:8080&quot;&#10;    depends_on:&#10;      db:&#10;        condition: service_healthy&#10;  db:&#10;    image: postgres&#10;    volumes:&#10;      - ./tmp/db:/var/lib/postgresql/data&#10;    environment:&#10;      POSTGRES_DB: ktor_tutorial_db&#10;      POSTGRES_HOST_AUTH_METHOD: trust&#10;    ports:&#10;      - &quot;5432:5432&quot;&#10;    healthcheck:&#10;      test: [ &quot;CMD-SHELL&quot;, &quot;pg_isready -U postgres&quot; ]&#10;      interval: 1s"/>
+        <list>
+            <li><code>web</code> 服务用于运行打包在 <a href="#prepare-docker-image">镜像</a> 内的 Ktor 应用程序。
+            </li>
+            <li><code>db</code> 服务使用 <code>postgres</code> 镜像创建 <code>ktor_tutorial_db</code> 数据库以存储任务。
+            </li>
+        </list>
+    </chapter>
+</chapter>
+<chapter title="构建并运行服务" id="build-run">
+    <procedure>
+        <step>
+            <p>
+                运行以下命令以创建包含 Ktor 应用程序的 <a href="#configure-ktor-plugin">fat JAR</a>：
+            </p>
+            <code-block lang="Bash" code="                    ./gradlew :tutorial-server-docker-compose:buildFatJar"/>
+        </step>
+        <step>
+            <p>
+                使用 <code>docker compose up</code> 命令构建镜像并启动容器：
+            </p>
+            <code-block lang="Bash" code="                    docker compose --project-directory snippets/tutorial-server-docker-compose up"/>
+        </step>
+        <step>
+            等待 Docker Compose 完成镜像构建。
+        </step>
+        <step>
+            <p>
+                导航至 <a href="http://localhost:8080/static/index.html">http://localhost:8080/static/index.html</a> 以打开 Web 应用程序。您应该会看到“任务管理器客户端”页面，其中显示了三个用于筛选和添加新任务的表单，以及一个任务表。
+            </p>
+            <img src="tutorial_server_db_integration_manual_test.gif"
+                 alt="显示任务管理器客户端的浏览器窗口"
+                 border-effect="rounded"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+</topic>

--- a/docs/ktor/full-stack-development-with-kotlin-multiplatform.md
+++ b/docs/ktor/full-stack-development-with-kotlin-multiplatform.md
@@ -1,0 +1,666 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="使用 Kotlin Multiplatform 构建全栈应用程序" id="full-stack-development-with-kotlin-multiplatform">
+    <show-structure for="chapter, procedure" depth="2"/>
+    <web-summary>
+        了解如何使用 Kotlin 和 Ktor 开发跨平台全栈应用程序。在本教程中，你将发现如何使用 Kotlin Multiplatform 为 Android、iOS 和桌面端构建应用，并使用 Ktor 轻松处理数据。
+    </web-summary>
+    <link-summary>
+        了解如何使用 Kotlin 和 Ktor 开发跨平台全栈应用程序。
+    </link-summary>
+    <card-summary>
+        了解如何使用 Kotlin 和 Ktor 开发跨平台全栈应用程序。
+    </card-summary>
+    <tldr>
+        <var name="example_name" value="full-stack-task-manager"/>
+        <p>
+            <b>代码示例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+        <p>
+            <b>使用的插件</b>：<Links href="//server-routing" summary="路由是服务器应用程序中处理传入请求的核心插件。">Routing</Links>、
+            <a href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>、
+            <Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要目的：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">Content Negotiation</Links>、
+            <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a>、
+            <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">Kotlin Multiplatform</a>
+        </p>
+    </tldr>
+    <p>
+        在本文中，你将学习如何使用 Kotlin 开发运行在 Android、iOS、Web 和桌面平台的全栈应用程序，同时利用 Ktor 进行无缝的数据处理。
+    </p>
+    <p>在本教程结束时，你将了解如何执行以下操作：</p>
+    <list>
+        <li>使用 <a
+                href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">
+            Kotlin Multiplatform</a> 创建全栈应用程序。
+        </li>
+        <li>理解由 IntelliJ IDEA 生成的项目。</li>
+        <li>创建调用 Ktor 服务的 <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a> 客户端。
+        </li>
+        <li>在设计的不同层级中复用共享类型。</li>
+        <li>正确包含和配置多平台库。</li>
+    </list>
+    <p>
+        在之前的教程中，我们使用任务管理器（Task Manager）示例来
+        <Links href="//server-requests-and-responses" summary="通过构建任务管理器应用程序，学习在 Kotlin 中使用 Ktor 处理请求、路由和参数的基础知识。">处理请求</Links>、
+        <Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 构建后端服务，其中包含一个生成 JSON 文件的 RESTful API 示例。">创建 RESTful API</Links> 以及
+        <Links href="//server-integrate-database" summary="了解使用 Exposed SQL 库将 Ktor 服务连接到数据库仓库的过程。">使用 Exposed 集成数据库</Links>。
+        当时客户端应用程序尽可能保持简单，以便你可以专注于学习 Ktor 的基础知识。
+    </p>
+    <p>
+        你将创建一个面向 Android、iOS、Web 和桌面平台的客户端，并使用 Ktor 服务获取要显示的数据。你将尽可能在客户端和服务器之间共享数据类型，从而加快开发速度并减少出错的可能性。
+    </p>
+    <chapter title="前提条件" id="prerequisites">
+        <p>
+            与之前的文章一样，你将使用 IntelliJ IDEA 作为 IDE。要安装和配置环境，请参阅
+            <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/quickstart.html">
+                Kotlin Multiplatform 快速入门指南
+            </a>
+            。
+        </p>
+        <p>
+            如果这是你第一次使用 Compose Multiplatform，我们建议你在开始本教程之前先完成
+            <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-getting-started.html">
+                Compose Multiplatform 入门
+            </a>
+            教程。为了降低任务的复杂度，你可以专注于单一的客户端平台。例如，如果你从未用过 iOS，那么专注于桌面端或 Android 开发可能是明智之举。
+        </p>
+    </chapter>
+    <chapter title="创建一个新项目" id="create-project">
+        <p>
+            不使用 Ktor 项目生成器，而是使用 IntelliJ IDEA 中的 Kotlin Multiplatform 项目向导。
+            它将创建一个基础的多平台项目，你可以通过客户端和服务对其进行扩展。客户端可以使用原生 UI 库（如 SwiftUI），但在本教程中，你将使用 <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a> 为所有平台创建一个共享 UI。
+        </p>
+        <procedure id="generate-project">
+            <step>
+                启动 IntelliJ IDEA。
+            </step>
+            <step>
+                在 IntelliJ IDEA 中，选择
+                <ui-path>File | New | Project</ui-path>
+                。
+            </step>
+            <step>
+                在左侧面板中，选择
+                <ui-path>Kotlin Multiplatform</ui-path>
+                。
+            </step>
+            <step>
+                在
+                <ui-path>New Project</ui-path>
+                窗口中指定以下字段：
+                <list>
+                    <li>
+                        <ui-path>Name</ui-path>
+                        : full-stack-task-manager
+                    </li>
+                    <li>
+                        <ui-path>Project ID</ui-path>
+                        : com.example.ktor
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    选择
+                    <ui-path>Android</ui-path>
+                    、
+                    <ui-path>Desktop</ui-path>
+                    、
+                    <ui-path>Web</ui-path>
+                    和
+                    <ui-path>Server</ui-path>
+                    作为目标平台。
+                </p>
+            </step>
+            <step>
+                <p>
+                    如果你使用的是 Mac，也请选择
+                    <ui-path>iOS</ui-path>
+                    。确保已选中
+                    <ui-path>Share UI</ui-path>
+                    选项。
+                    <img style="block" src="full_stack_development_tutorial_create_project.png"
+                         alt="Kotlin Multiplatform 向导设置" width="706" border-effect="rounded"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    点击
+                    <control>Create</control>
+                    按钮并等待 IDE 生成并导入项目。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="运行服务" id="run-service">
+        <procedure id="run-service-procedure">
+            <step>
+                在 IntelliJ IDEA 中，选择
+                <Path>ApplicationKt</Path>
+                运行配置。
+                <img src="full_stack_development_tutorial_server_run_configuration.png"
+                     alt="运行和调试窗口" width="300"
+                     border-effect="line" style="block"/>
+            </step>
+            <step>
+                点击
+                <ui-path>Run</ui-path>
+                按钮
+                (<img src="intellij_idea_run_icon.svg"
+                      style="inline" height="16" width="16"
+                      alt="IntelliJ IDEA 运行图标"/>)
+                以运行该配置。
+                <p>
+                    <ui-path>Run</ui-path>
+                    工具窗口中将打开一个新标签页。
+                </p>
+            </step>
+            <step>
+                <p>
+                    导航至 <a href="http://0.0.0.0:8080/">http://0.0.0.0:8080/</a> 以打开应用程序。
+                    你应该会看到浏览器中显示的来自 Ktor 的消息。
+                    <img src="full_stack_development_tutorial_run.png"
+                         alt="Ktor 服务器浏览器响应" width="706"
+                         border-effect="rounded" style="block"/>
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="检查项目" id="examine-project">
+        <p>
+            <Path>server</Path>
+            文件夹是项目中的三个 Kotlin 模块之一。另外两个是
+            <Path>core</Path>
+            和
+            <Path>app</Path>
+            。
+        </p>
+        <p>
+            <Path>server</Path>
+            模块的结构与 <a href="https://start.ktor.io/">Ktor 项目生成器</a> 生成的结构非常相似。
+            你拥有一个专门的构建文件来声明插件和依赖项，以及一个包含用于构建和启动 Ktor 服务代码的源集：
+        </p>
+        <img src="full_stack_development_tutorial_server_folder.png"
+             alt="Kotlin Multiplatform 项目中 server 文件夹的内容" width="300"
+             border-effect="line"/>
+        <p>
+            如果你查看
+            <Path>Application.kt</Path>
+            文件中的路由指令，你会看到对 <code>sayHello()</code> 函数的调用：
+        </p>
+        <code-block lang="kotlin" code="            fun Application.module() {&#10;                routing {&#10;                    get(&quot;/&quot;) {&#10;                        call.respondText(sayHello(&quot;Ktor&quot;))&#10;                    }&#10;                }&#10;            }"/>
+        <p>
+            <code>sayHello()</code> 函数定义在
+            <Path>core</Path>
+            模块中。这是你放置要在服务器和所有不同客户端平台之间共享的通用代码的地方。
+        </p>
+        <p>
+           打开 <Path>app/shared/src/commonMain</Path> 模块中的 <Path>Greeting.kt</Path> 文件，你会看到
+            <code>sayHello()</code> 函数也在那里被使用了：
+        </p>
+        <code-block lang="kotlin" code="            class Greeting {&#10;                private val platform = getPlatform()&#10;&#10;                fun greet(): String {&#10;                    return sayHello(platform.name)&#10;                }&#10;            }"/>
+        <p>
+            <Path>app</Path> 模块包含以下子模块：
+        </p>
+        <list>
+            <li>
+                <Path>androidApp</Path>、<Path>desktopApp</Path>、<Path>iosApp</Path> 和 <Path>webApp</Path> 子模块分别包含针对 Android、桌面端、iOS 和 Web 客户端应用的平台特定代码。目前，这些客户端应用都没有链接到 Ktor 服务。
+            </li>
+            <li>
+                <p>
+                    <Path>shared</Path>
+                    子模块为你希望提供客户端的每个平台都包含一个源集。这是因为
+                    <Path>commonMain</Path>
+                    中声明的类型需要的功能因目标平台而异。
+                </p>
+                <p>
+                    例如，在 <code>Greeting</code> 类型中，当前平台的名称是使用平台特定的 API，通过 <a
+                        href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-connect-to-apis.html">预期声明 (expect) 和实际声明 (actual)</a> 获取的。
+                </p>
+                <p>
+                    在
+                    <Path>shared</Path>
+                    子模块的
+                    <Path>commonMain</Path>
+                    源集中，<code>getPlatform()</code> 函数使用 <code>expect</code> 关键字声明：
+                </p>
+                <Tabs>
+                    <TabItem title="commonMain/Platform.kt" id="commonMain">
+                <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;interface Platform {&#10;    val name: String&#10;}&#10;&#10;expect fun getPlatform(): Platform"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    然后，每个目标平台都提供 <code>getPlatform()</code> 函数的一个 <code>actual</code> 声明，如下所示：
+                </p>
+                <Tabs>
+                    <TabItem title="Platform.ios.kt" id="iosMain">
+                <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import platform.UIKit.UIDevice&#10;&#10;class IOSPlatform : Platform {&#10;    override val name: String = UIDevice.currentDevice.systemName() + &quot; &quot; + UIDevice.currentDevice.systemVersion&#10;}&#10;&#10;actual fun getPlatform(): Platform = IOSPlatform()"/>
+                    </TabItem>
+                    <TabItem title="Platform.android.kt" id="androidMain">
+                <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import android.os.Build&#10;&#10;class AndroidPlatform : Platform {&#10;    override val name: String = &quot;Android ${Build.VERSION.SDK_INT}&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = AndroidPlatform()"/>
+                    </TabItem>
+                    <TabItem title="Platform.jvm.kt" id="jvmMain">
+                <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;class JVMPlatform : Platform {&#10;    override val name: String = &quot;Java ${System.getProperty(&quot;java.version&quot;)}&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = JVMPlatform()"/>
+                    </TabItem>
+                    <TabItem title="Platform.wasmJs.kt" id="wasmJsMain">
+                <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;class WasmPlatform : Platform {&#10;    override val name: String = &quot;Web with Kotlin/Wasm&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = WasmPlatform()"/>
+                    </TabItem>
+                </Tabs>
+            </li>
+        </list>
+    </chapter>
+    <chapter title="运行客户端应用程序" id="run-client-app">
+        <p>
+            你可以通过执行目标的运行配置来运行客户端应用程序。要在 iOS 模拟器（Simulator）上运行应用程序，请按照以下步骤操作：
+        </p>
+        <procedure id="run-ios-app-procedure">
+            <step>
+                在 IntelliJ IDEA 中，选择
+                <Path>iosApp</Path>
+                运行配置和一个模拟设备。
+                <img src="full_stack_development_tutorial_run_configurations.png"
+                     alt="运行和调试窗口" width="400"
+                     border-effect="line" style="block"/>
+            </step>
+            <step>
+                点击
+                <ui-path>Run</ui-path>
+                按钮
+                (<img src="intellij_idea_run_icon.svg"
+                      style="inline" height="16" width="16"
+                      alt="IntelliJ IDEA 运行图标"/>)
+                以运行该配置。
+            </step>
+            <step>
+                <p>
+                    运行 iOS 应用时，它会在后台通过 Xcode 进行构建并在 iOS 模拟器中启动。
+                    应用会显示一个按钮，点击后可以切换图片的显示。
+                    <img style="block" src="full_stack_development_tutorial_run_ios.gif"
+                         alt="在 iOS 模拟器中运行应用" width="300" border-effect="rounded"/>
+                </p>
+                <p>
+                    第一次按下按钮时，当前平台的详细信息会添加到按钮文本中。实现此功能的代码位于
+                    <Path>app/shared/src/commonMain/kotlin/com/example/ktor/App.kt</Path>
+                    ：
+                </p>
+                <code-block lang="kotlin" code="                @Composable&#10;                @Preview&#10;                fun App() {&#10;                    MaterialTheme {&#10;                        var showContent by remember { mutableStateOf(false) }&#10;                        Column(&#10;                            modifier = Modifier&#10;                                .background(MaterialTheme.colorScheme.primaryContainer)&#10;                                .safeContentPadding()&#10;                                .fillMaxSize(),&#10;                            horizontalAlignment = Alignment.CenterHorizontally,&#10;                        ) {&#10;                            Button(onClick = { showContent = !showContent }) {&#10;                                Text(&quot;Click me!&quot;)&#10;                            }&&#10;                            AnimatedVisibility(showContent) {&#10;                                val greeting = remember { Greeting().greet() }&#10;                                Column(&#10;                                    modifier = Modifier.fillMaxWidth(),&#10;                                    horizontalAlignment = Alignment.CenterHorizontally,&#10;                                ) {&#10;                                    Image(painterResource(Res.drawable.compose_multiplatform), null)&#10;                                    Text(&quot;Compose: $greeting&quot;)&#10;                                }&#10;                            }&#10;                        }&#10;                    }&#10;                }"/>
+                <p>
+                    这是一个可组合函数，你将在本文后面部分对其进行修改。目前，重要的是它显示了一个 UI，并使用了共享的 <code>Greeting</code> 类型，而该类型又使用了实现通用 <code>Platform</code> 接口的平台特定类。
+                </p>
+            </step>
+        </procedure>
+        <p>
+            现在你已经了解了生成的项目的结构，可以逐步添加任务管理器功能。
+        </p>
+    </chapter>
+    <chapter title="添加模型类型" id="add-model-types">
+        <p>
+            首先，添加模型类型，并确保它们对于客户端和服务器都是可访问的。
+        </p>
+        <procedure id="add-model-types-procedure">
+            <step>
+                导航至
+                <Path>gradle/libs.versions.toml</Path>
+                并定义以下 <code>kotlinx.serialization</code> 依赖项：
+                <code-block lang="toml" code="[versions]&#10;kotlinx-serialization-json = &quot;1.11.0&quot;&#10;&#10;[libraries]&#10;kotlinx-serialization-json = { module = &quot;org.jetbrains.kotlinx:kotlinx-serialization-json&quot;, version.ref = &quot;kotlinx-serialization-json&quot; }&#10;&#10;[plugins]&#10;kotlinSerialization = { id = &quot;org.jetbrains.kotlin.plugin.serialization&quot;, version.ref = &quot;kotlin&quot; }"/>
+            </step>
+            <step>
+                <p>
+                    导航至
+                    <Path>core/build.gradle.kts</Path>
+                    并添加序列化插件：
+                </p>
+                <code-block lang="kotlin" code="plugins {&#10;    //...&#10;    alias(libs.plugins.kotlinSerialization)&#10;}"/>
+            </step>
+            <step>
+                <p>
+                    在同一文件中，向
+                    <Path>commonMain</Path>
+                    源集添加一个新的依赖项：
+                </p>
+                <code-block lang="kotlin" code="    sourceSets {&#10;        commonMain.dependencies {&#10;            // 在此处放置你的多平台依赖项&#10;            implementation(libs.kotlinx.serialization.json)&#10;        }&#10;        //...&#10;    }"/>
+            </step>
+            <step>
+                在 IntelliJ IDEA 中，选择
+                <ui-path>Build | Sync Project with Gradle Files</ui-path>
+                以应用更新。Gradle 导入完成后，你应该会发现你的
+                <Path>Task.kt</Path>
+                文件编译成功。
+            </step>
+            <step>
+                导航至
+                <Path>core/src/commonMain/kotlin/com/example/ktor</Path>
+                并创建一个名为
+                <Path>model</Path>
+                的新包。
+            </step>
+            <step>
+                在新包内，创建一个名为
+                <Path>Task.kt</Path>
+                的新文件。
+            </step>
+            <step>
+                <p>
+                    添加一个表示优先级的枚举和一个表示任务的类。
+                    <code>Task</code>
+                    类使用来自
+                    <code>kotlinx.serialization</code>
+                    库的 <code>Serializable</code> 注解：
+                </p>
+                <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="创建服务器" id="create-server">
+        <p>
+            下一阶段是为任务管理器创建服务器实现。
+        </p>
+        <procedure id="create-server-procedure">
+            <step>
+                导航至
+                <Path>server/src/main/kotlin/com/example/ktor</Path>
+                文件夹并创建一个名为
+                <Path>model</Path>
+                的子包。
+            </step>
+            <step>
+                <p>
+                    在此包内，创建一个新的
+                    <Path>TaskRepository.kt</Path>
+                    文件，并为该仓库添加以下接口：
+                </p>
+                <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;interface TaskRepository {&#10;    fun allTasks(): List&lt;Task&gt;&#10;    fun tasksByPriority(priority: Priority): List&lt;Task&gt;&#10;    fun taskByName(name: String): Task?&#10;    fun addOrUpdateTask(task: Task)&#10;    fun removeTask(name: String): Boolean&#10;}"/>
+            </step>
+            <step>
+                <p>
+                    在同一包中，创建一个名为
+                    <Path>InMemoryTaskRepository.kt</Path>
+                    的新文件，其中包含以下类：
+                </p>
+                <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;class InMemoryTaskRepository : TaskRepository {&#10;    private var tasks = listOf(&#10;        Task(&quot;Cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;Gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;Shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;Painting&quot;, &quot;Paint the fence&quot;, Priority.Low),&#10;        Task(&quot;Cooking&quot;, &quot;Cook the dinner&quot;, Priority.Medium),&#10;        Task(&quot;Relaxing&quot;, &quot;Take a walk&quot;, Priority.High),&#10;        Task(&quot;Exercising&quot;, &quot;Go to the gym&quot;, Priority.Low),&#10;        Task(&quot;Learning&quot;, &quot;Read a book&quot;, Priority.Medium),&#10;        Task(&quot;Snoozing&quot;, &quot;Go for a nap&quot;, Priority.High),&#10;        Task(&quot;Socializing&quot;, &quot;Go to a party&quot;, Priority.High)&#10;    )&#10;&#10;    override fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    override fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    override fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    override fun addOrUpdateTask(task: Task) {&#10;        var notFound = true&#10;&#10;        tasks = tasks.map {&#10;            if (it.name == task.name) {&#10;                notFound = false&#10;                task&#10;            } else {&#10;                it&#10;            }&#10;        }&#10;        if (notFound) {&#10;            tasks = tasks.plus(task)&#10;        }&#10;    }&#10;&#10;    override fun removeTask(name: String): Boolean {&#10;        val oldTasks = tasks&#10;        tasks = tasks.filterNot { it.name == name }&#10;        return oldTasks.size &gt; tasks.size&#10;    }&#10;}"/>
+            </step>
+            <step>
+                <p>
+                    导航至
+                    <Path>server/src/main/kotlin/.../Application.kt</Path>
+                    并将现有代码替换为以下实现：
+                </p>
+                <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import com.example.ktor.model.InMemoryTaskRepository&#10;import com.example.ktor.model.Priority&#10;import com.example.ktor.model.Task&#10;import io.ktor.http.*&#10;import io.ktor.serialization.*&#10;import io.ktor.serialization.kotlinx.json.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.plugins.contentnegotiation.*&#10;import io.ktor.server.plugins.cors.routing.*&#10;import io.ktor.server.request.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;, module = Application::module)&#10;        .start(wait = true)&#10;}&#10;&#10;fun Application.module() {&#10;    install(ContentNegotiation) {&#10;        json()&#10;    }&#10;    install(CORS) {&#10;        allowHeader(HttpHeaders.ContentType)&#10;        allowMethod(HttpMethod.Delete)&#10;        // 为了演示方便，我们允许任何连接。&#10;        // 请勿在生产环境中这样做。&#10;        anyHost()&#10;    }&#10;    val repository = InMemoryTaskRepository()&#10;&#10;    routing {&#10;        route(&quot;/tasks&quot;) {&#10;            get {&#10;                val tasks = repository.allTasks()&#10;                call.respond(tasks)&#10;            }&#10;            get(&quot;/byName/{taskName}&quot;) {&#10;                val name = call.parameters[&quot;taskName&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                val task = repository.taskByName(name)&#10;                if (task == null) {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                    return@get&#10;                }&#10;                call.respond(task)&#10;            }&#10;            get(&quot;/byPriority/{priority}&quot;) {&#10;                val priorityAsText = call.parameters[&quot;priority&quot;]&#10;                if (priorityAsText == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(priorityAsText)&#10;                    val tasks = repository.tasksByPriority(priority)&#10;&#10;&#10;                    if (tasks.isEmpty()) {&#10;                        call.respond(HttpStatusCode.NotFound)&#10;                        return@get&#10;                    }&#10;                    call.respond(tasks)&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;            post {&#10;                try {&#10;                    val task = call.receive&lt;Task&gt;()&#10;                    repository.addOrUpdateTask(task)&#10;                    call.respond(HttpStatusCode.NoContent)&#10;                } catch (ex: IllegalStateException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                } catch (ex: JsonConvertException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;            delete(&quot;/{taskName}&quot;) {&#10;                val name = call.parameters[&quot;taskName&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@delete&#10;                }&#10;                if (repository.removeTask(name)) {&#10;                    call.respond(HttpStatusCode.NoContent)&#10;                } else {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    此实现与之前教程中的非常相似，不同之处在于，为了简单起见，现在你已将所有路由代码放置在 <code>Application.module()</code> 函数中。
+                </p>
+                <p>
+                    输入此代码并添加导入后，你会发现多个编译器错误，因为代码使用了多个需要作为依赖项包含的 Ktor 插件，包括用于与 Web 客户端交互的 <Links href="//server-cors" summary="所需依赖项：io.ktor:%artifact_name%">CORS</Links> 插件。
+                </p>
+            </step>
+            <step>
+                打开
+                <Path>gradle/libs.versions.toml</Path>
+                文件并定义以下库：
+                <code-block lang="toml" code="[libraries]&#10;ktor-serialization-kotlinx-json-jvm = { module = &quot;io.ktor:ktor-serialization-kotlinx-json-jvm&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-server-content-negotiation-jvm = { module = &quot;io.ktor:ktor-server-content-negotiation-jvm&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-server-cors-jvm = { module = &quot;io.ktor:ktor-server-cors-jvm&quot;, version.ref = &quot;ktor&quot; }"/>
+            </step>
+            <step>
+                <p>
+                    打开服务器模块构建文件 (
+                    <Path>server/build.gradle.kts</Path>
+                    ) 并添加以下依赖项：
+                </p>
+                <code-block lang="kotlin" code="dependencies {&#10;    //...&#10;    implementation(libs.ktor.serialization.kotlinx.json.jvm)&#10;    implementation(libs.ktor.server.content-negotiation.jvm)&#10;    implementation(libs.ktor.server.cors.jvm)&#10;}"/>
+            </step>
+            <step>
+                再次从主菜单中选择 <ui-path>Build | Sync Project with Gradle Files</ui-path>。
+                导入完成后，你应该会发现 <code>ContentNegotiation</code> 类型和 <code>json()</code> 函数的导入可以正常工作。
+            </step>
+            <step>
+                重新运行服务器。你应该会发现路由可以通过浏览器访问。
+            </step>
+            <step>
+                <p>
+                    导航至 <a href="http://0.0.0.0:8080/tasks"></a>
+                    和 <a href="http://0.0.0.0:8080/tasks/byPriority/Medium"></a>
+                    以查看 JSON 格式的任务服务器响应。
+                    <img style="block" src="full_stack_development_tutorial_run_server.gif"
+                         width="707" border-effect="rounded" alt="浏览器中的服务器响应"/>
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="创建客户端" id="create-client">
+        <p>
+            为了让你的客户端能够访问服务器，你需要包含 Ktor Client。这涉及三种类型的依赖项：
+        </p>
+        <list>
+            <li>Ktor Client 的核心功能。</li>
+            <li>处理网络连接的平台特定引擎。</li>
+            <li>对内容协商和序列化的支持。</li>
+        </list>
+        <procedure id="create-client-procedure">
+            <step>
+                在
+                <Path>gradle/libs.versions.toml</Path>
+                文件中，添加以下库：
+                <code-block lang="toml" code="[libraries]&#10;ktor-client-android = { module = &quot;io.ktor:ktor-client-android&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-cio = { module = &quot;io.ktor:ktor-client-cio&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-content-negotiation = { module = &quot;io.ktor:ktor-client-content-negotiation&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-core = { module = &quot;io.ktor:ktor-client-core&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-darwin = { module = &quot;io.ktor:ktor-client-darwin&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-wasm = { module = &quot;io.ktor:ktor-client-js-wasm-js&quot;, version.ref = &quot;ktor&quot;}&#10;ktor-serialization-kotlinx-json = { module = &quot;io.ktor:ktor-serialization-kotlinx-json&quot;, version.ref = &quot;ktor&quot; }"/>
+            </step>
+            <step>
+                导航至
+                <Path>app/shared/build.gradle.kts</Path>
+                并添加以下依赖项：
+                <code-block lang="kotlin" code="kotlin {&#10;    //...&#10;    sourceSets {&#10;        androidMain.dependencies {&#10;            //...&#10;            implementation(libs.ktor.client.android)&#10;        }&#10;        commonMain.dependencies {&#10;            //...&#10;            implementation(libs.ktor.client.core)&#10;            implementation(libs.ktor.client.content-negotiation)&#10;            implementation(libs.ktor.serialization.kotlinx.json)&#10;        }&#10;        jvmMain.dependencies {&#10;            implementation(libs.ktor.client.cio)&#10;        }&#10;        iosMain.dependencies {&#10;            implementation(libs.ktor.client.darwin)&#10;        }&#10;        wasmJsMain.dependencies {&#10;            implementation(libs.ktor.client.wasm)&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    完成后，你可以添加一个 <code>TaskApi</code> 类型，作为你的客户端围绕 Ktor Client 的薄封装。
+                </p>
+            </step>
+            <step>
+                从主菜单中选择
+                <ui-path>Build | Sync Project with Gradle Files</ui-path>
+                以导入构建文件中的更改。
+            </step>
+            <step>
+                导航至
+                <Path>app/shared/src/commonMain/kotlin/com/example/ktor</Path>
+                并创建一个名为
+                <Path>network</Path>
+                的新包。
+            </step>
+            <step>
+                <p>
+                    在新包内，创建一个新的
+                    <Path>HttpClientManager.kt</Path>
+                    文件用于客户端配置：
+                </p>
+                <code-block lang="kotlin" code="package com.example.ktor.network&#10;&#10;import io.ktor.client.HttpClient&#10;import io.ktor.client.plugins.contentnegotiation.ContentNegotiation&#10;import io.ktor.client.plugins.defaultRequest&#10;import io.ktor.serialization.kotlinx.json.json&#10;import kotlinx.serialization.json.Json&#10;&#10;fun createHttpClient() = HttpClient {&#10;    install(ContentNegotiation) {&#10;        json(Json {&#10;            encodeDefaults = true&#10;            isLenient = true&#10;            coerceInputValues = true&#10;            ignoreUnknownKeys = true&#10;        })&#10;    }&#10;    defaultRequest {&#10;        host = &quot;1.2.3.4&quot; // 请替换为你当前机器的 IP 地址。&#10;        port = 8080&#10;    }&#10;}"/>
+                <p>
+                    将 <code>1.2.3.4</code> 替换为你当前机器的 IP 地址。你将无法从运行在 Android 虚拟设备或 iOS 模拟器上的代码中调用 <code>0.0.0.0</code> 或 <code>localhost</code>。
+                </p>
+                <tip>
+                    <p><b>查找你的 IP 地址：</b></p>
+                    <p>
+                        由于移动端模拟器无法访问 <code>localhost</code>，你需要机器的实际 IP 地址。要查找你的 IP 地址，请运行以下命令之一：
+                    </p>
+                    <list>
+                        <li><b>macOS:</b> <code>ifconfig | grep "inet " | grep -v 127.0.0.1</code></li>
+                        <li><b>Linux:</b> <code>hostname -I | awk '{print $1}'</code></li>
+                        <li><b>Windows:</b> <code>ipconfig</code> 并查找“IPv4 地址”</li>
+                    </list>
+                </tip>
+            </step>
+            <step>
+                <p>
+                    在同一个
+                    <Path>app/shared/.../network</Path>
+                    包中，创建一个具有以下实现的新
+                    <Path>TaskApi.kt</Path>
+                    文件：
+                </p>
+                <code-block lang="kotlin" code="package com.example.ktor.network&#10;&#10;import com.example.ktor.model.Task&#10;import io.ktor.client.HttpClient&#10;import io.ktor.client.call.body&#10;import io.ktor.client.request.delete&#10;import io.ktor.client.request.get&#10;import io.ktor.client.request.post&#10;import io.ktor.client.request.setBody&#10;import io.ktor.http.ContentType&#10;import io.ktor.http.contentType&#10;&#10;class TaskApi(private val httpClient: HttpClient) {&#10;&#10;    suspend fun getAllTasks(): List&lt;Task&gt; {&#10;        return httpClient.get(&quot;tasks&quot;).body()&#10;    }&#10;&#10;    suspend fun removeTask(task: Task) {&#10;        httpClient.delete(&quot;tasks/${task.name}&quot;)&#10;    }&#10;&#10;    suspend fun updateTask(task: Task) {&#10;        httpClient.post(&quot;tasks&quot;) {&#10;            contentType(ContentType.Application.Json)&#10;            setBody(task)&#10;        }&#10;    }&#10;}"/>
+            </step>
+            <step>
+                <p>
+                    导航至
+                    <Path>app/shared/.../App.kt</Path>
+                    并使用以下实现替换代码。
+                    这将使用 <code>TaskApi</code> 类型从服务器检索任务列表，然后在一个列中显示每个任务的名称：
+                </p>
+                <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import com.example.ktor.network.TaskApi&#10;import com.example.ktor.network.createHttpClient&#10;import com.example.ktor.model.Task&#10;import androidx.compose.foundation.layout.Column&#10;import androidx.compose.foundation.layout.fillMaxSize&#10;import androidx.compose.foundation.layout.safeContentPadding&#10;import androidx.compose.material3.Button&#10;import androidx.compose.material3.MaterialTheme&#10;import androidx.compose.material3.Text&#10;import androidx.compose.runtime.*&#10;import androidx.compose.ui.Alignment&#10;import androidx.compose.ui.Modifier&#10;import kotlinx.coroutines.launch&#10;&#10;@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        val tasks = remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;&#10;        Column(&#10;            modifier = Modifier&#10;                .safeContentPadding()&#10;                .fillMaxSize(),&#10;            horizontalAlignment = Alignment.CenterHorizontally,&#10;        ) {&#10;            Button(onClick = {&#10;                scope.launch {&#10;                    tasks.value = taskApi.getAllTasks()&#10;                }&#10;            }) {&#10;                Text(&quot;Fetch Tasks&quot;)&#10;            }&#10;            for (task in tasks.value) {&#10;                Text(task.name)&#10;            }&#10;        }&#10;    }&#10;}"/>
+            </step>
+            <step>
+                <p>
+                    在服务器运行的同时，通过运行 <ui-path>iosApp</ui-path> 运行配置来测试 iOS 应用程序。
+                </p>
+            </step>
+            <step>
+                <p>
+                    点击
+                    <control>Fetch Tasks</control>
+                    按钮显示任务列表：
+                    <img style="block" src="full_stack_development_tutorial_run_iOS.png"
+                         alt="在 iOS 上运行的应用" width="363" border-effect="rounded"/>
+                </p>
+                <note>
+                    在本次演示中，为了清晰起见，我们简化了流程。在现实世界的应用中，避免在网络上发送未加密的数据至关重要。
+                </note>
+            </step>
+            <step>
+                <p>
+                    在 Android 平台上，你需要明确授予应用程序网络权限，并允许其以明文形式发送和接收数据。要启用这些权限，请打开
+                    <Path>app/androidApp/src/main/AndroidManifest.xml</Path>
+                    并添加以下设置：
+                </p>
+                <code-block lang="xml" code="                    &lt;manifest&gt;&#10;                        ...&#10;                        &lt;application&#10;                                android:usesCleartextTraffic=&quot;true&quot;&gt;&#10;                        ...&#10;                        ...&#10;                        &lt;/application&gt;&#10;                        &lt;uses-permission android:name=&quot;android.permission.INTERNET&quot;/&gt;&#10;                    &lt;/manifest&gt;"/>
+            </step>
+            <step>
+                <p>
+                    使用 <ui-path>app.androidApp</ui-path> 运行配置运行 Android 应用程序。
+                    你应该会发现你的 Android 客户端现在也能正常运行了：
+                    <img style="block" src="full_stack_development_tutorial_run_android.png"
+                         alt="在 Android 上运行的应用" width="350" />
+                </p>
+            </step>
+            <step>
+                <p>
+                    对于桌面端客户端，你将为包含的窗口分配尺寸和标题。
+                    打开文件
+                    <Path>app/desktopApp/src/.../main.kt</Path>
+                    并通过更改 <code>title</code> 和设置 <code>state</code> 属性来修改代码：
+                </p>
+                <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import androidx.compose.ui.unit.DpSize&#10;import androidx.compose.ui.unit.dp&#10;import androidx.compose.ui.window.Window&#10;import androidx.compose.ui.window.WindowPosition&#10;import androidx.compose.ui.window.WindowState&#10;import androidx.compose.ui.window.application&#10;&#10;fun main() = application {&#10;    val state = WindowState(&#10;        size = DpSize(400.dp, 600.dp),&#10;        position = WindowPosition(200.dp, 100.dp)&#10;    )&#10;    Window(&#10;        title = &quot;Task Manager (Desktop)&quot;,&#10;        state = state,&#10;        onCloseRequest = ::exitApplication,&#10;    ) {&#10;        App()&#10;    }&#10;}"/>
+            </step>
+            <step>
+                <p>
+                    使用 <ui-path>app [hot] 🔥</ui-path> 运行配置运行桌面端应用程序：
+                    <img style="block" src="full_stack_development_tutorial_run_desktop_resized.png"
+                         alt="在桌面端运行的应用" width="400" border-effect="rounded"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    使用以下运行配置之一运行 Web 客户端：
+                </p>
+                <list>
+                    <li>
+                        <ui-path>app [js]</ui-path>：运行你的 Kotlin/JS 应用程序。
+                    </li>
+                    <li>
+                        <ui-path>app [wasmJs]</ui-path>：运行你的 Kotlin/Wasm 应用程序。
+                    </li>
+                </list>
+                <img style="block" src="full_stack_development_tutorial_run_web.png"
+                     alt="在 Web 端运行的应用" width="400" border-effect="rounded"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="美化 UI" id="improve-ui">
+        <p>
+            现在客户端正在与服务器通信，但其 UI 显然不够吸引人。
+        </p>
+        <procedure id="improve-ui-procedure">
+            <step>
+                <p>
+                    打开位于
+                    <Path>app/shared/src/commonMain/.../ktor</Path>
+                    的
+                    <Path>App.kt</Path>
+                    文件，并使用下面的 <code>App</code> 和 <code>TaskCard</code> 可组合项替换现有的 <code>App</code>：
+                </p>
+                <code-block lang="kotlin" collapsed-title-line-number="31" collapsible="true" code="package com.example.ktor&#10;&#10;import com.example.ktor.network.TaskApi&#10;import com.example.ktor.model.Priority&#10;import com.example.ktor.model.Task&#10;import androidx.compose.foundation.layout.Column&#10;import androidx.compose.foundation.layout.Row&#10;import androidx.compose.foundation.layout.Spacer&#10;import androidx.compose.foundation.layout.fillMaxSize&#10;import androidx.compose.foundation.layout.fillMaxWidth&#10;import androidx.compose.foundation.layout.padding&#10;import androidx.compose.foundation.layout.safeContentPadding&#10;import androidx.compose.foundation.layout.width&#10;import androidx.compose.foundation.lazy.LazyColumn&#10;import androidx.compose.foundation.lazy.items&#10;import androidx.compose.foundation.shape.CornerSize&#10;import androidx.compose.foundation.shape.RoundedCornerShape&#10;import androidx.compose.material3.Card&#10;import androidx.compose.material3.MaterialTheme&#10;import androidx.compose.material3.OutlinedButton&#10;import androidx.compose.material3.Text&#10;import androidx.compose.runtime.*&#10;import androidx.compose.ui.Modifier&#10;import androidx.compose.ui.text.font.FontWeight&#10;import androidx.compose.ui.unit.dp&#10;import androidx.compose.ui.unit.sp&#10;import com.example.ktor.network.createHttpClient&#10;import kotlinx.coroutines.launch&#10;&#10;@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        var tasks by remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;&#10;        LaunchedEffect(Unit) {&#10;            tasks = taskApi.getAllTasks()&#10;        }&#10;&#10;        LazyColumn(&#10;            modifier = Modifier&#10;                .safeContentPadding()&#10;                .fillMaxSize()&#10;        ) {&#10;            items(tasks) { task -&gt;&#10;                TaskCard(&#10;                    task,&#10;                    onDelete = {&#10;                        scope.launch {&#10;                            taskApi.removeTask(it)&#10;                            tasks = taskApi.getAllTasks()&#10;                        }&#10;                    },&#10;                    onUpdate = {&#10;                    }&#10;                )&#10;            }&#10;        }&#10;    }&#10;}&#10;&#10;@Composable&#10;fun TaskCard(&#10;    task: Task,&#10;    onDelete: (Task) -&gt; Unit,&#10;    onUpdate: (Task) -&gt; Unit&#10;) {&#10;    fun pickWeight(priority: Priority) = when (priority) {&#10;        Priority.Low -&gt; FontWeight.SemiBold&#10;        Priority.Medium -&gt; FontWeight.Bold&#10;        Priority.High, Priority.Vital -&gt; FontWeight.ExtraBold&#10;    }&#10;&#10;    Card(&#10;        modifier = Modifier.fillMaxWidth().padding(4.dp),&#10;        shape = RoundedCornerShape(CornerSize(4.dp))&#10;    ) {&#10;        Column(modifier = Modifier.padding(10.dp)) {&#10;            Text(&#10;                &quot;${task.name}: ${task.description}&quot;,&#10;                fontSize = 20.sp,&#10;                fontWeight = pickWeight(task.priority)&#10;            )&#10;&#10;            Row {&#10;                OutlinedButton(onClick = { onDelete(task) }) {&#10;                    Text(&quot;Delete&quot;)&#10;                }&#10;                Spacer(Modifier.width(8.dp))&#10;                OutlinedButton(onClick = { onUpdate(task) }) {&#10;                    Text(&quot;Update&quot;)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    通过这一实现，你的客户端现在已经具备了一些基本功能。
+                </p>
+                <p>
+                    通过使用 <code>LaunchedEffect</code> 类型，所有任务都会在启动时加载，而 <code>LazyColumn</code> 可组合项允许用户滚动浏览任务。
+                </p>
+                <p>
+                    最后，创建了一个独立的 <code>TaskCard</code> 可组合项，它反过来使用 <code>Card</code> 来显示每个 <code>Task</code> 的详细信息。添加了用于删除和更新任务的按钮。
+                </p>
+            </step>
+            <step>
+                <p>
+                    重新运行客户端应用程序——例如 Android 应用。
+                    你现在可以滚动浏览任务、查看其详细信息并删除它们：
+                    <img style="block" src="full_stack_development_tutorial_improved_ui.gif"
+                         alt="具有改进 UI 的 Android 应用" width="350" border-effect="rounded"/>
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="添加更新功能" id="add-update-functionality">
+        <p>
+            为了完善客户端，加入允许更新任务详细信息的功能。
+        </p>
+        <procedure id="add-update-func-procedure">
+            <step>
+                导航至
+                <Path>app/shared/src/commonMain/.../ktor</Path>
+                中的
+                <Path>App.kt</Path>
+                文件。
+            </step>
+            <step>
+                <p>
+                    添加 <code>UpdateTaskDialog</code> 可组合项和必要的导入，如下所示：
+                </p>
+                <code-block lang="kotlin" code="import androidx.compose.material3.TextField&#10;import androidx.compose.material3.TextFieldDefaults&#10;import androidx.compose.ui.graphics.Color&#10;import androidx.compose.ui.window.Dialog&#10;&#10;@Composable&#10;fun UpdateTaskDialog(&#10;    task: Task,&#10;    onConfirm: (Task) -&gt; Unit&#10;) {&#10;    var description by remember { mutableStateOf(task.description) }&#10;    var priorityText by remember { mutableStateOf(task.priority.toString()) }&#10;    val colors = TextFieldDefaults.colors(&#10;        focusedTextColor = Color.Blue,&#10;        focusedContainerColor = Color.White,&#10;    )&#10;&#10;    Dialog(onDismissRequest = {}) {&#10;        Card(&#10;            modifier = Modifier.fillMaxWidth().padding(4.dp),&#10;            shape = RoundedCornerShape(CornerSize(4.dp))&#10;        ) {&#10;            Column(modifier = Modifier.padding(10.dp)) {&#10;                Text(&quot;Update ${task.name}&quot;, fontSize = 20.sp)&#10;                TextField(&#10;                    value = description,&#10;                    onValueChange = { description = it },&#10;                    label = { Text(&quot;Description&quot;) },&#10;                    colors = colors&#10;                )&#10;                TextField(&#10;                    value = priorityText,&#10;                    onValueChange = { priorityText = it },&#10;                    label = { Text(&quot;Priority&quot;) },&#10;                    colors = colors&#10;                )&#10;                OutlinedButton(onClick = {&#10;                    val newTask = Task(&#10;                        task.name,&#10;                        description,&#10;                        try {&#10;                            Priority.valueOf(priorityText)&#10;                        } catch (e: IllegalArgumentException) {&#10;                            Priority.Low&#10;                        }&#10;                    )&#10;                    onConfirm(newTask)&#10;                }) {&#10;                    Text(&quot;Update&quot;)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    这是一个使用对话框显示 <code>Task</code> 详细信息的可组合项。<code>description</code> 和 <code>priority</code> 被放置在 <code>TextField</code> 可组合项中，以便它们可以被更新。当用户按下更新按钮时，它会触发 <code>onConfirm()</code> 回调。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在同一个文件中更新 <code>App</code> 可组合项：
+                </p>
+                <code-block lang="kotlin" code="@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        var tasks by remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;        var currentTask by remember { mutableStateOf&lt;Task?&gt;(null) }&#10;&#10;        LaunchedEffect(Unit) {&#10;            tasks = taskApi.getAllTasks()&#10;        }&#10;&#10;        if (currentTask != null) {&#10;            UpdateTaskDialog(&#10;                currentTask!!,&#10;                onConfirm = {&#10;                    scope.launch {&#10;                        taskApi.updateTask(it)&#10;                        tasks = taskApi.getAllTasks()&#10;                    }&#10;                    currentTask = null&#10;                }&#10;            )&#10;        }&#10;&#10;        LazyColumn(modifier = Modifier&#10;            .safeContentPadding()&#10;            .fillMaxSize()&#10;        ) {&#10;            items(tasks) { task -&gt;&#10;                TaskCard(&#10;                    task,&#10;                    onDelete = {&#10;                        scope.launch {&#10;                            taskApi.removeTask(it)&#10;                            tasks = taskApi.getAllTasks()&#10;                        }&#10;                    },&#10;                    onUpdate = {&#10;                        currentTask = task&#10;                    }&#10;                )&#10;            }&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    你正在存储一个额外的状态片段，即当前选定的任务。如果该值不为 null，那么我们就调用 <code>UpdateTaskDialog</code> 可组合项，并将 <code>onConfirm()</code> 回调设置为使用 <code>TaskApi</code> 向服务器发送 POST 请求。
+                </p>
+                <p>
+                    最后，在创建 <code>TaskCard</code> 可组合项时，你使用 <code>onUpdate()</code> 回调来设置 <code>currentTask</code> 状态变量。
+                </p>
+            </step>
+            <step>
+                重新运行客户端应用程序。你现在应该能够使用这些按钮更新每个任务的详细信息。
+                <img style="block" src="full_stack_development_tutorial_update_task.gif"
+                     alt="在 Android 上删除任务" width="350" border-effect="rounded"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="后续步骤" id="next-steps">
+        <p>
+            在本文中，你已在 Kotlin Multiplatform 应用程序的环境中使用了 Ktor。你现在可以创建一个包含多个服务和客户端的项目，目标平台涵盖一系列不同的平台。
+        </p>
+        <p>
+            如你所见，构建功能而不产生任何代码重复或冗余是可能的。项目各层所需的类型可以放置在
+            <Path>core</Path>
+            多平台模块中。仅由服务需要的功能放置在
+            <Path>server</Path>
+            模块中，而仅由客户端需要的功能则放置在
+            <Path>app</Path>
+            模块中。
+        </p>
+        <p>
+            这种开发方式不可避免地需要客户端和服务器端技术的知识。但你可以使用 <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">Kotlin Multiplatform</a> 库和 <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a> 来最大限度地减少你需要学习的新材料。即使你的重点最初只在单一平台上，你也可以随着对应用程序需求的增长轻松添加其他平台。
+        </p>
+    </chapter>
+</topic>

--- a/docs/ktor/migration-from-express-js.md
+++ b/docs/ktor/migration-from-express-js.md
@@ -16,110 +16,102 @@
 </p>
 <chapter title="生成应用" id="generate">
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     你可以使用 <code>express-generator</code> 工具生成一个新的 Express 应用程序：
                 </p>
-                <code-block lang="shell" code="                        npx express-generator"/>
-            </td>
+<code-block lang="shell" code="                        npx express-generator"/>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor 提供了以下方式来生成应用程序骨架：
                 </p>
-                <list>
-                    <li>
-                        <p>
-                            <a href="https://start.ktor.io/">Ktor 项目生成器</a> — 使用基于 Web 的生成器。
+<list>
+<li>
+<p>
+<a href="https://start.ktor.io/">Ktor 项目生成器</a> — 使用基于 Web 的生成器。
                         </p>
-                    </li>
-                    <li>
-                        <p>
-                            <a href="https://github.com/ktorio/ktor-cli">
+</li>
+<li>
+<p>
+<a href="https://github.com/ktorio/ktor-cli">
                                 Ktor 命令行工具
                             </a> — 通过命令行界面使用 <code>ktor new</code> 命令生成 Ktor 项目：
                         </p>
-                        <code-block lang="shell" code="                                ktor new ktor-sample"/>
-                    </li>
-                    <li>
-                        <p>
-                            <a href="https://www.npmjs.com/package/generator-ktor">
+<code-block lang="shell" code="                                ktor new ktor-sample"/>
+</li>
+<li>
+<p>
+<a href="https://www.npmjs.com/package/generator-ktor">
                                 Yeoman 生成器
                             </a>
                             — 以交互方式配置项目设置并选择所需的插件：
                         </p>
-                        <code-block lang="shell" code="                                yo ktor"/>
-                    </li>
-                    <li>
-                        <p>
-                            <a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 使用内置的 Ktor 项目向导。
+<code-block lang="shell" code="                                yo ktor"/>
+</li>
+<li>
+<p>
+<a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 使用内置的 Ktor 项目向导。
                         </p>
-                    </li>
-                </list>
-                <p>
+</li>
+</list>
+<p>
                     有关详细说明，请参阅 <Links href="//server-create-a-new-project" summary="了解如何使用 Ktor 打开、运行和测试服务器应用程序。">创建、打开并运行新的 Ktor 项目</Links> 教程。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="Hello world" id="hello">
     <p>
         在本节中，我们将了解如何创建最简单的服务器应用程序，该程序接受 <code>GET</code> 请求并响应预定义的纯文本。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     下面的示例展示了启动服务器并侦听端口 <control>3000</control> 连接的 Express 应用程序。
                 </p>
-                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     在 Ktor 中，你可以使用 <a href="#embedded-server">embeddedServer</a> 函数在代码中配置服务器参数并快速运行应用程序。
                 </p>
-                <code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
-                <p>
+<code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a>
                     项目。
                 </p>
-                <p>
+<p>
                     你还可以在使用 HOCON 或 YAML 格式的 <a href="#engine-main">外部配置文件</a> 中指定服务器设置。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         请注意，上述 Express 应用程序添加了 <control>Date</control>、<control>X-Powered-By</control> 和 <control>ETag</control> 响应头，其内容可能如下所示：
     </p>
@@ -134,43 +126,39 @@
     </p>
     <code-block code="            public&#10;            ├── index.html&#10;            ├── ktor_logo.png&#10;            ├── css&#10;            │   └──styles.css&#10;            └── js&#10;                └── script.js"/>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     在 Express 中，将文件夹名称传递给 <code>express.static</code> 函数。
                 </p>
-                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     在 Ktor 中，使用 <a href="#folders"><code>staticFiles()</code></a> 函数将对 <Path>/</Path> 路径发出的任何请求映射到 <Path>public</Path> 物理文件夹。此函数可以递归地提供 <Path>public</Path> 文件夹中的所有文件。
                 </p>
-                <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
-                <p>
+<code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
+<p>
                     有关完整示例，请参阅 <a
                         href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         提供静态内容时，Express 会添加多个响应头，如下所示：
     </p>
@@ -207,138 +195,126 @@
         <Links href="//server-routing" summary="路由是服务器应用程序中处理传入请求的核心插件。">路由</Links> 允许处理发送到特定端点的传入请求，该端点由特定的 HTTP 请求方法（<code>GET</code>、<code>POST</code> 等）和路径定义。下面的示例展示了如何处理发送到 <Path>/</Path> 路径的 <code>GET</code> 和 <code>POST</code> 请求。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
-                <tip>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
+<tip>
+<p>
                         请参阅 <a href="#receive-request">接收请求</a>，了解如何接收 <code>POST</code>、<code>PUT</code> 或 <code>PATCH</code> 请求的请求体。
                     </p>
-                </tip>
-                <p>
+</tip>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         以下示例演示了如何按路径对路由处理程序进行分组。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     在 Express 中，你可以使用 <code>app.route()</code> 为路由路径创建可链式调用的路由处理程序。
                 </p>
-                <code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
-                <p>
+<code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor 提供了一个 <code>route</code> 函数，通过该函数你可以定义路径，然后将该路径的动作（动词）作为嵌套函数放置。
                 </p>
-                <code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
-                <p>
+<code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         这两个框架都允许你在单个文件中对相关路由进行分组。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     Express 提供了 <code>express.Router</code> 类来创建可挂载的路由处理程序。假设在应用程序目录中有一个 <Path>birds.js</Path> 路由文件。这个路由模块可以像 <Path>app.js</Path> 中所示的那样加载到应用程序中：
                 </p>
-                <Tabs>
-                    <TabItem title="birds.js">
-                        <code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
-                    </TabItem>
-                    <TabItem title="app.js">
-                        <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                    </TabItem>
-                </Tabs>
-                <p>
+<Tabs>
+<TabItem title="birds.js">
+<code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
+</TabItem>
+<TabItem title="app.js">
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+</TabItem>
+</Tabs>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     在 Ktor 中，一种常见的模式是在 <code>Routing</code> 类型上使用扩展函数来定义实际路由。下面的示例（<Path>Birds.kt</Path>）定义了 <code>birdsRoutes</code> 扩展函数。通过在 <code>routing</code> 块内调用此函数，你可以在应用程序（<Path>Application.kt</Path>）中包含相应的路由：
                 </p>
-                <Tabs>
-                    <TabItem title="Birds.kt" id="birds-kt">
-                        <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
-                    </TabItem>
-                    <TabItem title="Application.kt" id="application-kt">
-                        <code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
-                    </TabItem>
-                </Tabs>
-                <p>
+<Tabs>
+<TabItem title="Birds.kt" id="birds-kt">
+<code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
+</TabItem>
+<TabItem title="Application.kt" id="application-kt">
+<code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
+</TabItem>
+</Tabs>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         除了将 URL 路径指定为字符串外，Ktor 还包含实现 <Links href="//server-resources" summary="Resources 插件允许你实现类型安全路由。">类型安全路由</Links> 的功能。
     </p>
@@ -351,84 +327,76 @@
         路由（或路径）参数是命名的 URL 段，用于捕获 URL 中其所在位置指定的值。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     要在 Express 中访问路由参数，你可以使用 <code>Request.params</code>。例如，对于 <Path>/user/admin</Path> 路径，下面代码片段中的 <code>req.parameters["login"]</code> 将返回 <emphasis>admin</emphasis>：
                 </p>
-                <code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
-                <p>
+<code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     在 Ktor 中，路由参数使用 <code>{param}</code> 语法定义。你可以在路由处理程序中使用 <code>call.parameters</code> 来访问路由参数：
                 </p>
-                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
-                <p>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         下表比较了如何访问查询字符串的参数。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     要在 Express 中访问路由参数，你可以使用 <code>Request.params</code>。例如，对于 <Path>/user/admin</Path> 路径，下面代码片段中的 <code>req.parameters["login"]</code> 将返回 <emphasis>admin</emphasis>：
                 </p>
-                <code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
-                <p>
+<code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     在 Ktor 中，路由参数使用 <code>{param}</code> 语法定义。你可以在路由处理程序中使用 <code>call.parameters</code> 来访问路由参数：
                 </p>
-                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
-                <p>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="发送响应" id="send-response">
     <p>
@@ -436,174 +404,158 @@
     </p>
     <chapter title="JSON" id="send-json">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中发送具有适当内容类型的 JSON 响应，请调用 <code>res.json</code> 函数：
                     </p>
-                    <code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，你需要安装 <Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">ContentNegotiation</Links> 插件并配置 JSON 序列化程序：
                     </p>
-                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
-                    <p>
+<code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
+<p>
                         要将数据序列化为 JSON，你需要创建一个带有 <code>@Serializable</code> 注解的数据类：
                     </p>
-                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
-                    <p>
+<code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+<p>
                         然后，你可以使用 <code>call.respond</code> 在响应中发送该类的对象：
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="文件" id="send-file">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中响应一个文件，请使用 <code>res.sendFile</code>：
                     </p>
-                    <code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor 提供了 <code>call.respondFile</code> 函数用于向客户端发送文件：
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
         <p>
             Express 应用程序在响应文件时会添加 <control>Accept-Ranges</control> HTTP 响应头。服务器使用此标头向客户端宣告其支持文件下载的部分请求。在 Ktor 中，你需要安装 <Links href="//server-partial-content" summary="所需依赖项：io.ktor:%artifact_name% 服务器示例：download-file，客户端示例：client-download-file-range">PartialContent</Links> 插件来支持部分请求。
         </p>
     </chapter>
     <chapter title="文件附件" id="send-file-attachment">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
-                        <code>res.download</code> 函数将指定文件作为附件传输：
+<control>Express</control>
+</td>
+<td>
+<p>
+<code>res.download</code> 函数将指定文件作为附件传输：
                     </p>
-                    <code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，你需要手动配置 <control>Content-Disposition</control> 标头以将文件作为附件传输：
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="重定向" id="redirect">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中生成重定向响应，请调用 <code>redirect</code> 函数：
                     </p>
-                    <code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，使用 <code>respondRedirect</code> 发送重定向响应：
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
 </chapter>
 <chapter title="模板" id="templates">
@@ -611,47 +563,43 @@
         Express 和 Ktor 都允许配合模板引擎来处理视图。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     假设我们在 <Path>views</Path> 文件夹中具有以下 Pug 模板：
                 </p>
-                <code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
-                <p>
+<code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
+<p>
                     要响应此模板，请调用 <code>res.render</code>：
                 </p>
-                <code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
-                <p>
+<code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor 支持多种 <Links href="//server-templating" summary="了解如何使用通过 HTML/CSS 或 JVM 模板引擎构建的视图。">JVM 模板引擎</Links>，例如 FreeMarker、Velocity 等。例如，如果你需要响应放置在应用程序资源中的 FreeMarker 模板，请安装并配置 <code>FreeMarker</code> 插件，然后使用 <code>call.respond</code> 发送模板：
                 </p>
-                <code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
-                <p>
+<code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="接收请求" id="receive-request">
     <p>
@@ -666,47 +614,43 @@
             让我们看看如何在服务器端以纯文本形式接收此请求的请求体。
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中解析传入的请求体，你需要添加 <code>body-parser</code>：
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
+<p>
                         在 <code>post</code> 处理程序中，你需要传递文本解析器（<code>bodyParser.text</code>）。请求体将在 <code>req.body</code> 属性下可用：
                     </p>
-                    <code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，你可以使用 <code>call.receiveText</code> 以文本形式接收请求体：
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="JSON" id="receive-json">
         <p>
@@ -714,51 +658,47 @@
         </p>
         <code-block lang="http" code="POST http://0.0.0.0:3000/json&#10;Content-Type: application/json&#10;&#10;{&#10;  &quot;type&quot;: &quot;Fiat&quot;,&#10;  &quot;model&quot; : &quot;500&quot;,&#10;  &quot;color&quot;: &quot;white&quot;&#10;}"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中接收 JSON，请使用 <code>bodyParser.json</code>：
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，你需要安装 <Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">ContentNegotiation</Links> 插件并配置 <code>Json</code> 序列化程序：
                     </p>
-                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
-                    <p>
+<code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
+<p>
                         要将接收到的数据反序列化为对象，你需要创建一个数据类：
                     </p>
-                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
-                    <p>
+<code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+<p>
                         然后，使用接受此数据类作为参数的 <code>receive</code> 方法：
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="URL 编码" id="receive-url-encoded">
         <p>
@@ -766,43 +706,39 @@
         </p>
         <code-block lang="http" code="POST http://localhost:3000/urlencoded&#10;Content-Type: application/x-www-form-urlencoded&#10;&#10;username=JetBrains&amp;email=example@jetbrains.com&amp;password=foobar&amp;confirmation=foobar"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         与纯文本和 JSON 一样，Express 需要 <code>body-parser</code>。你需要将解析器类型设置为 <code>bodyParser.urlencoded</code>：
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，请使用 <code>call.receiveParameters</code> 函数：
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="原始数据" id="receive-raw-data">
         <p>
@@ -810,44 +746,40 @@
         </p>
         <code-block lang="http" code="POST http://localhost:3000/raw&#10;Content-Type: application/octet-stream&#10;&#10;&lt; ./ktor_logo.png"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中处理二进制数据，请将解析器类型设置为 <code>raw</code>：
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor 提供了 <code>ByteReadChannel</code> 和 <code>ByteWriteChannel</code> 用于异步读/写字节序列：
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive
                             request</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-    </table>
+</table>
     </chapter>
     <chapter title="多部分 (Multipart)" id="receive-multipart">
         <p>
@@ -855,43 +787,39 @@
         </p>
         <code-block lang="http" code="POST http://localhost:3000/multipart&#10;Content-Type: multipart/form-data; boundary=WebAppBoundary&#10;&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;description&quot;&#10;Content-Type: text/plain&#10;&#10;Ktor logo&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;image&quot;; filename=&quot;ktor_logo.png&quot;&#10;Content-Type: image/png&#10;&#10;&lt; ./ktor_logo.png&#10;--WebAppBoundary--"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express 需要一个单独的模块来解析多部分数据。在下面的示例中，使用了 <control>multer</control> 将文件上传到服务器：
                     </p>
-                    <code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，如果你需要接收作为多部分请求一部分发送的文件，请调用 <code>receiveMultipart</code> 函数，然后根据需要遍历每个部分。在下面的示例中，<code>PartData.FileItem</code> 用于以字节流的形式接收文件：
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
+<p>
                         有关完整示例，请参阅
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         项目。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
 </chapter>
 <chapter title="创建中间件" id="middleware">
@@ -899,43 +827,39 @@
         我们要看的最后一件事是如何创建允许你扩展服务器功能的中间件。下面的示例展示了如何使用 Express 和 Ktor 实现请求日志记录。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     在 Express 中，中间件是使用 <code>app.use</code> 绑定到应用程序的函数：
                 </p>
-                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
-                <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor 允许你使用 <Links href="//server-custom-plugins" summary="了解如何创建你自己的自定义插件。">自定义插件</Links> 来扩展其功能。下面的代码示例展示了如何处理 <code>onCall</code> 来实现请求日志记录：
                 </p>
-                <code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
-                <p>
+<code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
+<p>
                     有关完整示例，请参阅
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a>
                     项目。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="后续步骤" id="next">
     <p>

--- a/docs/ktor/migration-from-express-js.md
+++ b/docs/ktor/migration-from-express-js.md
@@ -1,0 +1,945 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="从 Express 迁移到 Ktor"
+       id="migration-from-express-js" help-id="express-js;migrating-from-express-js">
+<show-structure for="chapter" depth="2"/>
+<link-summary>本指南介绍了如何创建、运行和测试一个简单的 Ktor 应用程序。</link-summary>
+<tldr>
+    <p>
+        <b>代码示例</b>：
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express">migrating-express</a>
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor">migrating-express-ktor</a>
+    </p>
+</tldr>
+<p>
+    在本指南中，我们将了解在基本场景下如何将 Express 应用程序迁移到 Ktor：从生成应用程序和编写第一个应用程序，到创建用于扩展应用程序功能的中间件。
+</p>
+<chapter title="生成应用" id="generate">
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    你可以使用 <code>express-generator</code> 工具生成一个新的 Express 应用程序：
+                </p>
+                <code-block lang="shell" code="                        npx express-generator"/>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor 提供了以下方式来生成应用程序骨架：
+                </p>
+                <list>
+                    <li>
+                        <p>
+                            <a href="https://start.ktor.io/">Ktor 项目生成器</a> — 使用基于 Web 的生成器。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <a href="https://github.com/ktorio/ktor-cli">
+                                Ktor 命令行工具
+                            </a> — 通过命令行界面使用 <code>ktor new</code> 命令生成 Ktor 项目：
+                        </p>
+                        <code-block lang="shell" code="                                ktor new ktor-sample"/>
+                    </li>
+                    <li>
+                        <p>
+                            <a href="https://www.npmjs.com/package/generator-ktor">
+                                Yeoman 生成器
+                            </a>
+                            — 以交互方式配置项目设置并选择所需的插件：
+                        </p>
+                        <code-block lang="shell" code="                                yo ktor"/>
+                    </li>
+                    <li>
+                        <p>
+                            <a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 使用内置的 Ktor 项目向导。
+                        </p>
+                    </li>
+                </list>
+                <p>
+                    有关详细说明，请参阅 <Links href="//server-create-a-new-project" summary="了解如何使用 Ktor 打开、运行和测试服务器应用程序。">创建、打开并运行新的 Ktor 项目</Links> 教程。
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="Hello world" id="hello">
+    <p>
+        在本节中，我们将了解如何创建最简单的服务器应用程序，该程序接受 <code>GET</code> 请求并响应预定义的纯文本。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    下面的示例展示了启动服务器并侦听端口 <control>3000</control> 连接的 Express 应用程序。
+                </p>
+                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    在 Ktor 中，你可以使用 <a href="#embedded-server">embeddedServer</a> 函数在代码中配置服务器参数并快速运行应用程序。
+                </p>
+                <code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a>
+                    项目。
+                </p>
+                <p>
+                    你还可以在使用 HOCON 或 YAML 格式的 <a href="#engine-main">外部配置文件</a> 中指定服务器设置。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        请注意，上述 Express 应用程序添加了 <control>Date</control>、<control>X-Powered-By</control> 和 <control>ETag</control> 响应头，其内容可能如下所示：
+    </p>
+    <code-block code="            Date: Fri, 05 Aug 2022 06:30:48 GMT&#10;            X-Powered-By: Express&#10;            ETag: W/&quot;c-Lve95gjOVATpfV8EL5X4nxwjKHE&quot;"/>
+    <p>
+        要在 Ktor 的每个响应中添加默认的 <control>Server</control> 和 <control>Date</control> 标头，你需要安装 <Links href="//server-default-headers" summary="所需依赖项：io.ktor:%artifact_name%">DefaultHeaders</Links> 插件。<Links href="//server-conditional-headers" summary="所需依赖项：io.ktor:%artifact_name%">ConditionalHeaders</Links> 插件可用于配置 <control>Etag</control> 响应头。
+    </p>
+</chapter>
+<chapter title="提供静态内容" id="static">
+    <p>
+        在本节中，我们将了解如何在 Express 和 Ktor 中提供静态文件，例如图像、CSS 文件和 JavaScript 文件。假设我们有一个包含主 <Path>index.html</Path> 页面和一组链接资产的 <Path>public</Path> 文件夹。
+    </p>
+    <code-block code="            public&#10;            ├── index.html&#10;            ├── ktor_logo.png&#10;            ├── css&#10;            │   └──styles.css&#10;            └── js&#10;                └── script.js"/>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    在 Express 中，将文件夹名称传递给 <code>express.static</code> 函数。
+                </p>
+                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    在 Ktor 中，使用 <a href="#folders"><code>staticFiles()</code></a> 函数将对 <Path>/</Path> 路径发出的任何请求映射到 <Path>public</Path> 物理文件夹。此函数可以递归地提供 <Path>public</Path> 文件夹中的所有文件。
+                </p>
+                <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
+                <p>
+                    有关完整示例，请参阅 <a
+                        href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        提供静态内容时，Express 会添加多个响应头，如下所示：
+    </p>
+    <code-block code="            Accept-Ranges: bytes&#10;            Cache-Control: public, max-age=0&#10;            ETag: W/&quot;181-1823feafeb1&quot;&#10;            Last-Modified: Wed, 27 Jul 2022 13:49:01 GMT"/>
+    <p>
+        要在 Ktor 中管理这些标头，你需要安装以下插件：
+    </p>
+    <list>
+        <li>
+            <p>
+                <control>Accept-Ranges</control>
+                ：<Links href="//server-partial-content" summary="所需依赖项：io.ktor:%artifact_name% 服务器示例：download-file，客户端示例：client-download-file-range">PartialContent</Links>
+            </p>
+        </li>
+        <li>
+            <p>
+                <control>Cache-Control</control>
+                ：<Links href="//server-caching-headers" summary="所需依赖项：io.ktor:%artifact_name%">CachingHeaders</Links>
+            </p>
+        </li>
+        <li>
+            <p>
+                <control>ETag</control>
+                和
+                <control>Last-Modified</control>
+                ：
+                <Links href="//server-conditional-headers" summary="所需依赖项：io.ktor:%artifact_name%">ConditionalHeaders</Links>
+            </p>
+        </li>
+    </list>
+</chapter>
+<chapter title="路由" id="routing">
+    <p>
+        <Links href="//server-routing" summary="路由是服务器应用程序中处理传入请求的核心插件。">路由</Links> 允许处理发送到特定端点的传入请求，该端点由特定的 HTTP 请求方法（<code>GET</code>、<code>POST</code> 等）和路径定义。下面的示例展示了如何处理发送到 <Path>/</Path> 路径的 <code>GET</code> 和 <code>POST</code> 请求。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
+                <tip>
+                    <p>
+                        请参阅 <a href="#receive-request">接收请求</a>，了解如何接收 <code>POST</code>、<code>PUT</code> 或 <code>PATCH</code> 请求的请求体。
+                    </p>
+                </tip>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        以下示例演示了如何按路径对路由处理程序进行分组。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    在 Express 中，你可以使用 <code>app.route()</code> 为路由路径创建可链式调用的路由处理程序。
+                </p>
+                <code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor 提供了一个 <code>route</code> 函数，通过该函数你可以定义路径，然后将该路径的动作（动词）作为嵌套函数放置。
+                </p>
+                <code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        这两个框架都允许你在单个文件中对相关路由进行分组。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    Express 提供了 <code>express.Router</code> 类来创建可挂载的路由处理程序。假设在应用程序目录中有一个 <Path>birds.js</Path> 路由文件。这个路由模块可以像 <Path>app.js</Path> 中所示的那样加载到应用程序中：
+                </p>
+                <Tabs>
+                    <TabItem title="birds.js">
+                        <code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
+                    </TabItem>
+                    <TabItem title="app.js">
+                        <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    在 Ktor 中，一种常见的模式是在 <code>Routing</code> 类型上使用扩展函数来定义实际路由。下面的示例（<Path>Birds.kt</Path>）定义了 <code>birdsRoutes</code> 扩展函数。通过在 <code>routing</code> 块内调用此函数，你可以在应用程序（<Path>Application.kt</Path>）中包含相应的路由：
+                </p>
+                <Tabs>
+                    <TabItem title="Birds.kt" id="birds-kt">
+                        <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
+                    </TabItem>
+                    <TabItem title="Application.kt" id="application-kt">
+                        <code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        除了将 URL 路径指定为字符串外，Ktor 还包含实现 <Links href="//server-resources" summary="Resources 插件允许你实现类型安全路由。">类型安全路由</Links> 的功能。
+    </p>
+</chapter>
+<chapter title="路由参数与查询参数" id="route-query-param">
+    <p>
+        本节将展示如何访问路由参数和查询参数。
+    </p>
+    <p>
+        路由（或路径）参数是命名的 URL 段，用于捕获 URL 中其所在位置指定的值。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    要在 Express 中访问路由参数，你可以使用 <code>Request.params</code>。例如，对于 <Path>/user/admin</Path> 路径，下面代码片段中的 <code>req.parameters["login"]</code> 将返回 <emphasis>admin</emphasis>：
+                </p>
+                <code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    在 Ktor 中，路由参数使用 <code>{param}</code> 语法定义。你可以在路由处理程序中使用 <code>call.parameters</code> 来访问路由参数：
+                </p>
+                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        下表比较了如何访问查询字符串的参数。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    要在 Express 中访问路由参数，你可以使用 <code>Request.params</code>。例如，对于 <Path>/user/admin</Path> 路径，下面代码片段中的 <code>req.parameters["login"]</code> 将返回 <emphasis>admin</emphasis>：
+                </p>
+                <code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    在 Ktor 中，路由参数使用 <code>{param}</code> 语法定义。你可以在路由处理程序中使用 <code>call.parameters</code> 来访问路由参数：
+                </p>
+                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="发送响应" id="send-response">
+    <p>
+        在前面的章节中，我们已经了解了如何响应纯文本内容。下面让我们看看如何发送 JSON、文件和重定向响应。
+    </p>
+    <chapter title="JSON" id="send-json">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中发送具有适当内容类型的 JSON 响应，请调用 <code>res.json</code> 函数：
+                    </p>
+                    <code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，你需要安装 <Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">ContentNegotiation</Links> 插件并配置 JSON 序列化程序：
+                    </p>
+                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
+                    <p>
+                        要将数据序列化为 JSON，你需要创建一个带有 <code>@Serializable</code> 注解的数据类：
+                    </p>
+                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+                    <p>
+                        然后，你可以使用 <code>call.respond</code> 在响应中发送该类的对象：
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="文件" id="send-file">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中响应一个文件，请使用 <code>res.sendFile</code>：
+                    </p>
+                    <code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor 提供了 <code>call.respondFile</code> 函数用于向客户端发送文件：
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+        <p>
+            Express 应用程序在响应文件时会添加 <control>Accept-Ranges</control> HTTP 响应头。服务器使用此标头向客户端宣告其支持文件下载的部分请求。在 Ktor 中，你需要安装 <Links href="//server-partial-content" summary="所需依赖项：io.ktor:%artifact_name% 服务器示例：download-file，客户端示例：client-download-file-range">PartialContent</Links> 插件来支持部分请求。
+        </p>
+    </chapter>
+    <chapter title="文件附件" id="send-file-attachment">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        <code>res.download</code> 函数将指定文件作为附件传输：
+                    </p>
+                    <code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，你需要手动配置 <control>Content-Disposition</control> 标头以将文件作为附件传输：
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="重定向" id="redirect">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中生成重定向响应，请调用 <code>redirect</code> 函数：
+                    </p>
+                    <code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，使用 <code>respondRedirect</code> 发送重定向响应：
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+</chapter>
+<chapter title="模板" id="templates">
+    <p>
+        Express 和 Ktor 都允许配合模板引擎来处理视图。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    假设我们在 <Path>views</Path> 文件夹中具有以下 Pug 模板：
+                </p>
+                <code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
+                <p>
+                    要响应此模板，请调用 <code>res.render</code>：
+                </p>
+                <code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor 支持多种 <Links href="//server-templating" summary="了解如何使用通过 HTML/CSS 或 JVM 模板引擎构建的视图。">JVM 模板引擎</Links>，例如 FreeMarker、Velocity 等。例如，如果你需要响应放置在应用程序资源中的 FreeMarker 模板，请安装并配置 <code>FreeMarker</code> 插件，然后使用 <code>call.respond</code> 发送模板：
+                </p>
+                <code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="接收请求" id="receive-request">
+    <p>
+        本节将展示如何接收不同格式的请求体。
+    </p>
+    <chapter title="原始文本" id="receive-raw-text">
+        <p>
+            下面的 <code>POST</code> 请求向服务器发送文本数据：
+        </p>
+        <code-block lang="http" code="POST http://0.0.0.0:3000/text&#10;Content-Type: text/plain&#10;&#10;Hello, world!"/>
+        <p>
+            让我们看看如何在服务器端以纯文本形式接收此请求的请求体。
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中解析传入的请求体，你需要添加 <code>body-parser</code>：
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
+                    <p>
+                        在 <code>post</code> 处理程序中，你需要传递文本解析器（<code>bodyParser.text</code>）。请求体将在 <code>req.body</code> 属性下可用：
+                    </p>
+                    <code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，你可以使用 <code>call.receiveText</code> 以文本形式接收请求体：
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="JSON" id="receive-json">
+        <p>
+            在本节中，我们将了解如何接收 JSON 请求体。下面的示例展示了一个请求体中包含 JSON 对象的 <code>POST</code> 请求：
+        </p>
+        <code-block lang="http" code="POST http://0.0.0.0:3000/json&#10;Content-Type: application/json&#10;&#10;{&#10;  &quot;type&quot;: &quot;Fiat&quot;,&#10;  &quot;model&quot; : &quot;500&quot;,&#10;  &quot;color&quot;: &quot;white&quot;&#10;}"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中接收 JSON，请使用 <code>bodyParser.json</code>：
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，你需要安装 <Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">ContentNegotiation</Links> 插件并配置 <code>Json</code> 序列化程序：
+                    </p>
+                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
+                    <p>
+                        要将接收到的数据反序列化为对象，你需要创建一个数据类：
+                    </p>
+                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+                    <p>
+                        然后，使用接受此数据类作为参数的 <code>receive</code> 方法：
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="URL 编码" id="receive-url-encoded">
+        <p>
+            现在让我们看看如何接收使用 <control>application/x-www-form-urlencoded</control> 类型发送的表单数据。下面的代码片段展示了一个包含表单数据的 <code>POST</code> 请求示例：
+        </p>
+        <code-block lang="http" code="POST http://localhost:3000/urlencoded&#10;Content-Type: application/x-www-form-urlencoded&#10;&#10;username=JetBrains&amp;email=example@jetbrains.com&amp;password=foobar&amp;confirmation=foobar"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        与纯文本和 JSON 一样，Express 需要 <code>body-parser</code>。你需要将解析器类型设置为 <code>bodyParser.urlencoded</code>：
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，请使用 <code>call.receiveParameters</code> 函数：
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="原始数据" id="receive-raw-data">
+        <p>
+            下一个用例是处理二进制数据。下面的请求向服务器发送一个类型为 <control>application/octet-stream</control> 的 PNG 图像：
+        </p>
+        <code-block lang="http" code="POST http://localhost:3000/raw&#10;Content-Type: application/octet-stream&#10;&#10;&lt; ./ktor_logo.png"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中处理二进制数据，请将解析器类型设置为 <code>raw</code>：
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor 提供了 <code>ByteReadChannel</code> 和 <code>ByteWriteChannel</code> 用于异步读/写字节序列：
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive
+                            request</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+    </table>
+    </chapter>
+    <chapter title="多部分 (Multipart)" id="receive-multipart">
+        <p>
+            在最后一部分，让我们看看如何处理 <emphasis>多部分 (multipart)</emphasis> 请求体。下面的 <code>POST</code> 请求使用 <control>multipart/form-data</control> 类型发送带有描述的 PNG 图像：
+        </p>
+        <code-block lang="http" code="POST http://localhost:3000/multipart&#10;Content-Type: multipart/form-data; boundary=WebAppBoundary&#10;&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;description&quot;&#10;Content-Type: text/plain&#10;&#10;Ktor logo&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;image&quot;; filename=&quot;ktor_logo.png&quot;&#10;Content-Type: image/png&#10;&#10;&lt; ./ktor_logo.png&#10;--WebAppBoundary--"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express 需要一个单独的模块来解析多部分数据。在下面的示例中，使用了 <control>multer</control> 将文件上传到服务器：
+                    </p>
+                    <code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，如果你需要接收作为多部分请求一部分发送的文件，请调用 <code>receiveMultipart</code> 函数，然后根据需要遍历每个部分。在下面的示例中，<code>PartData.FileItem</code> 用于以字节流的形式接收文件：
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
+                    <p>
+                        有关完整示例，请参阅
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        项目。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+</chapter>
+<chapter title="创建中间件" id="middleware">
+    <p>
+        我们要看的最后一件事是如何创建允许你扩展服务器功能的中间件。下面的示例展示了如何使用 Express 和 Ktor 实现请求日志记录。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    在 Express 中，中间件是使用 <code>app.use</code> 绑定到应用程序的函数：
+                </p>
+                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor 允许你使用 <Links href="//server-custom-plugins" summary="了解如何创建你自己的自定义插件。">自定义插件</Links> 来扩展其功能。下面的代码示例展示了如何处理 <code>onCall</code> 来实现请求日志记录：
+                </p>
+                <code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a>
+                    项目。
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="后续步骤" id="next">
+    <p>
+        本指南中还有许多未涵盖的用例，例如会话管理、授权、数据库集成等。对于大多数这些功能，Ktor 提供了专用插件，可以将其安装在应用程序中并根据需要进行配置。要继续你的 Ktor 之旅，请访问 <control><a href="https://ktor.io/learn/">学习页面</a></control>，该页面提供了一系列分步指南和开箱即用的示例。
+    </p>
+</chapter>
+</topic>

--- a/docs/ktor/server-auto-reload.md
+++ b/docs/ktor/server-auto-reload.md
@@ -1,0 +1,195 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="自动重载 (Auto-reload)"
+       id="server-auto-reload" help-id="Auto_reload">
+    <tldr>
+        <p>
+            <b>代码示例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>，
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-embedded-server">autoreload-embedded-server</a>
+        </p>
+    </tldr>
+    <link-summary>
+        了解如何使用自动重载 (Auto-reload) 在代码更改时重载应用类。
+    </link-summary>
+    <p>
+        在开发过程中<Links href="//server-run" summary="了解如何运行服务器 Ktor 应用程序。">重新启动</Links>服务器可能需要一些时间。
+        Ktor 允许您通过使用<emphasis>自动重载 (Auto-reload)</emphasis>来克服这一限制，它可以在代码更改时重载应用类并提供快速的反馈循环。
+        要使用自动重载，请遵循以下步骤：
+    </p>
+    <list style="decimal">
+        <li>
+            <p>
+                <a href="#enable">启用开发模式</a>
+            </p>
+        </li>
+        <li>
+            <p>
+                （可选）<a href="#watch-paths">配置监视路径</a>
+            </p>
+        </li>
+        <li>
+            <p>
+                <a href="#recompile">启用更改时重新编译</a>
+            </p>
+        </li>
+    </list>
+    <chapter title="限制" id="limitations">
+        自动重载仅适用于特定的模块声明。下表显示了跨版本的支持情况：
+        <table>
+            
+<tr>
+<td>模块类型</td>
+                <td>&lt;= 3.2</td>
+                <td>&gt; 3.2</td>
+</tr>
+
+            
+<tr>
+<td>Lambda 初始值设定项</td>
+                <td>❌ 不支持</td>
+                <td>❌ 不支持</td>
+</tr>
+
+            
+<tr>
+<td>阻塞函数引用</td>
+                <td>✅ 支持</td>
+                <td>❌ 不支持</td>
+</tr>
+
+            
+<tr>
+<td>挂起函数引用</td>
+                <td>❌ 不支持</td>
+                <td>✅ 支持</td>
+</tr>
+
+            
+<tr>
+<td>配置引用</td>
+                <td>✅ 支持</td>
+                <td>✅ 支持</td>
+</tr>
+
+        </table>
+        <chapter title="支持" id="supported">
+            <code-block lang="kotlin" code="                // 挂起函数引用&#10;                embeddedServer(Netty, port = 8080, module = Application::mySuspendModule)&#10;&#10;                // 配置引用&#10;                ktor {&#10;                    application {&#10;                        modules = [ com.example.ApplicationKt.mySuspendModule ]&#10;                    }&#10;                }"/>
+        </chapter>
+        <chapter title="不支持" id="not-supported">
+            <code-block lang="kotlin" code="                // Lambda&#10;                embeddedServer(Netty, port = 8080) { configureServer() }&#10;&#10;                // 阻塞函数引用&#10;                embeddedServer(Netty, port = 8080, module = Application::myBlockingModule)"/>
+        </chapter>
+    </chapter>
+    <chapter title="启用开发模式" id="enable">
+        <p>
+            要使用自动重载，您需要先启用
+            <a href="#enable">开发模式</a>。
+            这取决于您用于<Links href="//server-create-and-configure" summary="了解如何根据应用部署需求创建服务器。">创建和运行服务器</Links>的方式：
+        </p>
+        <list>
+            <li>
+                <p>
+                    如果您使用 <code>EngineMain</code> 运行服务器，请在<a href="#application-conf">配置文件</a>中启用开发模式。
+                </p>
+            </li>
+            <li>
+                <p>
+                    如果您使用 <code>embeddedServer</code> 运行服务器，可以使用
+                    <a href="#system-property"><code>io.ktor.development</code></a>
+                    系统属性。
+                </p>
+            </li>
+        </list>
+        <p>
+            启用开发模式后，Ktor 将自动监视工作目录中的输出文件。
+            如有需要，您可以通过指定<a href="#watch-paths">监视路径</a>来缩小监视文件夹的范围。
+        </p>
+    </chapter>
+    <chapter title="配置监视路径" id="watch-paths">
+        <p>
+            当您<a href="#enable">启用</a>开发模式时，
+            Ktor 开始监视工作目录中的输出文件。
+            例如，对于使用 Gradle 构建的 <Path>ktor-sample</Path> 项目，将监视以下文件夹：
+        </p>
+        <code-block code="            ktor-sample/build/classes/kotlin/main/META-INF&#10;            ktor-sample/build/classes/kotlin/main/com/example&#10;            ktor-sample/build/classes/kotlin/main/com&#10;            ktor-sample/build/classes/kotlin/main&#10;            ktor-sample/build/resources/main"/>
+        <p>
+            监视路径允许您缩小监视文件夹的范围。
+            为此，您可以指定监视路径的一部分。
+            例如，要监控 <Path>ktor-sample/build/classes</Path> 子文件夹中的更改，
+            请将 <code>classes</code> 作为监视路径传递。
+            根据您运行服务器的方式，您可以通过以下方式指定监视路径：
+        </p>
+        <list>
+            <li>
+                <p>
+                    在 <Path>application.conf</Path> 或 <Path>application.yaml</Path> 文件中，指定 <code>watch</code> 选项：
+                </p>
+                <Tabs group="config">
+                    <TabItem title="application.conf" group-key="hocon">
+                        <code-block code="ktor {&#10;    development = true&#10;    deployment {&#10;        watch = [ classes ]&#10;    }&#10;}"/>
+                    </TabItem>
+                    <TabItem title="application.yaml" group-key="yaml">
+                        <code-block lang="yaml" code="ktor:&#10;    development: true&#10;    deployment:&#10;        watch:&#10;            - classes"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    您还可以指定多个监视路径，例如：
+                </p>
+                <Tabs group="config">
+                    <TabItem title="application.conf" group-key="hocon">
+                        <code-block code="                            watch = [ classes, resources ]"/>
+                    </TabItem>
+                    <TabItem title="application.yaml" group-key="yaml">
+                        <code-block lang="yaml" code="                            watch:&#10;                                - classes&#10;                                - resources"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    您可以在此处找到完整示例：<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>。
+                </p>
+            </li>
+            <li>
+                <p>
+                    如果您使用的是 <code>embeddedServer</code>，请将监视路径作为 <code>watchPaths</code>
+                    形参传递：
+                </p>
+                <code-block lang="Kotlin" code="fun main() {&#10;    embeddedServer(Netty, port = 8080, watchPaths = listOf(&quot;classes&quot;), host = &quot;0.0.0.0&quot;, module = Application::module)&#10;        .start(wait = true)&#10;}&#10;&#10;fun Application.module() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, world!&quot;)&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    有关完整示例，请参阅
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-embedded-server">
+                        autoreload-embedded-server
+                    </a>
+                    。
+                </p>
+            </li>
+        </list>
+    </chapter>
+    <chapter title="启用更改时重新编译" id="recompile">
+        <p>
+            由于自动重载检测的是输出文件中的更改，
+            因此您需要重新构建项目。
+            您可以在 IntelliJ IDEA 中手动执行此操作，或者
+            使用 <code>-t</code> 命令行选项在 Gradle 中启用持续构建执行。
+        </p>
+        <list>
+            <li>
+                <p>
+                    要在 IntelliJ IDEA 中手动重新构建项目，请从主菜单选择
+                    <ui-path>Build | Rebuild Project</ui-path>。
+                </p>
+            </li>
+            <li>
+                <p>
+                    要使用 Gradle 自动重新构建项目，
+                    您可以在终端中使用 <code>-t</code> 选项运行 <code>build</code> 任务：
+                </p>
+                <code-block lang="Bash" code="                    ./gradlew -t build"/>
+                <tip>
+                    <p>
+                        要在重载项目时跳过运行测试，可以将 <code>-x</code> 选项传递给 <code>build</code> 任务：
+                    </p>
+                    <code-block lang="Bash" code="                        ./gradlew -t build -x test -i"/>
+                </tip>
+            </li>
+        </list>
+    </chapter>
+</topic>

--- a/docs/ktor/server-auto-reload.md
+++ b/docs/ktor/server-auto-reload.md
@@ -37,42 +37,32 @@
     <chapter title="限制" id="limitations">
         自动重载仅适用于特定的模块声明。下表显示了跨版本的支持情况：
         <table>
-            
 <tr>
 <td>模块类型</td>
-                <td>&lt;= 3.2</td>
-                <td>&gt; 3.2</td>
+<td>&lt;= 3.2</td>
+<td>&gt; 3.2</td>
 </tr>
-
-            
 <tr>
 <td>Lambda 初始值设定项</td>
-                <td>❌ 不支持</td>
-                <td>❌ 不支持</td>
+<td>❌ 不支持</td>
+<td>❌ 不支持</td>
 </tr>
-
-            
 <tr>
 <td>阻塞函数引用</td>
-                <td>✅ 支持</td>
-                <td>❌ 不支持</td>
+<td>✅ 支持</td>
+<td>❌ 不支持</td>
 </tr>
-
-            
 <tr>
 <td>挂起函数引用</td>
-                <td>❌ 不支持</td>
-                <td>✅ 支持</td>
+<td>❌ 不支持</td>
+<td>✅ 支持</td>
 </tr>
-
-            
 <tr>
 <td>配置引用</td>
-                <td>✅ 支持</td>
-                <td>✅ 支持</td>
+<td>✅ 支持</td>
+<td>✅ 支持</td>
 </tr>
-
-        </table>
+</table>
         <chapter title="支持" id="supported">
             <code-block lang="kotlin" code="                // 挂起函数引用&#10;                embeddedServer(Netty, port = 8080, module = Application::mySuspendModule)&#10;&#10;                // 配置引用&#10;                ktor {&#10;                    application {&#10;                        modules = [ com.example.ApplicationKt.mySuspendModule ]&#10;                    }&#10;                }"/>
         </chapter>

--- a/docs/ktor/server-configuration-code.md
+++ b/docs/ktor/server-configuration-code.md
@@ -1,0 +1,165 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="代码内配置"
+       id="server-configuration-code" help-id="Configuration-code;server-configuration-in-code">
+<show-structure for="chapter"/>
+<link-summary>
+    了解如何在代码中配置各种服务器参数。
+</link-summary>
+<p>
+    Ktor 允许您直接在代码中配置各种服务器参数，包括主机地址、端口、<Links href="//server-modules" summary="模块允许您通过对路由进行分组来构建应用程序结构。">服务器模块</Links>等。配置方法取决于您设置服务器的方式 —— 使用 <Links href="//server-create-and-configure" summary="了解如何根据您的应用程序部署需求创建服务器。">embeddedServer 或 EngineMain</Links>。
+</p>
+<p>
+    使用 <code>embeddedServer</code> 时，您可以通过将所需参数直接传递给该函数来配置服务器。
+    <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/embedded-server.html">
+        embeddedServer
+    </a>
+    函数接受用于配置服务器的不同形参，包括<Links href="//server-engines" summary="了解处理网络请求的引擎。">服务器引擎</Links>、服务器侦听的主机和端口以及其他配置。
+</p>
+<p>
+    在本节中，我们将查看几个运行 <code>embeddedServer</code> 的不同示例，说明如何根据您的需要配置服务器。
+</p>
+<chapter title="基础配置" id="embedded-basic">
+    <p>
+        下面的代码段展示了使用 Netty 引擎和 <code>8080</code> 端口的基础服务器设置。
+    </p>
+    <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(Netty, port = 8080) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+    <p>
+        请注意，您可以将 <code>port</code> 形参设置为 <code>0</code> 以在随机端口上运行服务器。
+        <code>embeddedServer</code> 函数会返回一个引擎实例，因此您可以在代码中使用
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/resolved-connectors.html">
+            ApplicationEngine.resolvedConnectors
+        </a>
+        函数获取端口值。
+    </p>
+</chapter>
+<chapter title="引擎配置" id="embedded-engine">
+    <snippet id="embedded-engine-configuration">
+        <p>
+            <code>embeddedServer</code> 函数允许您使用 <code>configure</code> 形参传递引擎特定的选项。该形参包含所有引擎通用的选项，由
+            <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/index.html">
+                ApplicationEngine.Configuration
+            </a>
+            类提供。
+        </p>
+        <p>
+            下面的示例展示了如何使用 <code>Netty</code> 引擎配置服务器。在 <code>configure</code> 块中，我们定义了一个 <code>connector</code>（连接器）来指定主机和端口，并自定义了各种服务器参数：
+        </p>
+        <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(Netty, configure = {&#10;        connectors.add(EngineConnectorBuilder().apply {&#10;            host = &quot;127.0.0.1&quot;&#10;            port = 8080&#10;        })&#10;        connectionGroupSize = 2&#10;        workerGroupSize = 5&#10;        callGroupSize = 10&#10;        shutdownGracePeriod = 2000&#10;        shutdownTimeout = 3000&#10;    }) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+        <p>
+            <code>connectors.add()</code> 方法使用指定的主机 (<code>127.0.0.1</code>) 和端口 (<code>8080</code>) 定义了一个连接器。
+        </p>
+        <p>除了这些选项之外，您还可以配置其他特定于引擎的属性。</p>
+        <chapter title="Netty" id="netty-code">
+            <p>
+                Netty 特定的选项由
+                <a href="https://api.ktor.io/ktor-server-netty/io.ktor.server.netty/-netty-application-engine/-configuration/index.html">
+                    NettyApplicationEngine.Configuration
+                </a>
+                类提供。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.netty.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Netty, configure = {&#10;                            requestQueueLimit = 16&#10;                            shareWorkGroup = false&#10;                            configureBootstrap = {&#10;                                // ...&#10;                            }&#10;                            responseWriteTimeoutSeconds = 10&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="Jetty" id="jetty-code">
+            <p>
+                Jetty 特定的选项由
+                <a href="https://api.ktor.io/ktor-server-jetty-jakarta/io.ktor.server.jetty.jakarta/-jetty-application-engine-base/-configuration/index.html">
+                    JettyApplicationEngineBase.Configuration
+                </a>
+                类提供。
+            </p>
+            <p>您可以在
+                <a href="https://api.ktor.io/ktor-server-jetty-jakarta/io.ktor.server.jetty.jakarta/-jetty-application-engine-base/-configuration/configure-server.html">
+                    configureServer
+                </a>
+                块中配置 Jetty 服务器，该块提供了对
+                <a href="https://www.eclipse.org/jetty/javadoc/jetty-11/org/eclipse/jetty/server/Server.html">Server</a>
+                实例的访问。
+            </p>
+            <p>
+                使用 <code>idleTimeout</code> 属性来指定连接在关闭之前可以空闲的时间长度。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.jetty.jakarta.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Jetty, configure = {&#10;                            configureServer = { // this: Server -&amp;gt;&#10;                                // ...&#10;                            }&#10;                            idleTimeout = 30.seconds&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="CIO" id="cio-code">
+            <p>CIO 特定的选项由
+                <a href="https://api.ktor.io/ktor-server-cio/io.ktor.server.cio/-c-i-o-application-engine/-configuration/index.html">
+                    CIOApplicationEngine.Configuration
+                </a>
+                类提供。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.cio.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(CIO, configure = {&#10;                            connectionIdleTimeoutSeconds = 45&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="Tomcat" id="tomcat-code">
+            <p>如果您使用 Tomcat 作为引擎，您可以使用
+                <a href="https://api.ktor.io/ktor-server-tomcat-jakarta/io.ktor.server.tomcat.jakarta/-tomcat-application-engine/-configuration/configure-tomcat.html">
+                    configureTomcat
+                </a>
+                属性进行配置，该属性提供了对
+                <a href="https://tomcat.apache.org/tomcat-10.1-doc/api/org/apache/catalina/startup/Tomcat.html">Tomcat</a>
+                实例的访问。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.tomcat.jakarta.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Tomcat, configure = {&#10;                            configureTomcat = { // this: Tomcat -&amp;gt;&#10;                                // ...&#10;                            }&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+    </snippet>
+</chapter>
+<chapter title="自定义环境" id="embedded-custom">
+    <p>
+        下面的示例展示了如何使用由
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/index.html">
+            ApplicationEngine.Configuration
+        </a>
+        类表示的自定义配置运行带有多个连接器端点的服务器。
+    </p>
+    <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main() {&#10;    val appProperties = serverConfig {&#10;        module { module() }&#10;    }&#10;    embeddedServer(Netty, appProperties) {&#10;        envConfig()&#10;    }.start(true)&#10;}&#10;&#10;fun ApplicationEngine.Configuration.envConfig() {&#10;    connector {&#10;        host = &quot;0.0.0.0&quot;&#10;        port = 8080&#10;    }&#10;    connector {&#10;        host = &quot;127.0.0.1&quot;&#10;        port = 9090&#10;    }&#10;}"/>
+    <p>
+        有关完整示例，请参阅
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server-multiple-connectors">
+            embedded-server-multiple-connectors
+        </a>。
+    </p>
+    <tip>
+        <p>
+            您还可以使用自定义环境来
+            <a href="#embedded-server">
+                提供 HTTPS 服务
+            </a>。
+        </p>
+    </tip>
+</chapter>
+<chapter id="command-line" title="命令行配置">
+    <p>
+        Ktor 允许您使用命令行实参动态配置 <code>embeddedServer</code>。在需要在运行时指定端口、主机或超时等配置的情况下，这特别有用。
+    </p>
+    <p>
+        为了实现这一点，请使用
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-command-line-config.html">
+            CommandLineConfig
+        </a>
+        类将命令行实参解析为配置对象，并将其在配置块中传递：
+    </p>
+    <code-block lang="kotlin" code="fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(&#10;        factory = Netty,&#10;        configure = {&#10;            val cliConfig = CommandLineConfig(args)&#10;            takeFrom(cliConfig.engineConfig)&#10;            loadCommonConfiguration(cliConfig.rootConfig.environment.config)&#10;        }&#10;    ) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+    <p>
+        在此示例中，来自 <code>Application.Configuration</code> 的
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/take-from.html">
+            <code>takeFrom()</code>
+        </a>
+        函数被用于替代引擎配置值，例如 <code>port</code> 和 <code>host</code>。
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/load-common-configuration.html">
+            <code>loadCommonConfiguration()</code>
+        </a>
+        函数从根环境加载配置，例如超时设置。
+    </p>
+    <p>
+        要运行服务器，请按以下方式指定实参：
+    </p>
+    <code-block lang="shell" code="            ./gradlew run --args=&quot;-port=8080&quot;"/>
+    <tip>
+        对于静态配置，您可以使用配置文件或环境变量。
+        要了解更多信息，请参阅
+        <a href="#command-line">
+            文件中的配置
+        </a>。
+    </tip>
+</chapter>
+</topic>

--- a/docs/ktor/server-create-a-new-project.md
+++ b/docs/ktor/server-create-a-new-project.md
@@ -1,0 +1,824 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="创建、打开并运行新的 Ktor 项目"
+       id="server-create-a-new-project"
+       help-id="server_create_a_new_project">
+    <show-structure for="chapter" depth="2"/>
+    <tldr>
+        <var name="example_name" value="tutorial-server-get-started"/>
+        <p>
+            <b>代码示例</b>:
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+    </tldr>
+    <link-summary>
+        学习如何使用 Ktor 打开、运行及测试服务器应用程序。
+    </link-summary>
+    <web-summary>
+        开始构建您的第一个 Ktor Server 应用程序。在本教程中，您将学习如何创建、打开及运行新的 Ktor 项目。
+    </web-summary>
+    <p>
+        在本教程中，您将学习如何创建、打开并运行您的第一个 Ktor 服务器项目。一旦运行起来，您就可以完成一系列任务来熟悉 Ktor。
+    </p>
+    <p>
+        这是关于使用 Ktor 构建服务器应用程序入门系列教程的第一部分。您可以独立完成每个教程，但我们强烈建议您按照建议的顺序进行：
+    </p>
+    <list type="decimal">
+        <li>创建、打开并运行新的 Ktor 项目。</li>
+        <li><Links href="//server-requests-and-responses" summary="通过构建一个任务管理器应用程序，学习 Ktor 中关于路由、处理请求以及形参的基础知识。">处理请求并生成响应</Links>。</li>
+        <li><Links href="//server-create-restful-apis" summary="学习如何使用 Kotlin 和 Ktor 构建后端服务，其中包括一个生成 JSON 文件的 RESTful API 示例。">创建生成 JSON 的 RESTful API</Links>。</li>
+        <li><Links href="//server-create-website" summary="学习如何使用 Ktor 和 Thymeleaf 模板构建 Kotlin 网站。">使用 Thymeleaf 模板创建网站</Links>。</li>
+        <li><Links href="//server-create-websocket-application" summary="学习如何利用 WebSocket 的力量发送和接收内容。">创建 WebSocket 应用程序</Links>。</li>
+        <li><Links href="//server-integrate-database" summary="学习使用 Exposed SQL 库将 Ktor 服务连接到数据库仓库的过程。">使用 Exposed 集成数据库</Links>。</li>
+    </list>
+    <chapter id="create-project" title="创建新的 Ktor 项目">
+        <p>
+            创建新 Ktor 项目最快的方法之一是 <a href="#create-project-with-the-ktor-project-generator">使用基于 Web 的 Ktor 项目生成器</a>。
+        </p>
+        <p>
+            或者，您也可以 <a href="#create_project_with_intellij">使用专用的 IntelliJ IDEA Ultimate Ktor 插件</a> 或 <a href="#create_project_with_ktor_cli_tool">Ktor CLI 工具</a> 生成项目。
+        </p>
+        <chapter title="使用 Ktor 项目生成器"
+                 id="create-project-with-the-ktor-project-generator">
+            <p>
+                要使用 Ktor 项目生成器创建新项目，请按照以下步骤操作：
+            </p>
+            <procedure>
+                <step>
+                    <p>导航至 <a href="https://start.ktor.io/">Ktor 项目生成器</a>。</p>
+                </step>
+                <step>
+                    <p>在
+                        <control>Project artifact</control>
+                        字段中，输入
+                        <Path>com.example.ktor-sample</Path>
+                        作为项目标识的名称。
+                        <img src="ktor_343_project_generator_new_project_artifact_name.png"
+                             alt="Ktor 项目生成器，项目标识名称为 com.example.ktor-sample"
+                             border-effect="line"
+                             style="block"
+                             width="706"/>
+                    </p>
+                </step>
+                <step id="configure-project-step">
+                    <p>点击
+                        <control>Configure</control>
+                        以打开设置下拉菜单：
+                        <img src="ktor_343_project_generator_new_project_configure.png"
+                             style="block"
+                             alt="Ktor 项目设置的展开视图" border-effect="line" width="706"/>
+                    </p>
+                    <p>
+                        提供以下设置：
+                    </p>
+                    <list>
+                        <li>
+                            <p>
+                                <control>Build System</control>：
+                                选择所需的 <Links href="//server-dependencies" summary="学习如何向现有的 Gradle/Maven 项目中添加 Ktor Server 依赖项。">构建系统</Links>。
+                                可以是
+                                <emphasis>Gradle Kotlin</emphasis>、
+                                <emphasis>Gradle Groovy</emphasis>、
+                                <emphasis>Maven</emphasis> 或 <emphasis>Amper</emphasis>。
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Engine</control>：
+                                选择用于运行服务器的 <Links href="//server-engines" summary="了解处理网络请求的引擎。">引擎</Links>。
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Configuration</control>：
+                                选择是 <Links href="//server-configuration-file" summary="学习如何在配置文件中配置各种服务器参数。">在 YAML 或 HOCON 文件中</Links>，还是 <Links href="//server-configuration-code" summary="学习如何在代码中配置各种服务器参数。">在代码中</Links> 指定服务器参数。
+                            </p>
+                            <warning>
+                                目前基于 Maven 的 Ktor 项目不支持 YAML 配置。
+                            </warning>
+                        </li>
+                    </list>
+                    <p>对于本教程，您可以保留这些设置的默认值。</p>
+                </step>
+                <step>
+                    <p>点击
+                        <control>Done</control>
+                        以保存配置并关闭菜单。
+                    </p>
+                </step>
+                <step>
+                    <p>在下方您会发现一组可以添加到项目中的 <Links href="//server-plugins" summary="插件提供常用功能，例如序列化、内容编码、压缩等。">插件</Links>。插件是提供 Ktor 应用程序常用功能的构建块，例如身份验证、序列化和内容编码、压缩、Cookie 支持等。
+                    </p>
+                    <p>就本教程而言，您目前不需要添加任何插件。</p>
+                </step>
+                <step>
+                    <p>
+                        点击
+                        <control>Download</control>
+                        按钮来生成并下载您的 Ktor 项目。
+                        <img src="ktor_343_project_generator_new_project_download.png"
+                             alt="Ktor 项目生成器下载按钮"
+                             border-effect="line"
+                             style="block"
+                             width="706"/>
+                    </p>
+                </step>
+                <p>下载应会自动开始。</p>
+            </procedure>
+            <p>现在您已经生成了新项目，请继续 <a href="#unpacking">解压缩并运行您的 Ktor 项目</a>。</p>
+        </chapter>
+        <chapter title="使用 IntelliJ IDEA Ultimate 的 Ktor 插件" id="create_project_with_intellij"
+                 collapsible="true">
+            <p>
+                本节介绍如何使用 IntelliJ IDEA Ultimate 的 <a
+                    href="https://plugins.jetbrains.com/plugin/16008-ktor">Ktor 插件</a> 进行项目设置。
+            </p>
+            <p>
+                要创建一个新的 Ktor 项目，请 <a href="https://www.jetbrains.com/help/idea/run-for-the-first-time.html">打开 IntelliJ IDEA</a> 并按照以下步骤操作：
+            </p>
+            <procedure>
+                <step>
+                    <p>
+                        在欢迎屏幕上，点击 <control>New Project</control>。
+                    </p>
+                    <p>
+                        或者，从主菜单中选择 <ui-path>File | New | Project</ui-path>。
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        在
+                        <control>New Project</control>
+                        向导中，从左侧列表中选择
+                        <control>Ktor</control>。
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        在右侧面板中，您可以指定以下设置：
+                    </p>
+                    <img src="ktor_idea_new_project_settings.png" alt="Ktor 项目设置" width="706"
+                         border-effect="rounded"/>
+                    <list>
+                        <li>
+                            <p>
+                                <control>Name</control>：指定项目名称。输入
+                                <Path>ktor-sample</Path>
+                                作为项目名称。
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Location</control>：为您的项目指定一个目录。
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Website</control>：
+                                指定用于生成软件包名称的域名。
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Artifact</control>：
+                                此字段显示生成的项目标识名称。
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Engine</control>：
+                                选择用于运行服务器的 <Links href="//server-engines" summary="了解处理网络请求的引擎。">引擎</Links>。
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Include samples</control>：
+                                保持启用此选项以添加插件的示例代码。
+                            </p>
+                        </li>
+                    </list>
+                </step>
+                <step>
+                    <p>
+                        点击
+                        <control>Advanced Settings</control>
+                        以展开额外设置菜单：
+                    </p>
+                    <img src="ktor_idea_new_project_advanced_settings.png" alt="Ktor 项目高级设置"
+                         width="706" border-effect="rounded"/>
+                    <p>
+                        提供以下设置：
+                    </p>
+                    <list>
+                        <li>
+                            <p>
+                                <control>Build System</control>：
+                                选择所需的 <Links href="//server-dependencies" summary="学习如何向现有的 Gradle/Maven 项目中添加 Ktor Server 依赖项。">构建系统</Links>。
+                                可以是
+                                <emphasis>Gradle Kotlin</emphasis>、
+                                <emphasis>Gradle Groovy</emphasis>、
+                                <emphasis>Maven</emphasis> 或 <emphasis>Amper</emphasis>。
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Ktor version</control>：
+                                选择所需的 Ktor 版本。
+                            </p>
+                        </li>
+                        <li>
+                            <p>
+                                <control>Configuration</control>：
+                                选择是 <Links href="//server-configuration-file" summary="学习如何在配置文件中配置各种服务器参数。">在 YAML 或 HOCON 文件中</Links>，还是 <Links href="//server-configuration-code" summary="学习如何在代码中配置各种服务器参数。">在代码中</Links> 指定服务器参数。
+                            </p>
+                            <warning>
+                                目前基于 Maven 的 Ktor 项目不支持 YAML 配置。
+                            </warning>
+                        </li>
+                    </list>
+                    <p>就本教程而言，您可以保留这些设置的默认值。</p>
+                </step>
+                <step>
+                    <p>
+                        点击
+                        <control>Next</control>
+                        进入下一页。
+                    </p>
+                    <img src="ktor_idea_new_project_plugins_list.png" alt="Ktor 插件" width="706"
+                         border-effect="rounded"/>
+                    <p>
+                        在此页面上，您可以选择一组 <Links href="//server-plugins" summary="插件提供常用功能，例如序列化、内容编码、压缩等。">插件</Links> - 这些构建块提供 Ktor 应用程序的常用功能，例如身份验证、序列化和内容编码、压缩、Cookie 支持等。
+                    </p>
+                    <p>就本教程而言，您目前不需要添加任何插件。</p>
+                </step>
+                <step>
+                    <p>
+                        点击
+                        <control>Create</control>
+                        并等待 IntelliJ IDEA 生成项目并安装依赖项。
+                    </p>
+                </step>
+            </procedure>
+            <p>
+                现在您已经创建了新项目，请继续学习如何 <a href="#open-explore-run">打开、探索并运行</a> 应用程序。
+            </p>
+        </chapter>
+        <chapter title="使用 Ktor CLI 工具" id="create_project_with_ktor_cli_tool"
+                 collapsible="true">
+            <p>
+                本节介绍如何使用 <a href="https://github.com/ktorio/ktor-cli">Ktor CLI 工具</a> 进行项目设置。
+            </p>
+            <p>
+                要创建一个新的 Ktor 项目，请打开您选择的终端并按照以下步骤操作：
+            </p>
+            <procedure>
+                <step>
+                    使用以下命令之一安装 Ktor CLI 工具：
+                    <Tabs>
+                        <TabItem title="macOS/Linux" id="macos-linux">
+                            <code-block lang="console" code="                                brew install ktor"/>
+                        </TabItem>
+                        <TabItem title="Windows" id="windows">
+                            <code-block lang="console" code="                                winget install JetBrains.KtorCLI"/>
+                        </TabItem>
+                    </Tabs>
+                </step>
+                <step>
+                    要以交互模式生成新项目，请使用以下命令：
+                    <code-block lang="console" code="                      ktor new"/>
+                </step>
+                <step>
+                    输入
+                    <Path>ktor-sample</Path>
+                    作为项目名称：
+                    <img src="server_create_cli_tool_name_dark.png"
+                         alt="以交互模式使用 Ktor CLI 工具"
+                         border-effect="rounded"
+                         style="block"
+                         width="706"/>
+                    <p>
+                        （可选）您还可以通过编辑项目名称下方的 <ui-path>Location</ui-path> 路径来更改项目的保存位置。
+                    </p>
+                </step>
+                <step>
+                    按
+                    <shortcut>Enter</shortcut>
+                    继续。
+                </step>
+                <step>
+                    在下一步中，您可以搜索并向项目添加 <Links href="//server-plugins" summary="插件提供常用功能，例如序列化、内容编码、压缩等。">插件</Links>。插件是提供 Ktor 应用程序常用功能的构建块，例如身份验证、序列化和内容编码、压缩、Cookie 支持等。
+                    <img src="server_create_cli_tool_add_plugins_dark.png"
+                         alt="使用 Ktor CLI 工具向项目添加插件"
+                         border-effect="rounded"
+                         style="block"
+                         width="706"/>
+                    <p>就本教程而言，您目前不需要添加任何插件。</p>
+                </step>
+                <step>
+                    按
+                    <shortcut>CTRL+G</shortcut>
+                    生成项目。
+                    <p>
+                        或者，您可以通过选择
+                        <control>CREATE PROJECT (CTRL+G)</control>
+                        并按
+                        <shortcut>Enter</shortcut>
+                        来生成项目。
+                    </p>
+                </step>
+            </procedure>
+        </chapter>
+    </chapter>
+    <chapter title="解压缩并运行您的 Ktor 项目" id="unpacking">
+        <p>
+            在本节中，您将学习如何从命令行解压缩、构建和运行项目。以下步骤假设：
+        </p>
+        <list type="bullet">
+            <li>您已创建并下载了一个名为
+                <Path>ktor-sample</Path>
+                的 Gradle 项目。
+            </li>
+            <li>该项目位于主目录中名为
+                <Path>myprojects</Path>
+                的文件夹内。
+            </li>
+        </list>
+        <p>如有必要，请更改名称和路径以匹配您自己的设置。</p>
+        <p>打开您选择的命令行工具并按照以下步骤操作：</p>
+        <procedure>
+            <step>
+                <p>在终端窗口中，导航到您下载项目的文件夹：</p>
+                <code-block lang="console" code="                    cd ~/myprojects"/>
+            </step>
+            <step>
+                <p>将 ZIP 存档解压缩到同名文件夹中：</p>
+                <Tabs>
+                    <TabItem title="macOS" group-key="macOS">
+                        <code-block lang="console" code="                            unzip ktor-sample.zip -d ktor-sample"/>
+                    </TabItem>
+                    <TabItem title="Windows" group-key="windows">
+                        <code-block lang="console" code="                            tar -xf ktor-sample.zip"/>
+                    </TabItem>
+                </Tabs>
+                <p>您的目录现在将包含 ZIP 存档和解压后的文件夹。</p>
+            </step>
+            <step>
+                <p>从该目录进入新创建的文件夹：</p>
+                <code-block lang="console" code="                    cd ktor-sample"/>
+            </step>
+            <step>
+                <p>在 macOS 和 UNIX 系统上，您必须使 Gradle 辅助脚本具有可执行权限，以便系统将其识别为可运行命令。为此，请使用 <code>chmod</code> 命令：</p>
+                <Tabs>
+                    <TabItem title="macOS" group-key="macOS">
+                        <code-block lang="console" code="                            chmod +x ./gradlew"/>
+                    </TabItem>
+                </Tabs>
+            </step>
+            <step>
+                <p>要构建项目，请使用以下命令：</p>
+                <Tabs>
+                    <TabItem title="macOS" group-key="macOS">
+                        <code-block lang="console" code="                            ./gradlew build"/>
+                    </TabItem>
+                    <TabItem title="Windows" group-key="windows">
+                        <code-block lang="console" code="                            gradlew build"/>
+                    </TabItem>
+                </Tabs>
+                <p>构建成功后，继续执行下一步以运行项目。</p>
+            </step>
+            <step>
+                <p>要运行项目，请使用以下命令：</p>
+                <Tabs>
+                    <TabItem title="macOS" group-key="macOS">
+                        <code-block lang="console" code="                            ./gradlew run"/>
+                    </TabItem>
+                    <TabItem title="Windows" group-key="windows">
+                        <code-block lang="console" code="                            gradlew run"/>
+                    </TabItem>
+                </Tabs>
+            </step>
+            <step>
+                <p>要验证项目是否正在运行，请在浏览器中打开终端输出显示的 URL（<a
+                        href="http://0.0.0.0:8080">http://0.0.0.0:8080</a>）。
+                    您应该在浏览器中看到显示的消息 "Hello World!"：</p>
+                <img src="server_get_started_ktor_sample_app_output.png" alt="生成的 Ktor 项目输出"
+                     border-effect="line" width="706"/>
+            </step>
+        </procedure>
+        <p>恭喜！您已成功启动了 Ktor 项目。</p>
+        <note>
+            请注意，命令行将无响应，因为底层进程正忙于运行 Ktor 应用程序。您可以按
+            <shortcut>CTRL+C</shortcut>
+            来终止应用程序。
+        </note>
+    </chapter>
+    <chapter title="在 IntelliJ IDEA 中打开、探索并运行您的 Ktor 项目" id="open-explore-run">
+        <chapter title="打开项目" id="open">
+            <p>如果您安装了 <a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a>，可以轻松地从命令行打开项目。
+            </p>
+            <p>
+                确保您位于项目文件夹中，然后输入 <code>idea</code> 命令，后跟一个点（代表当前文件夹）：
+            </p>
+            <code-block lang="Bash" code="                idea ."/>
+            <p>
+                或者，要手动打开项目，请启动 IntelliJ IDEA。
+            </p>
+            <p>
+                如果显示欢迎屏幕，请点击
+                <control>Open</control>。否则，前往主菜单中的
+                <ui-path>File | Open</ui-path>
+                并选择
+                <Path>ktor-sample</Path>
+                文件夹以将其打开。
+            </p>
+            <tip>
+                有关管理项目的更多详细信息，请参阅 <a href="https://www.jetbrains.com/help/idea/creating-and-managing-projects.html">IntelliJ IDEA 文档</a>。
+            </tip>
+        </chapter>
+        <chapter title="探索项目" id="explore">
+            <p>打开项目后，您可以看到以下结构：</p>
+            <img src="tutorial_server_get_started_idea_project_view.png" alt="IDE 中生成的 Ktor 项目视图" width="706"/>
+            <p>
+                要查看完整布局，请点击每个文件夹旁边的展开箭头，展开 <control>Project</control> 视图中的文件夹。
+            </p>
+            <p>
+                应用程序源代码位于
+                <Path>src/main/kotlin</Path>
+                目录下。默认创建了两个文件，分别名为
+                <Path>Application.kt</Path>
+                和
+                <Path>Routing.kt</Path>。
+            </p>
+            <img src="tutorial_server_get_started_idea_main_folder.png" alt="Ktor 项目 src 文件夹结构" width="400"/>
+            <p>项目的名称在
+                <Path>settings.gradle.kts</Path>
+                文件中配置：
+            </p>
+            <code-block lang="kotlin" code="rootProject.name = &quot;ktor-sample&quot;"/>
+            <p>
+                配置文件以及其他类型的内容存放在
+                <Path>src/main/resources</Path>
+                文件夹内。
+            </p>
+            <img src="tutorial_server_get_started_idea_resources_folder.png" alt="Ktor 项目 resources 文件夹结构"
+                 width="400"/>
+        </chapter>
+        <chapter title="运行项目" id="run">
+            <procedure>
+                <p>要在 IntelliJ IDEA 内部运行项目：</p>
+                <step>
+                    <p>点击右侧侧边栏上的 Gradle 图标（<img alt="IntelliJ IDEA gradle 图标"
+                                                          src="intellij_idea_gradle_icon.svg" width="16" height="26"/>）打开 <a href="https://www.jetbrains.com/help/idea/jetgradle-tool-window.html">Gradle 工具窗口</a>。</p>
+                </step>
+                <step>
+                    <p>在此工具窗口中，导航到
+                        <ui-path>Tasks | application</ui-path>
+                        并双击
+                        <control>run</control>
+                        任务。
+                    </p>
+                    <img src="tutorial_server_get_started_idea_gradle_run.png" alt="IntelliJ IDEA 中的 Gradle 选项卡"
+                         border-effect="line" width="450"/>
+                </step>
+                <step>
+                    <p>您的 Ktor 应用程序将在 IDE 底部的 <a
+                            href="https://www.jetbrains.com/help/idea/run-tool-window.html">Run 工具窗口</a> 中启动：</p>
+                    <img src="tutorial_server_get_started_idea_run_terminal.png" alt="在终端中运行的项目" width="706"/>
+                    <p>之前在命令行上显示的相同消息现在将在
+                        <ui-path>Run</ui-path>
+                        工具窗口中可见。
+                    </p>
+                </step>
+                <step>
+                    <p>要确认项目正在运行，请在浏览器中打开指定的 URL
+                        （<a href="http://0.0.0.0:8080">http://0.0.0.0:8080</a>）。</p>
+                    <p>您应该会再次看到屏幕上显示消息 "Hello World!"：</p>
+                    <img src="server_get_started_ktor_sample_app_output.png" alt="浏览器屏幕中的 Hello World"
+                         width="706"/>
+                </step>
+            </procedure>
+            <p>
+                您可以通过
+                <ui-path>Run</ui-path>
+                工具窗口管理应用程序。
+            </p>
+            <list type="bullet">
+                <li>
+                    要终止应用程序，请点击停止按钮 <img src="intellij_idea_terminate_icon.svg"
+                                                                             style="inline" height="16" width="16"
+                                                                             alt="IntelliJ IDEA 终止图标"/>。
+                </li>
+                <li>
+                    要重新启动进程，请点击重新运行按钮 <img src="intellij_idea_rerun_icon.svg"
+                                                                        style="inline" height="16" width="16"
+                                                                        alt="IntelliJ IDEA 重新运行图标"/>。
+                </li>
+            </list>
+            <p>
+                这些选项在 <a href="https://www.jetbrains.com/help/idea/run-tool-window.html#run-toolbar">IntelliJ IDEA Run 工具窗口文档</a> 中有进一步解释。
+            </p>
+        </chapter>
+    </chapter>
+    <chapter title="尝试其他任务" id="additional-tasks">
+        <p>以下是您可能希望尝试的一些其他任务：</p>
+        <list type="decimal">
+            <li><a href="#change-the-default-port">更改默认端口</a></li>
+            <li><a href="#add-a-new-http-endpoint">添加新的 HTTP 端点</a></li>
+            <li><a href="#configure-static-content">配置静态内容</a></li>
+            <li><a href="#write-an-integration-test">编写集成测试</a></li>
+            <li><a href="#register-error-handlers">注册错误处理程序</a></li>
+        </list>
+        <p>
+            这些任务彼此不依赖，但复杂程度逐渐增加。按声明的顺序尝试它们是递进学习最简单的方法。为简单起见并避免重复，下面的描述假设您按顺序尝试任务。
+        </p>
+        <p>
+            在需要编码的地方，我们指定了代码和相应的导入。IDE 可能会为您自动添加这些导入。
+        </p>
+        <chapter title="更改默认端口" id="change-the-default-port">
+            <chapter title="在配置文件中更改端口" id="change-the-port-in-config">
+                <p>
+                    如果您选择将配置存储在外部的 YAML 或 HOCON 文件中，请在
+                    <ui-path>Project</ui-path>
+                    视图中导航到
+                    <Path>src/main/resources</Path>
+                    文件夹并按照以下步骤操作：
+                </p>
+                <procedure id="change-default-port-yaml-procedure">
+                    <step>
+                        打开您的配置文件（
+                        <Path>application.yaml</Path>
+                        或
+                        <Path>application.conf</Path>
+                        ）。它应该如下所示：
+                        <Tabs>
+                            <TabItem title="application.yaml (YAML)" group-key="yaml">
+                                <code-block lang="yaml" code="ktor:&#10;  deployment:&#10;    port: 8080&#10;  application:&#10;    modules:&#10;      - com.example.RoutingKt.configureRouting"/>
+                            </TabItem>
+                            <TabItem title="application.conf (HOCON)" group-key="hocon">
+                                <code-block lang="generic" code="ktor {&#10;  deployment {&#10;    port = 8080&#10;    port = ${?PORT}&#10;  }&#10;  application {&#10;    modules = [&#10;      com.example.RoutingKt.configureRouting&#10;    ]&#10;  }&#10;}"/>
+                            </TabItem>
+                        </Tabs>
+                    </step>
+                    <step>
+                        将文件中的 <code>port</code> 值更改为您选择的另一个数字，例如
+                        <code>9292</code>。
+                    </step>
+                    <step>
+                        <p>点击重新运行按钮（<img alt="IntelliJ IDEA 重新运行按钮图标"
+                                                           src="intellij_idea_rerun_icon.svg" height="16" width="16"/>）以重新启动应用程序。</p>
+                    </step>
+                    <step>
+                        <p>要验证您的应用程序是否在新端口号下运行，您可以在浏览器中打开新 URL（<a href="http://0.0.0.0:9292">http://0.0.0.0:9292</a>）或 <a href="https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html#creating-http-request-files">在 IntelliJ IDEA 中创建一个新的 HTTP Request 文件</a>：</p>
+                        <img src="tutorial_server_get_started_port_change.png"
+                             alt="在 IntelliJ IDEA 中使用 HTTP 请求文件测试端口更改" width="706"/>
+                    </step>
+                </procedure>
+            </chapter>
+            <chapter title="在代码中更改端口" id="change-the-port-in-code">
+                <p>
+                    <a href="#configure-project-step">创建新的 Ktor 项目时</a>，您可以选择在代码中或在外部的 YAML 或 HOCON 文件中存储配置。
+                </p>
+                <p>
+                    如果您选择了在代码中存储配置的选项，请在
+                    <ui-path>Project</ui-path>
+                    视图中导航到
+                    <Path>src/main/kotlin</Path>
+                    文件夹并按照以下步骤操作：
+                </p>
+                <procedure id="change-the-default-port-code-procedure">
+                    <step>
+                        <p>打开
+                            <Path>main.kt</Path>
+                            文件。您应该会发现类似以下内容的代码：
+                        </p>
+                        <code-block lang="kotlin" code="                            fun main(args: Array&lt;String&gt;) {&#10;                                embeddedServer(&#10;                                    factory = io.ktor.server.netty.Netty,&#10;                                    port = 8080,&#10;                                    host = &quot;0.0.0.0&quot;,&#10;                                    module = Application::rootModule&#10;                                ).start(wait = true)&#10;                            }"/>
+                    </step>
+                    <step>
+                        <p>在 <code>embeddedServer()</code> 函数中，将 <code>port</code> 形参更改为您选择的另一个数字，例如 <code>9292</code>。</p>
+                        <code-block lang="kotlin" code="                            fun main(args: Array&lt;String&gt;) {&#10;                                embeddedServer(&#10;                                    factory = io.ktor.server.netty.Netty,&#10;                                    port = 9292,&#10;                                    host = &quot;0.0.0.0&quot;,&#10;                                    module = Application::rootModule&#10;                                ).start(wait = true)&#10;                            }"/>
+                    </step>
+                    <step>
+                        <p>点击重新运行按钮（<img alt="IntelliJ IDEA 重新运行按钮图标"
+                                                           src="intellij_idea_rerun_icon.svg" height="16" width="16"/>）以重新启动应用程序。</p>
+                    </step>
+                    <step>
+                        <p>要验证您的应用程序是否在新端口号下运行，您可以在浏览器中打开新 URL（<a href="http://0.0.0.0:9292">http://0.0.0.0:9292</a>），或者 <a href="https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html#creating-http-request-files">在 IntelliJ IDEA 中创建一个新的 HTTP Request 文件</a>：</p>
+                        <img src="tutorial_server_get_started_port_change.png"
+                             alt="在 IntelliJ IDEA 中使用 HTTP 请求文件测试端口更改" width="706"/>
+                    </step>
+                </procedure>
+            </chapter>
+        </chapter>
+        <chapter title="添加新的 HTTP 端点" id="add-a-new-http-endpoint">
+            <p>
+                在
+                <ui-path>Project</ui-path>
+                工具窗口中，导航到
+                <Path>src/main/kotlin</Path>
+                文件夹并按照以下步骤操作：
+            </p>
+            <procedure>
+                <step>
+                    <p>打开
+                        <Path>Routing.kt</Path>
+                        文件。您应该看到以下代码：
+                    </p>
+                    <code-block lang="Kotlin" validate="true" code="                        fun Application.configureRouting() {&#10;                            routing {&#10;                                get(&quot;/&quot;) {&#10;                                    call.respondText(&quot;Hello World!&quot;)&#10;                                }&#10;                            }&#10;                        }"/>
+                </step>
+                <step>
+                    <p>要创建新端点，请按照下文所示插入额外的路由：</p>
+                    <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        // ...&#10;&#10;        get(&quot;/test1&quot;) {&#10;            val text = &quot;&lt;h1&gt;Hello From Ktor&lt;/h1&gt;&quot;&#10;            val type = ContentType.parse(&quot;text/html&quot;)&#10;            call.respondText(text, type)&#10;        }&#10;    }&#10;}"/>
+                    <note>请注意，您可以根据需要将 <code>/test1</code> URL 更改为任何您喜欢的名称。</note>
+                </step>
+                <step>
+                    <p>IDE 会自动添加 <code>ContentType</code> 的导入：</p>
+                    <code-block lang="kotlin" code="                        import io.ktor.http.ContentType"/>
+                </step>
+                <step>
+                    <p>点击重新运行按钮（<img alt="IntelliJ IDEA 重新运行按钮图标"
+                                                       src="intellij_idea_rerun_icon.svg" height="16" width="16"/>）以重新启动应用程序。</p>
+                </step>
+                <step>
+                    <p>在浏览器中请求新的 URL（<a href="http://0.0.0.0:9292/test1">http://0.0.0.0:9292/test1</a>）。端口号取决于您是否完成了 <a href="#change-the-default-port">更改默认端口</a> 任务。您应该看到如下所示的输出：</p>
+                    <img src="server_get_started_add_new_http_endpoint_output.png"
+                         alt="显示 Hello from Ktor 的浏览器屏幕" width="706"/>
+                    <p>如果您创建了 HTTP 请求文件，也可以在其中验证新端点：</p>
+                    <code-block lang="http" code="                    GET http://0.0.0.0:9292&#10;&#10;                    ###&#10;&#10;                    GET http://0.0.0.0:9292/test1"/>
+                    <note>请注意，需要包含三个井号（<code>###</code>）的一行来分隔不同的请求。</note>
+                </step>
+            </procedure>
+        </chapter>
+        <chapter title="配置静态内容" id="configure-static-content">
+            <p>在
+                <ui-path>Project</ui-path>
+                工具窗口中，导航到
+                <Path>src/main/kotlin</Path>
+                文件夹并按照以下步骤操作：
+            </p>
+            <procedure>
+                <step>
+                    <p>打开 <Path>Routing.kt</Path> 文件并在路由部分添加以下路由：</p>
+                    <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        staticResources(&quot;/content&quot;, &quot;mycontent&quot;)&#10;        // ...&#10;    }&#10;}"/>
+                    <p>这一行的含义如下：</p>
+                    <list type="bullet">
+                        <li>调用 <code>staticResources()</code> 使您的应用程序能够提供标准网站内容，例如 HTML 和 JavaScript 文件。虽然这些内容可以在浏览器中执行，但从服务器的角度来看，它们被认为是静态的。
+                        </li>
+                        <li>URL <code>/content</code> 指定了用于获取此路径的路径。
+                        </li>
+                        <li>路径 <code>mycontent</code> 是静态内容所在的文件夹名称。Ktor 将在 <code>resources</code> 目录中查找此文件夹。
+                        </li>
+                    </list>
+                </step>
+                <step>
+                    <p>如果 IDE 没有自动添加，请添加以下导入。</p>
+                    <code-block lang="kotlin" code="                        import io.ktor.server.http.content.staticResources"/>
+                </step>
+                <step>
+                    <p>在
+                        <control>Project</control>
+                        工具窗口中，右键点击 <Path>src/main/resources</Path> 文件夹并选择
+                        <control>New | Directory</control>。
+                    </p>
+                    <p>或者，选择 <Path>src/main/resources</Path> 文件夹，按
+                        <shortcut>⌘Cmd+N</shortcut> (macOS) 或 <shortcut>Ctrl+N</shortcut> (Windows/Linux) 并点击
+                        <control>Directory</control>。
+                    </p>
+                </step>
+                <step>
+                    <p>将新目录命名为 <code>mycontent</code> 并按
+                        <shortcut>↩Enter</shortcut>。
+                    </p>
+                </step>
+                <step>
+                    <p>右键点击新创建的文件夹并点击
+                        <control>New | File</control>。
+                    </p>
+                </step>
+                <step>
+                    <p>将新文件命名为 <Path>sample.html</Path> 并按
+                        <shortcut>↩Enter</shortcut>。
+                    </p>
+                </step>
+                <step>
+                    <p>在新创建的文件中填充有效的 HTML，例如：</p>
+                    <code-block lang="html" code="&lt;html lang=&quot;en&quot;&gt;&#10;    &lt;head&gt;&#10;        &lt;meta charset=&quot;UTF-8&quot; /&gt;&#10;        &lt;title&gt;My sample&lt;/title&gt;&#10;    &lt;/head&gt;&#10;    &lt;body&gt;&#10;        &lt;h1&gt;This page is built with:&lt;/h1&gt;&#10;        &lt;ol&gt;&#10;            &lt;li&gt;Ktor&lt;/li&gt;&#10;            &lt;li&gt;Kotlin&lt;/li&gt;&#10;            &lt;li&gt;HTML&lt;/li&gt;&#10;        &lt;/ol&gt;&#10;    &lt;/body&gt;&#10;&lt;/html&gt;"/>
+                </step>
+                <step>
+                    <p>点击重新运行按钮（<img alt="IntelliJ IDEA 重新运行按钮图标"
+                                                       src="intellij_idea_rerun_icon.svg" height="16" width="16"/>）以重新启动应用程序。</p>
+                </step>
+                <step>
+                    <p>当您在浏览器中打开 <a href="http://0.0.0.0:9292/content/sample.html">http://0.0.0.0:9292/content/sample.html</a> 时，应显示示例页面的内容：</p>
+                    <img src="server_get_started_configure_static_content_output.png"
+                         alt="浏览器中静态页面的输出" width="706"/>
+                </step>
+            </procedure>
+        </chapter>
+        <chapter title="编写集成测试" id="write-an-integration-test">
+            <p>
+                Ktor 支持 <Links href="//server-testing" summary="了解如何使用特殊的测试引擎测试服务器应用程序。">创建集成测试</Links>，并且您生成的项目中已捆绑了此功能。
+            </p>
+            <p>要利用此功能，请按照以下步骤操作：</p>
+            <procedure>
+                <step>
+                    <p>
+                        导航至
+                        <Path>src/test/kotlin</Path>
+                        文件夹。
+                    </p>
+                </step>
+                <step>
+                    <p>打开 <Path>ServerTest.kt</Path> 文件。您应该看到以下代码：</p>
+                    <code-block lang="kotlin" code="class ServerTest {&#10;&#10;    @Test&#10;    fun `test root endpoint`() = testApplication {&#10;        // loads default configuration&#10;        configure()&#10;        // verify server root returns 200&#10;        assertEquals(HttpStatusCode.OK, client.get(&quot;/&quot;).status)&#10;    }&#10;&#10;}"/>
+                    <p><code>testApplication()</code> 函数创建一个新的 Ktor 实例。该实例运行在测试环境中，而不是像 Netty 这样的服务器中。</p>
+                    <p>然后您可以使用 <code>configure()</code> 函数来调用与 <code>embeddedServer()</code> 中调用的相同的设置。</p>
+                    <p>最后，您可以使用内置的 <code>client</code> 对象和 JUnit 断言来发送示例请求并检查响应。</p>
+                </step>
+            </procedure>
+            <p>
+                您可以使用在 IntelliJ IDEA 中执行测试的任何标准方式运行测试。请注意，因为您正在运行一个新的 Ktor 实例，所以测试的成功或失败并不取决于您的应用程序是否正在 <code>0.0.0.0</code> 运行。
+            </p>
+            <p>
+                如果您已成功完成了 <a href="#add-a-new-http-endpoint">添加新的 HTTP 端点</a>，请添加此额外测试：
+            </p>
+            <code-block lang="kotlin" code="    @Test&#10;    fun `test new endpoint`() = testApplication {&#10;        configure()&#10;&#10;        val response = client.get(&quot;/test1&quot;)&#10;&#10;        assertEquals(HttpStatusCode.OK, response.status)&#10;        assertEquals(&quot;html&quot;, response.contentType()?.contentSubtype)&#10;        assertContains(response.bodyAsText(), &quot;Hello From Ktor&quot;)&#10;    }"/>
+            <p>添加以下额外的导入：</p>
+            <code-block lang="Kotlin" code="                import io.ktor.http.contentType&#10;                import io.ktor.client.statement.bodyAsText"/>
+        </chapter>
+        <chapter title="注册错误处理程序" id="register-error-handlers">
+            <p>
+                您可以使用 <Links href="//server-status-pages" summary="StatusPages 允许 Ktor 应用程序根据抛出的异常或状态码适当地响应任何失败状态。">StatusPages 插件</Links> 在 Ktor 应用程序中处理错误。
+            </p>
+            <tip>
+                默认情况下，您的项目中不包含此插件。您可以在使用 Ktor 项目生成器或 IntelliJ IDEA 中的项目向导创建项目时，通过 <ui-path>Plugins</ui-path> 部分将其添加到您的项目中。
+            </tip>
+            <p>
+                在接下来的步骤中，您将学习如何手动添加和配置该插件。实现此目标共有四个步骤：
+            </p>
+            <list type="decimal">
+                <li><a href="#add-dependency">在 Gradle 构建文件中添加新依赖项。</a></li>
+                <li><a href="#install-plugin-and-specify-handler">安装插件并指定异常处理程序。</a></li>
+                <li><a href="#write-sample-code">编写示例代码来触发处理程序。</a></li>
+                <li><a href="#restart-and-invoke">重新启动并调用示例代码。</a></li>
+            </list>
+            <procedure title="添加新依赖项" id="add-dependency">
+                <p>在
+                    <control>Project</control>
+                    工具窗口中，导航到项目根文件夹并按照以下步骤操作：
+                </p>
+                <step>
+                    <p>打开 <Path>build.gradle.kts</Path> 文件并按下文所示添加新依赖项：</p>
+                    <code-block lang="kotlin" code="dependencies {&#10;    implementation(ktorLibs.server.config.yaml)&#10;    implementation(ktorLibs.server.core)&#10;    implementation(ktorLibs.server.netty)&#10;    // 添加新依赖项&#10;    implementation(ktorLibs.server.statusPages)&#10;    implementation(libs.logback.classic)&#10;&#10;    testImplementation(kotlin(&quot;test&quot;))&#10;    testImplementation(ktorLibs.server.testHost)&#10;}"/>
+                </step>
+                <step>
+                    <p>通过按
+                        <shortcut>Shift+⌘Cmd+I</shortcut> (macOS) 或
+                        <shortcut>Ctrl+Shift+O</shortcut> (Windows/Linux) 重新加载项目。
+                    </p>
+                </step>
+            </procedure>
+            <procedure title="安装插件并指定异常处理程序"
+                       id="install-plugin-and-specify-handler">
+                <step>
+                    <p>导航到 <Path>Routing.kt</Path> 中的 <code>.configureRouting()</code> 方法并添加以下代码行：</p>
+                    <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    install(StatusPages) {&#10;        exception&lt;IllegalStateException&gt; { call, cause -&gt;&#10;            call.respondText(&quot;App in illegal state as ${cause.message}&quot;)&#10;        }&#10;    }&#10;    routing {&#10;        // ...&#10;    }&#10;}"/>
+                    <p>这些行安装了 <code>StatusPages</code> 插件，并指定了当抛出 <code>IllegalStateException</code> 类型的异常时应采取的操作。</p>
+                </step>
+                <step>
+                    <p>添加以下导入：</p>
+                    <code-block lang="kotlin" code="                        import io.ktor.server.plugins.statuspages.StatusPages"/>
+                </step>
+            </procedure>
+            <p>
+                请注意，响应中通常会设置 HTTP 错误码，但出于本任务的目的，输出直接显示在浏览器中。
+            </p>
+            <procedure title="编写示例代码来触发处理程序" id="write-sample-code">
+                <step>
+                    <p>继续在 <code>.configureRouting()</code> 方法中，按下文所示添加额外的路由：</p>
+                    <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    install(StatusPages) {&#10;        exception&lt;IllegalStateException&gt; { call, cause -&gt;&#10;            call.respondText(&quot;App in illegal state as ${cause.message}&quot;)&#10;        }&#10;    }&#10;    routing {&#10;        // ...&#10;&#10;        get(&quot;/error-test&quot;) {&#10;            throw IllegalStateException(&quot;Too Busy&quot;)&#10;        }&#10;    }&#10;}"/>
+                    <p>您现在已添加了一个 URL 为 <code>/error-test</code> 的端点。当触发此端点时，将抛出处理程序中使用的类型的异常。</p>
+                </step>
+            </procedure>
+            <procedure title="重新启动并调用示例代码" id="restart-and-invoke">
+                <step>
+                    <p>点击重新运行按钮（<img alt="IntelliJ IDEA 重新运行按钮图标"
+                                                       src="intellij_idea_rerun_icon.svg" height="16" width="16"/>）以重新启动应用程序。</p></step>
+                <step>
+                    <p>在浏览器中，导航至 URL <a href="http://0.0.0.0:9292/error-test">http://0.0.0.0:9292/error-test</a>。您应该看到如下所示的错误消息：</p>
+                    <img src="server_get_started_register_error_handler_output.png"
+                         alt="显示消息 `App in illegal state as Too Busy` 的浏览器屏幕" width="706"/>
+                </step>
+            </procedure>
+        </chapter>
+    </chapter>
+    <chapter title="下一步" id="next_steps">
+        <p>
+            如果您已经完成了上述附加任务，那么您现在已经掌握了如何配置 Ktor 服务器、集成 Ktor 插件以及实现新路由。然而，这仅仅是个开始。要更深入地了解 Ktor 的基础概念，请继续学习本指南中的下一个教程。
+        </p>
+        <p>
+            接下来，您将学习如何 <Links href="//server-requests-and-responses" summary="通过构建一个任务管理器应用程序，学习 Ktor 中关于路由、处理请求以及形参的基础知识。">通过创建一个任务管理器应用程序来处理请求并生成响应</Links>。
+        </p>
+    </chapter>
+</topic>

--- a/docs/ktor/server-create-and-configure.md
+++ b/docs/ktor/server-create-and-configure.md
@@ -1,0 +1,97 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="创建服务器"
+       id="server-create-and-configure" help-id="start_server;create_server">
+    <show-structure for="chapter" depth="2"/>
+    <tldr>
+        <p>
+            <b>代码示例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">embedded-server</a>、
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">engine-main</a>、
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-yaml">engine-main-yaml</a>
+        </p>
+    </tldr>
+    <link-summary>
+        了解如何根据应用部署需求创建服务器。
+    </link-summary>
+    <p>
+        在创建 Ktor 应用之前，您需要考虑应用将如何<Links href="//server-deployment" summary="">部署</Links>：
+    </p>
+    <list>
+        <li>
+            <p>
+                作为<control><a href="#embedded">自包含包</a></control>
+            </p>
+            <p>
+                在此情况下，用于处理网络请求的应用<Links href="//server-engines" summary="了解处理网络请求的引擎。">引擎</Links>应该是应用的一部分。您的应用可以控制引擎设置、连接和 SSL 选项。
+            </p>
+        </li>
+        <li>
+            <p>
+                作为
+                <control>
+                    <a href="#servlet">servlet</a>
+                </control>
+            </p>
+            <p>
+                在此情况下，Ktor 应用可以部署在 servlet 容器（如 Tomcat 或 Jetty）中，容器负责控制应用的生命周期和连接设置。
+            </p>
+        </li>
+    </list>
+    <chapter title="自包含包" id="embedded">
+        <p>
+            要将 Ktor 服务器应用作为自包含包交付，您首先需要创建一个服务器。服务器配置可以包含不同的设置：服务器<Links href="//server-engines" summary="了解处理网络请求的引擎。">引擎</Links>（如 Netty、Jetty 等）、各种特定于引擎的选项、主机和端口值等。在 Ktor 中，创建和运行服务器有两种主要方法：
+        </p>
+        <list>
+            <li>
+                <p>
+                    <code>embeddedServer</code>函数是在<a href="#embedded-server">代码中配置服务器参数</a>并快速运行应用的简单方法。
+                </p>
+            </li>
+            <li>
+                <p>
+                    <code>EngineMain</code>提供了更灵活的服务器配置方式。您可以在<a href="#engine-main">文件中指定服务器参数</a>，并在无需重新编译应用的情况下更改配置。此外，您可以从命令行运行应用，并通过传递相应的命令行实参来覆盖所需的服务器参数。
+                </p>
+            </li>
+        </list>
+        <chapter title="在代码中配置" id="embedded-server">
+            <p>
+                <code>embeddedServer</code>函数是在<Links href="//server-configuration-code" summary="了解如何在代码中配置各种服务器参数。">代码</Links>中配置服务器参数并快速运行应用的简单方法。在下面的代码片段中，它接受<code>引擎</code>和端口作为形参来启动服务器。在以下示例中，我们使用<code>Netty</code>引擎运行服务器并侦听<code>8080</code>端口：
+            </p>
+            <code-block lang="kotlin" code="package com.example&#10;&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    if (args.isEmpty()) {&#10;        println(&quot;Running basic server...&quot;)&#10;        println(&quot;Provide the 'configured' argument to run a configured server.&quot;)&#10;        runBasicServer()&#10;    }&#10;&#10;    when (args[0]) {&#10;        &quot;basic&quot; -&gt; runBasicServer()&#10;        &quot;configured&quot; -&gt; runConfiguredServer()&#10;        else -&gt; runServerWithCommandLineConfig(args)&#10;    }&#10;}&#10;&#10;fun runBasicServer() {&#10;    embeddedServer(Netty, port = 8080) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}&#10;&#10;fun runConfiguredServer() {&#10;    embeddedServer(Netty, configure = {&#10;        connectors.add(EngineConnectorBuilder().apply {&#10;            host = &quot;127.0.0.1&quot;&#10;            port = 8080&#10;        })&#10;        connectionGroupSize = 2&#10;        workerGroupSize = 5&#10;        callGroupSize = 10&#10;        shutdownGracePeriod = 2000&#10;        shutdownTimeout = 3000&#10;    }) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}&#10;&#10;fun runServerWithCommandLineConfig(args: Array&lt;String&gt;) {&#10;    embeddedServer(&#10;        factory = Netty,&#10;        configure = {&#10;            val cliConfig = CommandLineConfig(args)&#10;            takeFrom(cliConfig.engineConfig)&#10;            loadCommonConfiguration(cliConfig.rootConfig.environment.config)&#10;        }&#10;    ) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+            <p>
+                有关完整示例，请参阅<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">embedded-server</a>。
+            </p>
+        </chapter>
+        <chapter title="在文件中配置" id="engine-main">
+            <p>
+                <code>EngineMain</code>启动带有选定引擎的服务器，并从外部<Links href="//server-configuration-file" summary="了解如何在配置文件中配置各种服务器参数。">配置文件</Links>（通常是位于<code>resource</code>目录中的<Path>application.conf</Path>或<Path>application.yaml</Path>）中加载<Links href="//server-modules" summary="模块允许您通过对路由进行分组来构建应用结构。">应用模块</Links>。
+            </p>
+            <p>
+                除了指定要加载的模块外，配置文件还可以包含各种服务器参数，例如端口、主机和 SSL 设置。例如，下面的配置将服务器端口设置为<code>8080</code>。
+            </p>
+            <Tabs>
+                <TabItem title="Application.kt" id="application-kt">
+                    <code-block lang="kotlin" code="package com.example&#10;&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit = io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, world!&quot;)&#10;        }&#10;    }&#10;}"/>
+                </TabItem>
+                <TabItem title="application.conf" id="application-conf">
+                    <code-block code="ktor {&#10;    deployment {&#10;        port = 8080&#10;    }&#10;    application {&#10;        modules = [ com.example.ApplicationKt.module ]&#10;    }&#10;}"/>
+                </TabItem>
+                <TabItem title="application.yaml" id="application-yaml">
+                    <code-block lang="yaml" code="ktor:&#10;    deployment:&#10;        port: 8080&#10;    application:&#10;        modules:&#10;            - com.example.ApplicationKt.module"/>
+                </TabItem>
+            </Tabs>
+            <note>
+                除了直接使用<code>EngineMain.main()</code>启动服务器外，您还可以使用<code>EngineMain.createServer()</code>手动创建服务器实例。要了解更多信息，请参阅<a href="#createServer"></a>。
+            </note>
+            <p>
+                有关完整示例，请参阅<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">engine-main</a>和<a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-yaml">engine-main-yaml</a>。
+            </p>
+        </chapter>
+    </chapter>
+    <chapter title="Servlet" id="servlet">
+        <p>
+            Ktor 应用可以在包含 Tomcat 和 Jetty 在内的 servlet 容器中运行和部署。要部署在 servlet 容器中，您需要生成<Links href="//server-war" summary="了解如何使用 WAR 归档文件在 servlet 容器中运行和部署 Ktor 应用。">WAR</Links>归档文件，然后将其部署到支持 WAR 的服务器或云服务中。
+        </p>
+    </chapter>
+</topic>

--- a/docs/ktor/server-create-restful-apis.md
+++ b/docs/ktor/server-create-restful-apis.md
@@ -1,0 +1,603 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="如何使用 Ktor 在 Kotlin 中创建 RESTful API" id="server-create-restful-apis"
+       help-id="create-restful-apis">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <var name="example_name" value="tutorial-server-restful-api"/>
+    <p>
+        <b>代码示例</b>：
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+    <p>
+        <b>使用的插件</b>：<Links href="//server-routing" summary="Routing 是在服务器应用程序中处理传入请求的核心插件。">Routing</Links>、<Links href="//server-static-content" summary="了解如何提供静态内容，例如样式表、脚本、图像等。">静态内容</Links>、
+        <Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">内容协商</Links>、<a
+            href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>
+    </p>
+</tldr>
+<card-summary>
+    了解如何使用 Ktor 构建 RESTful API。本教程将通过一个实际示例介绍设置、路由和测试。
+</card-summary>
+<web-summary>
+    学习使用 Ktor 构建 Kotlin RESTful API。本教程通过一个实际示例介绍设置、路由和测试。这是 Kotlin 后端开发者的理想入门教程。
+</web-summary>
+<link-summary>
+    了解如何使用 Kotlin 和 Ktor 构建后端服务，其中包含一个生成 JSON 文件的 RESTful API 示例。
+</link-summary>
+<p>
+    在本教程中，我们将说明如何使用 Kotlin 和 Ktor 构建后端服务，并以一个生成 JSON 文件的 RESTful API 为例。
+</p>
+<p>
+    在<Links href="//server-requests-and-responses" summary="通过构建任务管理器应用程序，学习在 Kotlin 中使用 Ktor 进行路由、处理请求和参数的基础知识。">上一篇教程</Links>中，我们向您介绍了校验、错误处理和单元测试的基础知识。本教程将通过创建一个用于管理任务的 RESTful 服务来扩展这些主题。
+</p>
+<p>
+    您将学习如何执行以下操作：
+</p>
+<list>
+    <li>创建使用 JSON 序列化的 RESTful 服务。</li>
+    <li>理解<Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">内容协商</Links>的过程。</li>
+    <li>在 Ktor 中为 REST API 定义路由。</li>
+</list>
+<chapter title="前提条件" id="prerequisites">
+    <p>您可以独立完成本教程，但我们强烈建议您先完成上一篇教程，以学习如何<Links href="//server-requests-and-responses" summary="通过构建任务管理器应用程序，学习在 Kotlin 中使用 Ktor 进行路由、处理请求和参数的基础知识。">处理请求和生成响应</Links>。
+    </p>
+    <p>我们建议您安装 <a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA</a>，但您也可以使用其他自选 IDE。
+    </p>
+</chapter>
+<chapter title="你好，RESTful 任务管理器" id="hello-restful-task-manager">
+    <p>在本教程中，您将把现有的任务管理器重写为 RESTful 服务。为此，您将使用多个 Ktor <Links href="//server-plugins" summary="插件提供常用功能，如序列化、内容编码、压缩等。">插件</Links>。</p>
+    <p>
+        虽然您可以手动将其添加到现有项目中，但生成一个新项目然后逐步添加上一篇教程中的代码会更简单。您将在过程中重新编写所有代码，因此无需手头备有之前的项目。
+    </p>
+    <procedure title="使用插件创建一个新项目">
+        <step>
+            <p>
+                导航至
+                <a href="https://start.ktor.io/">Ktor 项目生成器</a>。
+            </p>
+        </step>
+        <step>
+            <p>在
+                <control>Project artifact</control>
+                字段中，输入
+                <Path>com.example.ktor-rest-task-app</Path>
+                作为项目构件的名称。
+                <img src="tutorial_creating_restful_apis_project_artifact.png"
+                     alt="在 Ktor 项目生成器中命名项目构件"
+                     style="block"
+                     border-effect="line"
+                     width="706"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                在插件部分搜索并通过点击
+                <control>Add</control>
+                按钮添加以下插件：
+            </p>
+            <list type="bullet">
+                <li>Content Negotiation</li>
+                <li>kotlinx.serialization</li>
+                <li>Static Content</li>
+            </list>
+            <p>
+                <img src="ktor_project_generator_add_plugins.gif" alt="在 Ktor 项目生成器中添加插件"
+                     border-effect="line"
+                     style="block"
+                     width="706"/>
+                添加插件后，您将看到项目设置下方列出的所有插件。
+                <img src="tutorial_creating_restful_apis_plugins_list.png"
+                     alt="Ktor 项目生成器中的插件列表"
+                     border-effect="line"
+                     style="block"
+                     width="706"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                点击
+                <control>Download</control>
+                按钮生成并下载您的 Ktor 项目。
+            </p>
+        </step>
+    </procedure>
+    <procedure title="添加初始代码" id="add-starter-code">
+        <step>
+            <p>在 IntelliJ IDEA 中打开您的项目，如之前的<a href="server-create-a-new-project.topic#open-explore-run">在 IntelliJ IDEA 中打开、探索并运行您的 Ktor 项目</a>教程中所述。</p>
+        </step>
+        <step>
+            <p>
+                导航至
+                <Path>src/main/kotlin</Path>
+                并创建一个名为
+                <Path>model</Path>
+                的子包。
+            </p>
+        </step>
+        <step>
+            <p>
+                在
+                <Path>model</Path>
+                包中，创建一个新的
+                <Path>Task.kt</Path>
+                文件。
+            </p>
+        </step>
+        <step>
+            <p>
+                打开
+                <Path>Task.kt</Path>
+                文件，并添加一个 <code>enum</code> 来表示优先级，以及一个 <code>class</code> 来表示任务：
+            </p>
+            <code-block lang="kotlin" code="package com.example.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+            <p>
+                在上一篇教程中，您使用了扩展函数将 <code>Task</code> 转换为 HTML。在本例中，
+                <code>Task</code> 类被标注了来自
+                <code>kotlinx.serialization</code> 库的 <a
+                    href="https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-serializable/"><code>Serializable</code></a>
+                类型。
+            </p>
+        </step>
+        <step>
+            <p>
+                打开
+                <Path>Routing.kt</Path>
+                文件，并将现有代码替换为以下实现：
+            </p>
+            <code-block lang="kotlin" code="                    package com.example&#10;&#10;                    import com.example.model.*&#10;                    import io.ktor.server.application.*&#10;                    import io.ktor.server.http.content.*&#10;                    import io.ktor.server.response.*&#10;                    import io.ktor.server.routing.*&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            staticResources(&quot;static&quot;, &quot;static&quot;)&#10;&#10;                            get(&quot;/tasks&quot;) {&#10;                                call.respond(&#10;                                    listOf(&#10;                                        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                                        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                                        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                                        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;                                    )&#10;                                )&#10;                            }&#10;                        }&#10;                    }"/>
+            <p>
+                与上一篇教程类似，您为指向 URL <code>/tasks</code> 的 GET 请求创建了一个路由。这次，您无需手动转换任务列表，而是直接返回该列表。
+            </p>
+        </step>
+        <step>
+            <p>在 IntelliJ IDEA 中，点击运行按钮
+                （<img src="intellij_idea_gutter_icon.svg"
+                      style="inline" height="16" width="16"
+                      alt="IntelliJ IDEA 运行图标"/>）
+                以启动应用程序。</p>
+        </step>
+        <step>
+            <p>
+                在浏览器中导航至 <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a>。您应该会看到 JSON 版本的任务列表，如下所示：
+            </p>
+        </step>
+        <img src="tutorial_creating_restful_apis_starter_code_preview.png"
+             alt="浏览器屏幕中显示的 JSON 数据"
+             border-effect="rounded"
+             width="706"/>
+        <p>显然，系统已经为我们完成了大量工作。这背后的机制究竟是什么？</p>
+    </procedure>
+</chapter>
+<chapter title="理解内容协商" id="content-negotiation">
+    <chapter title="通过浏览器进行内容协商" id="via-browser">
+        <p>
+            当您创建项目时，已经包含了 <Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">内容协商</Links>
+            插件。该插件会查看客户端可以渲染的内容类型，并将这些类型与当前服务可以提供的内容类型进行匹配。因此，术语为
+            <format style="italic">内容协商</format>。
+        </p>
+        <p>
+            在 HTTP 中，客户端通过 <code>Accept</code> 标头告知其可以渲染的内容类型。该标头的值是一个或多个内容类型。在上述示例中，您可以使用浏览器内置的开发者工具来检查此标头的值。
+        </p>
+        <p>
+            请看以下示例：
+        </p>
+        <code-block code="                text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"/>
+        <p>请注意 <code>&#42;/&#42;</code> 的包含。此标头表明它接受 HTML、XML 或图像——但它也接受任何其他内容类型。</p>
+        <p>内容协商插件需要找到一种格式将数据发送回浏览器。如果您查看项目中生成的代码，会在
+            <Path>src/main/kotlin</Path>
+            内找到一个名为
+            <Path>Serialization.kt</Path>
+            的文件，其中包含以下内容：
+        </p>
+        <code-block lang="kotlin" code="fun Application.configureSerialization() {&#10;    install(ContentNegotiation) {&#10;        json()&#10;    }&#10;}"/>
+        <p>
+            此代码安装了 <code>ContentNegotiation</code> 插件，并配置了 <code>kotlinx.serialization</code> 插件。有了这个配置，当客户端发送请求时，服务器可以发回被序列化为 JSON 的对象。
+        </p>
+        <p>
+            在来自浏览器的请求中，<code>ContentNegotiation</code> 插件知道它只能返回 JSON，而浏览器会尝试显示发送给它的任何内容。因此请求成功。
+        </p>
+    </chapter>
+    <procedure title="通过 JavaScript 进行内容协商" id="via-javascript">
+        <p>
+            在生产环境中，您通常不会直接在浏览器中显示 JSON。相反，在浏览器中运行的 JavaScript 代码会发出请求，然后将返回的数据作为单页应用程序 (SPA) 的一部分进行显示。通常，此类应用程序是使用 <a href="https://react.dev/">React</a>、<a href="https://angular.io/">Angular</a> 或 <a href="https://vuejs.org/">Vue.js</a> 等框架编写的。
+        </p>
+        <step>
+            <p>
+                为了模拟这一点，请打开
+                <Path>src/main/resources/static</Path>
+                内的
+                <Path>index.html</Path>
+                页面，并将默认内容替换为以下内容：
+            </p>
+            <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;A Simple SPA For Tasks&lt;/title&gt;&#10;    &lt;script type=&quot;application/javascript&quot;&gt;&#10;        function fetchAndDisplayTasks() {&#10;            fetchTasks()&#10;                .then(tasks =&gt; displayTasks(tasks))&#10;        }&#10;&#10;        function fetchTasks() {&#10;            return fetch(&#10;                &quot;/tasks&quot;,&#10;                {&#10;                    headers: { 'Accept': 'application/json' }&#10;                }&#10;            ).then(resp =&gt; resp.json());&#10;        }&#10;&#10;        function displayTasks(tasks) {&#10;            const tasksTableBody = document.getElementById(&quot;tasksTableBody&quot;)&#10;            tasks.forEach(task =&gt; {&#10;                const newRow = taskRow(task);&#10;                tasksTableBody.appendChild(newRow);&#10;            });&#10;        }&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Viewing Tasks Via JS&lt;/h1&gt;&#10;&lt;form action=&quot;javascript:fetchAndDisplayTasks()&quot;&gt;&#10;    &lt;input type=&quot;submit&quot; value=&quot;View The Tasks&quot;&gt;&#10;&lt;/form&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            <p>
+                此页面包含一个 HTML 表单和一个空表格。提交表单后，JavaScript 事件处理程序会向 <code>/tasks</code> 端点发送请求，并将 <code>Accept</code> 标头设置为 <code>application/json</code>。然后，返回的数据将被反序列化并添加到 HTML 表格中。
+            </p>
+        </step>
+        <step>
+            <p>
+                在 IntelliJ IDEA 中，点击重新运行按钮（<img src="intellij_idea_rerun_icon.svg"
+                                                               style="inline" height="16" width="16"
+                                                               alt="IntelliJ IDEA 重新运行图标"/>）以重启应用程序。
+            </p>
+        </step>
+        <step>
+            <p>
+                导航至 URL <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a>。您应该可以通过点击
+                <control>View The Tasks</control>
+                按钮来获取数据：
+            </p>
+            <img src="tutorial_creating_restful_apis_tasks_via_js.png"
+                 alt="显示按钮和任务以 HTML 表格形式展示的浏览器窗口"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="添加 GET 路由" id="porting-get-routes">
+    <p>
+        现在您已经熟悉了内容协商的过程，请继续将<Links href="//server-requests-and-responses" summary="通过构建任务管理器应用程序，学习在 Kotlin 中使用 Ktor 进行路由、处理请求和参数的基础知识。">上一篇教程</Links>中的功能转移到本教程中。
+    </p>
+    <chapter title="重用任务仓库" id="task-repository">
+        <p>
+            您可以无需任何修改地重用任务仓库，所以我们先来完成这一步。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    在
+                    <Path>model</Path>
+                    包中创建一个新的
+                    <Path>TaskRepository.kt</Path>
+                    文件。
+                </p>
+            </step>
+            <step>
+                <p>
+                    打开
+                    <Path>TaskRepository.kt</Path>
+                    并添加以下代码：
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&#10;        tasks.add(task)&#10;    }&#10;}"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="重用 GET 请求的路由" id="get-requests">
+        <p>
+            现在您已经创建了仓库，可以实现 GET 请求的路由。之前的代码可以简化，因为您不再需要担心将任务转换为 HTML 的问题：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    导航至
+                    <Path>src/main/kotlin</Path>
+                    中的
+                    <Path>Routing.kt</Path>
+                    文件。
+                </p>
+            </step>
+            <step>
+                <p>
+                    使用以下实现更新 <code>Application.configureRouting()</code> 函数中 <code>/tasks</code> 路由的代码：
+                </p>
+                <code-block lang="kotlin" code="                    package com.example&#10;&#10;                    import com.example.model.Priority&#10;                    import com.example.model.TaskRepository&#10;                    import io.ktor.http.*&#10;                    import io.ktor.server.application.*&#10;                    import io.ktor.server.http.content.*&#10;                    import io.ktor.server.response.*&#10;                    import io.ktor.server.routing.*&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            staticResources(&quot;static&quot;, &quot;static&quot;)&#10;&#10;                            // 更新后的实现&#10;                            route(&quot;/tasks&quot;) {&#10;                                get {&#10;                                    val tasks = TaskRepository.allTasks()&#10;                                    call.respond(tasks)&#10;                                }&#10;&#10;                                get(&quot;/byName/{taskName}&quot;) {&#10;                                    val name = call.parameters[&quot;taskName&quot;]&#10;                                    if (name == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@get&#10;                                    }&#10;&#10;                                    val task = TaskRepository.taskByName(name)&#10;                                    if (task == null) {&#10;                                        call.respond(HttpStatusCode.NotFound)&#10;                                        return@get&#10;                                    }&#10;                                    call.respond(task)&#10;                                }&#10;                                get(&quot;/byPriority/{priority}&quot;) {&#10;                                    val priorityAsText = call.parameters[&quot;priority&quot;]&#10;                                    if (priorityAsText == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@get&#10;                                    }&#10;                                    try {&#10;                                        val priority = Priority.valueOf(priorityAsText)&#10;                                        val tasks = TaskRepository.tasksByPriority(priority)&#10;&#10;                                        if (tasks.isEmpty()) {&#10;                                            call.respond(HttpStatusCode.NotFound)&#10;                                            return@get&#10;                                        }&#10;                                        call.respond(tasks)&#10;                                    } catch (ex: IllegalArgumentException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+                <p>
+                    有了这些，您的服务器就可以响应以下 GET 请求：</p>
+                <list>
+                    <li><code>/tasks</code> 返回仓库中的所有任务。</li>
+                    <li><code>/tasks/byName/{taskName}</code> 返回按指定的 <code>taskName</code> 过滤的任务。
+                    </li>
+                    <li><code>/tasks/byPriority/{priority}</code> 返回按指定的 <code>priority</code> 过滤的任务。
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，点击重新运行按钮（<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 重新运行图标"/>）以重启应用程序。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="测试功能" id="test-tasks-routes">
+        <procedure title="使用浏览器">
+            <p>您可以在浏览器中测试这些路由。例如，导航至 <a
+                    href="http://0.0.0.0:8080/tasks/byPriority/Medium">http://0.0.0.0:8080/tasks/byPriority/Medium</a>，即可看到所有以 JSON 格式显示的 <code>Medium</code> 优先级任务：</p>
+            <img src="tutorial_creating_restful_apis_tasks_medium_priority.png"
+                 alt="显示 JSON 格式的中等优先级任务的浏览器窗口"
+                 border-effect="rounded"
+                 width="706"/>
+            <p>
+                鉴于此类请求通常来自 JavaScript，因此采用更精细的测试方式更为理想。为此，您可以使用诸如 <a
+                    href="https://learning.postman.com/docs/sending-requests/requests/">Postman</a> 之类的专门工具。
+            </p>
+        </procedure>
+        <procedure title="使用 Postman">
+            <step>
+                <p>在 Postman 中，创建一个 URL 为 <code>http://0.0.0.0:8080/tasks/byPriority/Medium</code> 的新 GET 请求。</p>
+            </step>
+            <step>
+                <p>
+                    在
+                    <ui-path>Headers</ui-path>
+                    面板中，将
+                    <ui-path>Accept</ui-path>
+                    标头的值设置为 <code>application/json</code>。
+                </p>
+            </step>
+            <step>
+                <p>点击
+                    <control>Send</control>
+                    发送请求并在响应查看器中查看结果。
+                </p>
+                <img src="tutorial_creating_restful_apis_tasks_medium_priority_postman.png"
+                     alt="Postman 中的 GET 请求显示 JSON 格式的中等优先级任务"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+        <procedure title="使用 HTTP 请求文件">
+            <p>在 IntelliJ IDEA Ultimate 中，您可以在 HTTP 请求文件中执行相同的步骤。</p>
+            <step>
+                <p>
+                    在项目根目录中，创建一个新的
+                    <Path>REST Task Manager.http</Path>
+                    文件。
+                </p>
+            </step>
+            <step>
+                <p>
+                    打开
+                    <Path>REST Task Manager.http</Path>
+                    文件并添加以下 GET 请求：
+                </p>
+                <code-block lang="http" code="GET http://0.0.0.0:8080/tasks/byPriority/Medium&#10;Accept: application/json"/>
+            </step>
+            <step>
+                <p>
+                    要在 IntelliJ IDEA 中发送请求，点击它旁边的装订区域图标（<img
+                        alt="IntelliJ IDEA 装订区域图标"
+                        src="intellij_idea_gutter_icon.svg"
+                        width="16" height="26"/>）。
+                </p>
+            </step>
+            <step>
+                <p>这将在
+                    <Path>Services</Path>
+                    工具窗口中打开并运行：
+                </p>
+                <img src="tutorial_creating_restful_apis_tasks_medium_priority_http_file.png"
+                     alt="HTTP 文件中的 GET 请求显示 JSON 格式的中等优先级任务"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+        <note>
+            测试路由的另一种方法是在 Kotlin Notebook 中使用 <a
+                href="https://khttp.readthedocs.io/en/latest/">khttp</a> 库。
+        </note>
+    </chapter>
+</chapter>
+<chapter title="为 POST 请求添加路由" id="add-a-route-for-post-requests">
+    <p>
+        在上一篇教程中，任务是通过 HTML 表单创建的。然而，既然您现在正在构建 RESTful 服务，就不再需要那样做了。相反，您将利用 <code>kotlinx.serialization</code> 框架，它将完成大部分繁重的工作。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                打开
+                <Path>src/main/kotlin</Path>
+                内的
+                <Path>Routing.kt</Path>
+                文件。
+            </p>
+        </step>
+        <step>
+            <p>
+                向 <code>Application.configureRouting()</code> 函数添加一个新的 POST 路由，如下所示：
+            </p>
+            <code-block lang="kotlin" code="                    //...&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            //...&#10;&#10;                            route(&quot;/tasks&quot;) {&#10;                                //...&#10;&#10;                                // 添加以下新路由&#10;                                post {&#10;                                    try {&#10;                                        val task = call.receive&lt;Task&gt;()&#10;                                        TaskRepository.addTask(task)&#10;                                        call.respond(HttpStatusCode.Created)&#10;                                    } catch (ex: IllegalStateException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    } catch (ex: SerializationException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+            <p>
+                添加以下新导入：
+            </p>
+            <code-block lang="kotlin" code="                    //...&#10;                    import com.example.model.Task&#10;                    import io.ktor.server.request.receive&#10;                    import kotlinx.serialization.SerializationException"/>
+            <p>
+                当向 <code>/tasks</code> 发送 POST 请求时，<code>kotlinx.serialization</code> 框架被用于将请求体转换为 <code>Task</code> 对象。如果成功，任务将被添加到仓库中。如果反序列化过程失败，服务器将处理 <code>SerializationException</code>，而如果任务重复，则处理 <code>IllegalStateException</code>。
+            </p>
+        </step>
+        <step>
+            <p>
+                重启应用程序。
+            </p>
+        </step>
+        <step>
+            <p>
+                要在 Postman 中测试此功能，请创建一个指向 URL <code>http://0.0.0.0:8080/tasks</code> 的新 POST 请求。
+            </p>
+        </step>
+        <step>
+            <p>
+                在
+                <ui-path>Body</ui-path>
+                面板中，添加以下代表新任务的 JSON 文档：
+            </p>
+            <code-block lang="json" code="{&#10;    &quot;name&quot;: &quot;cooking&quot;,&#10;    &quot;description&quot;: &quot;Cook the dinner&quot;,&#10;    &quot;priority&quot;: &quot;High&quot;&#10;}"/>
+            <img src="tutorial_creating_restful_apis_add_task.png"
+                 alt="Postman 中用于添加新任务的 POST 请求"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+        <step>
+            <p>点击
+                <control>Send</control>
+                发送请求。
+            </p>
+        </step>
+        <step>
+            <p>
+                您可以通过向 <a
+                    href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a> 发送 GET 请求来验证任务是否已被添加。
+            </p>
+        </step>
+        <step>
+            <p>
+                在 IntelliJ IDEA Ultimate 中，您可以通过在 HTTP 请求文件中添加以下内容来执行相同的步骤：
+            </p>
+            <code-block lang="http" code="###&#10;&#10;POST http://0.0.0.0:8080/tasks&#10;Content-Type: application/json&#10;&#10;{&#10;    &quot;name&quot;: &quot;cooking&quot;,&#10;    &quot;description&quot;: &quot;Cook the dinner&quot;,&#10;    &quot;priority&quot;: &quot;High&quot;&#10;}"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="添加删除支持" id="remove-tasks">
+    <p>
+        您即将完成向服务添加基础操作的工作。这些操作通常被简称为 CRUD（创建、读取、更新和删除）操作。现在您将实现删除操作。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                在
+                <Path>TaskRepository.kt</Path>
+                文件中，在 <code>TaskRepository</code> 对象内添加以下方法以根据名称移除任务：
+            </p>
+            <code-block lang="kotlin" code="    fun removeTask(name: String): Boolean {&#10;        return tasks.removeIf { it.name == name }&#10;    }"/>
+        </step>
+        <step>
+            <p>
+                打开
+                <Path>Routing.kt</Path>
+                文件并在 <code>routing()</code> 函数中添加一个端点来处理 DELETE 请求：
+            </p>
+            <code-block lang="kotlin" code="                    fun Application.configureRouting() {&#10;                        //...&#10;&#10;                        routing {&#10;                            route(&quot;/tasks&quot;) {&#10;                                //...&#10;                                // 添加以下函数&#10;                                delete(&quot;/{taskName}&quot;) {&#10;                                    val name = call.parameters[&quot;taskName&quot;]&#10;                                    if (name == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@delete&#10;                                    }&#10;&#10;                                    if (TaskRepository.removeTask(name)) {&#10;                                        call.respond(HttpStatusCode.NoContent)&#10;                                    } else {&#10;                                        call.respond(HttpStatusCode.NotFound)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+        </step>
+        <step>
+            <p>
+                重启应用程序。
+            </p>
+        </step>
+        <step>
+            <p>
+                将以下 DELETE 请求添加到您的 HTTP 请求文件：
+            </p>
+            <code-block lang="http" code="###&#10;&#10;DELETE http://0.0.0.0:8080/tasks/gardening"/>
+        </step>
+        <step>
+            <p>
+                要在 IntelliJ IDEA 中发送 DELETE 请求，点击它旁边的装订区域图标（<img
+                    alt="IntelliJ IDEA 装订区域图标"
+                    src="intellij_idea_gutter_icon.svg"
+                    width="16" height="26"/>）。
+            </p>
+        </step>
+        <step>
+            <p>您将在
+                <Path>Services</Path>
+                工具窗口中看到响应：
+            </p>
+            <img src="tutorial_creating_restful_apis_delete_task.png"
+                 alt="HTTP 请求文件中的 DELETE 请求"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="使用 Ktor Client 创建单元测试" id="create-unit-tests">
+    <p>
+        到目前为止，您已经手动测试了应用程序，但如您所见，这种方法耗时且无法扩展。相反，您可以实现 <Links href="//server-testing" summary="学习如何使用特殊的测试引擎来测试服务器应用程序。">JUnit 测试</Links>，利用内置的 <code>client</code> 对象来获取并反序列化 JSON。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                打开
+                <Path>src/test/kotlin</Path>
+                内的
+                <Path>ServerTest.kt</Path>
+                文件。
+            </p>
+        </step>
+        <step>
+            <p>
+                将
+                <Path>ServerTest.kt</Path>
+                文件的内容替换为以下内容：
+            </p>
+            <code-block lang="kotlin" code="package com.example&#10;&#10;import com.example.model.Priority&#10;import com.example.model.Task&#10;import io.ktor.client.call.*&#10;import io.ktor.client.plugins.contentnegotiation.*&#10;import io.ktor.client.request.*&#10;import io.ktor.http.*&#10;import io.ktor.serialization.kotlinx.json.*&#10;import io.ktor.server.testing.*&#10;import kotlin.test.*&#10;&#10;class ApplicationTest {&#10;    @Test&#10;    fun tasksCanBeFoundByPriority() = testApplication {&#10;        configure()&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;        }&#10;&#10;        val response = client.get(&quot;/tasks/byPriority/Medium&quot;)&#10;        val results = response.body&lt;List&lt;Task&gt;&gt;()&#10;&#10;        assertEquals(HttpStatusCode.OK, response.status)&#10;&#10;        val expectedTaskNames = listOf(&quot;gardening&quot;, &quot;painting&quot;)&#10;        val actualTaskNames = results.map(Task::name)&#10;        assertContentEquals(expectedTaskNames, actualTaskNames)&#10;    }&#10;&#10;    @Test&#10;    fun invalidPriorityProduces400() = testApplication {&#10;        configure()&#10;        val response = client.get(&quot;/tasks/byPriority/Invalid&quot;)&#10;        assertEquals(HttpStatusCode.BadRequest, response.status)&#10;    }&#10;&#10;&#10;    @Test&#10;    fun unusedPriorityProduces404() = testApplication {&#10;        configure()&#10;        val response = client.get(&quot;/tasks/byPriority/Vital&quot;)&#10;        assertEquals(HttpStatusCode.NotFound, response.status)&#10;    }&#10;&#10;    @Test&#10;    fun newTasksCanBeAdded() = testApplication {&#10;        configure()&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;        }&#10;&#10;        val task = Task(&quot;swimming&quot;, &quot;Go to the beach&quot;, Priority.Low)&#10;        val response1 = client.post(&quot;/tasks&quot;) {&#10;            header(&#10;                HttpHeaders.ContentType,&#10;                ContentType.Application.Json&#10;            )&#10;&#10;            setBody(task)&#10;        }&#10;        assertEquals(HttpStatusCode.Created, response1.status)&#10;&#10;        val response2 = client.get(&quot;/tasks&quot;)&#10;        assertEquals(HttpStatusCode.OK, response2.status)&#10;&#10;        val taskNames = response2&#10;            .body&lt;List&lt;Task&gt;&gt;()&#10;            .map { it.name }&#10;&#10;        assertContains(taskNames, &quot;swimming&quot;)&#10;    }&#10;}"/>
+            <p>
+                请注意，您需要将 <code>ContentNegotiation</code> 和 <code>kotlinx.serialization</code> 插件安装到 <a href="client-create-and-configure.md#plugins">插件</a>中，方式与在服务器上相同。
+            </p>
+        </step>
+        <step>
+            <p>
+                在
+                <Path>build.gradle.kts</Path>
+                文件中添加以下依赖项：
+            </p>
+            <code-block lang="kotlin" code="                    testImplementation(ktorLibs.client.contentNegotiation)"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="使用 JsonPath 创建单元测试" id="unit-tests-via-jsonpath">
+    <p>
+        使用 Ktor client 或类似库测试服务非常方便，但从质量保证 (QA) 的角度来看，它也有一个缺点。服务器由于不直接处理 JSON，无法确定其关于 JSON 结构的假设是否正确。
+    </p>
+    <p>
+        例如，此类假设包括：
+    </p>
+    <list>
+        <li>值存储在 <code>array</code>（数组）中，而实际上使用了 <code>object</code>（对象）。</li>
+        <li>属性存储为 <code>numbers</code>（数字），而实际上是 <code>strings</code>（字符串）。</li>
+        <li>成员按照声明顺序序列化，而实际上并非如此。</li>
+    </list>
+    <p>
+        如果您的服务旨在供多个客户端使用，那么对 JSON 结构有信心至关重要。为此，请使用 Ktor Client 从服务器检索文本，然后使用 <a href="https://mvnrepository.com/artifact/com.jayway.jsonpath/json-path">JSONPath</a> 库分析此内容。</p>
+    <procedure>
+        <step>
+            <p>在您的
+                <Path>build.gradle.kts</Path>
+                文件的 <code>dependencies</code> 块中添加 JSONPath 库：
+            </p>
+            <code-block lang="kotlin" code="    testImplementation(&quot;com.jayway.jsonpath:json-path:2.9.0&quot;)"/>
+        </step>
+        <step>
+            <p>
+                导航至
+                <Path>src/test/kotlin</Path>
+                文件夹并创建一个新的
+                <Path>ApplicationJsonPathTest.kt</Path>
+                文件。
+            </p>
+        </step>
+        <step>
+            <p>
+                打开
+                <Path>ApplicationJsonPathTest.kt</Path>
+                文件并向其中添加以下内容：
+            </p>
+            <code-block lang="kotlin" code="package com.example&#10;&#10;import com.jayway.jsonpath.DocumentContext&#10;import com.jayway.jsonpath.JsonPath&#10;import io.ktor.client.*&#10;import com.example.model.Priority&#10;import io.ktor.client.request.*&#10;import io.ktor.client.statement.*&#10;import io.ktor.http.*&#10;import io.ktor.server.testing.*&#10;import kotlin.test.*&#10;&#10;&#10;class ApplicationJsonPathTest {&#10;    @Test&#10;    fun tasksCanBeFound() = testApplication {&#10;        configure()&#10;        val jsonDoc = client.getAsJsonPath(&quot;/tasks&quot;)&#10;&#10;        val result: List&lt;String&gt; = jsonDoc.read(&quot;$[*].name&quot;)&#10;        assertEquals(&quot;cleaning&quot;, result[0])&#10;        assertEquals(&quot;gardening&quot;, result[1])&#10;        assertEquals(&quot;shopping&quot;, result[2])&#10;    }&#10;&#10;    @Test&#10;    fun tasksCanBeFoundByPriority() = testApplication {&#10;        configure()&#10;        val priority = Priority.Medium&#10;        val jsonDoc = client.getAsJsonPath(&quot;/tasks/byPriority/$priority&quot;)&#10;&#10;        val result: List&lt;String&gt; =&#10;            jsonDoc.read(&quot;$[?(@.priority == '$priority')].name&quot;)&#10;        assertEquals(2, result.size)&#10;&#10;        assertEquals(&quot;gardening&quot;, result[0])&#10;        assertEquals(&quot;painting&quot;, result[1])&#10;    }&#10;&#10;    suspend fun HttpClient.getAsJsonPath(url: String): DocumentContext {&#10;        val response = this.get(url) {&#10;            accept(ContentType.Application.Json)&#10;        }&#10;        return JsonPath.parse(response.bodyAsText())&#10;    }&#10;}"/>
+            <p>
+                JsonPath 查询的工作原理如下：
+            </p>
+            <list>
+                <li>
+                    <code>$[&#42;].name</code> 表示“将文档视为数组并返回每个条目的 name 属性值”。
+                </li>
+                <li>
+                    <code>$[?(@.priority == '$priority')].name</code> 表示“返回数组中优先级等于所提供值的每个条目的 name 属性值”。
+                </li>
+            </list>
+            <p>
+                您可以使用此类查询来确认您对返回 JSON 的理解。当您进行代码重构和服务重新部署时，即使序列化中的任何修改不会破坏当前框架的反序列化，它们也会被识别出来。这让您能够放心地重新发布公开可用的 API。
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="后续步骤" id="next-steps">
+    <p>
+        恭喜！您现在已完成为任务管理器应用程序创建 RESTful API 服务，并学习了使用 Ktor Client 和 JsonPath 进行单元测试的细节与要点。</p>
+    <p>
+        继续阅读
+        <Links href="//server-create-website" summary="了解如何使用 Kotlin、Ktor 和 Thymeleaf 模板构建网站。">下一篇教程</Links>，学习如何重用您的 API 服务来构建 Web 应用程序。
+    </p>
+</chapter>
+</topic>

--- a/docs/ktor/server-create-website.md
+++ b/docs/ktor/server-create-website.md
@@ -1,0 +1,429 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="使用 Ktor 在 Kotlin 中创建网站" id="server-create-website">
+    <show-structure for="chapter,procedure" depth="3"/>
+    <tldr>
+        <var name="example_name" value="tutorial-server-web-application"/>
+        <p>
+            <b>代码示例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+        <p>
+            <b>使用的插件</b>：<Links href="//server-static-content" summary="了解如何提供静态内容，例如样式表、脚本、图像等。">Static Content</Links>、
+            <Links href="//server-thymeleaf" summary="所需的依赖项：io.ktor:%artifact_name%">Thymeleaf</Links>
+        </p>
+    </tldr>
+    <web-summary>
+        学习如何使用 Ktor 和 Kotlin 构建网站。本教程将向您展示如何将 Thymeleaf 模板与 Ktor 路由相结合，在服务器端生成基于 HTML 的用户界面。
+    </web-summary>
+    <card-summary>
+        学习如何使用 Ktor 和 Thymeleaf 模板在 Kotlin 中构建网站。
+    </card-summary>
+    <link-summary>
+        学习如何使用 Ktor 和 Thymeleaf 模板在 Kotlin 中构建网站。
+    </link-summary>
+    <p>
+        在本教程中，您将学习如何使用 Kotlin 结合 Ktor 和
+        <a href="https://www.thymeleaf.org/">Thymeleaf</a> 模板构建一个交互式网站。
+    </p>
+    <p>
+        在<Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 构建后端服务，其中包含生成 JSON 文件的 RESTful API 示例。">上一篇教程</Links>中，您学习了如何创建一个 RESTful 服务，供使用 JavaScript 编写的单页应用 (SPA) 调用。虽然这种架构非常流行，但它并不适用于每个项目。
+    </p>
+    <p>
+        出于多种原因，您可能希望将所有实现保留在服务器上，并且只向客户端发送标记，例如：
+    </p>
+    <list>
+        <li>简单性 – 维护单一代码库。</li>
+        <li>安全性 – 防止在浏览器中放置可能为攻击者提供洞察的数据或代码。
+        </li>
+        <li>
+            可支持性 – 允许尽可能广泛的客户端使用，包括旧版浏览器和禁用 JavaScript 的浏览器。
+        </li>
+    </list>
+    <p>
+        Ktor 通过集成<Links href="//server-templating" summary="了解如何处理使用 HTML/CSS 或 JVM 模板引擎构建的视图。">多种服务器页面技术</Links>来支持这种方法。
+    </p>
+    <chapter title="前提条件" id="prerequisites">
+        <p>
+            您可以独立学习本教程，但我们强烈建议您先完成
+            <Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 构建后端服务，其中包含生成 JSON 文件的 RESTful API 示例。">前一篇教程</Links>以学习如何创建 RESTful API。
+        </p>
+        <p>我们建议您安装 <a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ
+            IDEA</a>，但您也可以使用其他自选的 IDE。
+        </p>
+    </chapter>
+    <chapter title="Hello Task Manager Web 应用程序" id="hello-task-manager">
+        <p>
+            在本教程中，您将把在<Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 构建后端服务，其中包含生成 JSON 文件的 RESTful API 示例。">上一篇教程</Links>中构建的任务管理应用程序转换为一个 Web 应用程序。为此，您将使用多个 Ktor <Links href="//server-plugins" summary="插件提供常用功能，例如序列化、内容编码、压缩等。">插件</Links>。
+        </p>
+        <p>
+            虽然您可以手动将这些插件添加到现有项目中，但生成一个新项目并逐步合并上一篇教程中的代码会更容易。我们将全程提供所有必要的代码，因此您不需要手头备有之前的项目。
+        </p>
+        <procedure title="使用插件创建初始项目" id="create-project">
+            <step>
+                <p>
+                    导航至
+                    <a href="https://start.ktor.io/">Ktor Project Generator</a>。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在
+                    <control>Project artifact</control>
+                    字段中，输入
+                    <Path>com.example.ktor-task-web-app</Path>
+                    作为项目构件的名称。
+                    <img src="server_create_web_app_generator_project_artifact.png"
+                         alt="Ktor Project Generator 项目构件名称"
+                         style="block"
+                         border-effect="line" width="706"/>
+                </p>
+            </step>
+            <step>
+                <p> 在下一个屏幕中，通过点击
+                    <control>Add</control>
+                    按钮搜索并添加以下插件：
+                </p>
+                <list>
+                    <li>Static Content</li>
+                    <li>Thymeleaf</li>
+                </list>
+                <p>
+                    <img src="ktor_project_generator_add_plugins.gif"
+                         alt="在 Ktor Project Generator 中添加插件"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                    添加插件后，您将看到项目设置下方列出的所有三个插件。
+                    <img src="server_create_web_app_generator_plugins.png"
+                         alt="Ktor Project Generator 插件列表"
+                         style="block"
+                         border-effect="line" width="706"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    点击
+                    <control>Download</control>
+                    按钮以生成并下载您的 Ktor 项目。
+                </p>
+            </step>
+        </procedure>
+        <procedure title="添加入门代码" id="add-starter-code">
+            <step>
+                在 IntelliJ IDEA 或其他自选 IDE 中打开您的项目。
+            </step>
+            <step>
+                导航至
+                <Path>src/main/kotlin</Path>
+                并创建一个名为
+                <Path>model</Path>
+                的子包。
+            </step>
+            <step>
+                在
+                <Path>model</Path>
+                包内，创建一个新的
+                <Path>Task.kt</Path>
+                文件。
+            </step>
+            <step>
+                <p>
+                    在
+                    <Path>Task.kt</Path>
+                    文件中，添加一个 <code>enum</code> 来表示优先级，以及一个 <code>data class</code> 来表示任务：
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+                <p>
+                    再一次地，您需要创建 <code>Task</code> 对象，并以可以显示的形式将其发送给客户端。
+                </p>
+                <p>
+                    您可能还记得：
+                </p>
+                <list>
+                    <li>
+                        在<Links href="//server-requests-and-responses" summary="通过构建任务管理器应用程序，学习使用 Ktor 进行 Kotlin 路由、处理请求和参数的基础知识。">处理请求并生成响应</Links>教程中，您添加了手写的扩展函数来将任务转换为 HTML。
+                    </li>
+                    <li>
+                        在<Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 构建后端服务，其中包含生成 JSON 文件的 RESTful API 示例。">创建 RESTful API</Links>教程中，您使用 <code>kotlinx.serialization</code> 库中的 <code>Serializable</code> 类型注解了 <code>Task</code> 类。
+                    </li>
+                </list>
+                <p>
+                    在这种情况下，目标是创建一个服务器页面，将任务内容写入浏览器。
+                </p>
+            </step>
+            <step>
+                打开位于
+                <Path>src/main/kotlin</Path>
+                中的
+                <Path>Routing.kt</Path>
+                文件。
+            </step>
+            <step>
+                <p>
+                    在 <code>.configureRouting()</code> 函数中，按如下所示为 <code>/tasks</code> 添加一个路由：
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, World!&quot;)&#10;        }&#10;        get(&quot;/html-thymeleaf&quot;) {&#10;            call.respond(ThymeleafContent(&quot;index&quot;, mapOf(&quot;user&quot; to ThymeleafUser(1, &quot;user1&quot;))))&#10;        }&#10;        // 添加此额外路由&#10;        get(&quot;/tasks&quot;) {&#10;            val tasks = listOf(&#10;                Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;            )&#10;            call.respond(ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks)))&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;    }&#10;}"/>
+                <p>
+                    当服务器收到对 <code>/tasks</code> 的请求时，它会创建一个任务列表，然后将其传递给 Thymeleaf 模板。<code>ThymeleafContent</code> 类型接收要触发的模板名称，以及一个要在页面上访问的值表。
+                </p>
+            </step>
+            <step>
+                打开位于
+                <Path>src/main/kotlin</Path>
+                中的
+                <Path>Thymeleaf.kt</Path>
+                文件。
+            </step>
+            <step>
+                <p>您应该看到以下 <code>.configureThymeleaf</code> 函数：</p>
+                <code-block lang="kotlin" code="fun Application.configureThymeleaf() {&#10;    install(Thymeleaf) {&#10;        setTemplateResolver(ClassLoaderTemplateResolver().apply {&#10;            prefix = &quot;templates/thymeleaf/&quot;&#10;            suffix = &quot;.html&quot;&#10;            characterEncoding = &quot;utf-8&quot;&#10;        })&#10;    }&#10;}"/>
+                <p>
+                    在 Thymeleaf 插件的初始化过程中，Ktor 会在
+                    <Path>templates/thymeleaf</Path>
+                    文件夹中查找服务器页面。与静态内容一样，它预期此文件夹位于
+                    <Path>resources</Path>
+                    目录中。它还预期一个
+                    <Path>.html</Path>
+                    后缀。
+                </p>
+                <p>
+                    在这种情况下，名称 <code>all-tasks</code> 映射到路径
+                    <code>src/main/resources/templates/thymeleaf/all-tasks.html</code>
+                </p>
+            </step>
+            <step>
+                导航至 <Path>src/main/resources</Path>
+                并创建一个新的 <Path>templates/thymeleaf</Path>
+                目录。
+            </step>
+            <step>
+                在
+                <Path>src/main/resources/templates/thymeleaf</Path>
+                中，创建一个新的
+                <Path>all-tasks.html</Path>
+                文件。
+            </step>
+            <step>
+                <p>打开
+                    <Path>all-tasks.html</Path>
+                    文件并添加以下内容：
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html &gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;All Current Tasks&lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;All Current Tasks&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr th:each=&quot;task: ${tasks}&quot;&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>在 IntelliJ IDEA 中，点击运行按钮
+                    (<img src="intellij_idea_gutter_icon.svg"
+                          style="inline" height="16" width="16"
+                          alt="IntelliJ IDEA 运行图标"/>)
+                    以启动应用程序。</p>
+            </step>
+            <step>
+                <p>
+                    在浏览器中导航至 <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a>。您应该会看到显示在表格中的所有当前任务，如下所示：
+                </p>
+                <img src="server_create_web_app_all_tasks.png"
+                     alt="显示任务列表的 Web 浏览器窗口" border-effect="rounded" width="706"/>
+                <p>
+                    与所有服务器页面框架一样，Thymeleaf 模板将静态内容（发送到浏览器）与动态内容（在服务器上执行）混合在一起。如果您选择了其他框架，例如 <a href="https://freemarker.apache.org/">Freemarker</a>，您也可以使用稍有不同的语法提供相同的功能。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="添加 GET 路由" id="add-get-routes">
+        <p>既然您已经熟悉了请求服务器页面的过程，请继续将之前教程中的功能转移到本教程中。</p>
+        <p>因为您包含了
+            <control>Static Content</control>
+            插件，所以以下代码将存在于
+            <Path>Routing.kt</Path>
+            文件中：
+        </p>
+        <code-block lang="kotlin" code="            staticResources(&quot;/static&quot;, &quot;static&quot;)"/>
+        <p>
+            这意味着，例如，对 <code>/static/index.html</code> 的请求将由以下路径提供内容：
+        </p>
+        <code>src/main/resources/static/index.html</code>
+        <p>
+            由于此文件已经是生成的项目的一部分，您可以将其用作您希望添加的功能的主页。
+        </p>
+        <procedure title="复用索引页">
+            <step>
+                <p>
+                    打开
+                    <Path>src/main/resources/static</Path>
+                    中的
+                    <Path>index.html</Path>
+                    文件，并将其内容替换为以下实现：
+                </p>
+                <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Task Manager Web Application&lt;/h1&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;&lt;a href=&quot;/tasks&quot;&gt;View all the tasks&lt;/a&gt;&lt;/h3&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;View tasks by priority&lt;/h3&gt;&#10;    &lt;form method=&quot;get&quot; action=&quot;/tasks/byPriority&quot;&gt;&#10;        &lt;select name=&quot;priority&quot;&gt;&#10;            &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;            &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;            &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;            &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;        &lt;/select&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;View a task by name&lt;/h3&gt;&#10;    &lt;form method=&quot;get&quot; action=&quot;/tasks/byName&quot;&gt;&#10;        &lt;input type=&quot;text&quot; name=&quot;name&quot; width=&quot;10&quot;&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;Create or edit a task&lt;/h3&gt;&#10;    &lt;form method=&quot;post&quot; action=&quot;/tasks&quot;&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;name&quot;&gt;Name: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;name&quot; name=&quot;name&quot; size=&quot;10&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;description&quot;&gt;Description: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;description&quot;&#10;                   name=&quot;description&quot; size=&quot;20&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;priority&quot;&gt;Priority: &lt;/label&gt;&#10;            &lt;select id=&quot;priority&quot; name=&quot;priority&quot;&gt;&#10;                &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;                &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;                &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;                &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;            &lt;/select&gt;&#10;        &lt;/div&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，点击重新运行按钮 (<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 重新运行图标"/>) 以重新启动应用程序。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在浏览器中导航至 <a href="http://localhost:8080/static/index.html">http://localhost:8080/static/index.html</a>。您应该会看到一个链接按钮和三个 HTML 表单，允许您查看、筛选和创建任务：
+                </p>
+                <img src="server_create_web_app_tasks_form.png"
+                     alt="显示 HTML 表单的 Web 浏览器" border-effect="rounded" width="706"/>
+                <p>
+                    请注意，当您按 <code>name</code> 或 <code>priority</code> 筛选任务时，您是在通过 GET 请求提交 HTML 表单。这意味着参数会被添加到 URL 之后的查询字符串中。
+                </p>
+                <p>
+                    例如，如果您搜索 <code>Medium</code> 优先级的任务，发送到服务器的请求如下所示：
+                </p>
+                <code>http://localhost:8080/tasks/byPriority?priority=Medium</code>
+            </step>
+        </procedure>
+        <procedure title="复用任务仓库" id="task-repository">
+            <p>
+                任务的仓库可以保持与上一个教程中的完全一致。
+            </p>
+            <p>
+                在
+                <Path>model</Path>
+                包内创建一个新的
+                <Path>TaskRepository.kt</Path>
+                文件并添加以下代码：
+            </p>
+            <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&&#10;        tasks.add(task)&#10;    }&#10;}"/>
+        </procedure>
+        <procedure title="复用 GET 请求的路由" id="reuse-routes">
+            <p>
+                既然已经创建了仓库，您就可以实现 GET 请求的路由了。
+            </p>
+            <step>
+                导航至位于
+                <Path>src/main/kotlin</Path>
+                中的
+                <Path>Routing.kt</Path>
+                文件。
+            </step>
+            <step>
+                <p>
+                    将当前版本的 <code>.configureRouting()</code> 替换为以下实现：
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, World!&quot;)&#10;        }&#10;        get(&quot;/html-thymeleaf&quot;) {&#10;            call.respond(ThymeleafContent(&quot;index&quot;, mapOf(&quot;user&quot; to ThymeleafUser(1, &quot;user1&quot;))))&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;&#10;        route(&quot;/tasks&quot;) {&#10;            get {&#10;                val tasks = TaskRepository.allTasks()&#10;                call.respond(&#10;                    ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks))&#10;                )&#10;            }&#10;            get(&quot;/byName&quot;) {&#10;                val name = call.request.queryParameters[&quot;name&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                val task = TaskRepository.taskByName(name)&#10;                if (task == null) {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                    return@get&#10;                }&#10;                call.respond(&#10;                    ThymeleafContent(&quot;single-task&quot;, mapOf(&quot;task&quot; to task))&#10;                )&#10;            }&#10;            get(&quot;/byPriority&quot;) {&#10;                val priorityAsText = call.request.queryParameters[&quot;priority&quot;]&#10;                if (priorityAsText == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(priorityAsText)&#10;                    val tasks = TaskRepository.tasksByPriority(priority)&#10;&#10;&#10;                    if (tasks.isEmpty()) {&#10;                        call.respond(HttpStatusCode.NotFound)&#10;                        return@get&#10;                    }&#10;                    val data = mapOf(&#10;                        &quot;priority&quot; to priority,&#10;                        &quot;tasks&quot; to tasks&#10;                    )&#10;                    call.respond(ThymeleafContent(&quot;tasks-by-priority&quot;, data))&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    上述代码可以概括如下：
+                </p>
+                <list>
+                    <li>
+                        在对 <code>/tasks</code> 的 GET 请求中，服务器从仓库中检索所有任务，并使用
+                        <Path>all-tasks</Path>
+                        模板生成发送到浏览器的下一个视图。
+                    </li>
+                    <li>
+                        在对 <code>/tasks/byName</code> 的 GET 请求中，服务器从 <code>queryString</code> 中检索参数 <code>name</code>，找到匹配的任务，并使用
+                        <Path>single-task</Path>
+                        模板生成发送到浏览器的下一个视图。
+                    </li>
+                    <li>
+                        在对 <code>/tasks/byPriority</code> 的 GET 请求中，服务器从 <code>queryString</code> 中检索参数 <code>priority</code>，找到匹配的任务，并使用
+                        <Path>tasks-by-priority</Path>
+                        模板生成发送到浏览器的下一个视图。
+                    </li>
+                </list>
+                <p>为了让所有这些正常工作，您需要添加额外的模板。</p>
+            </step>
+            <step>
+                导航至
+                <Path>src/main/resources/templates/thymeleaf</Path>
+                并创建一个新的
+                <Path>single-task.html</Path>
+                文件。
+            </step>
+            <step>
+                <p>
+                    打开
+                    <Path>single-task.html</Path>
+                    文件并添加以下内容：
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html &gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;All Current Tasks&lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;The Selected Task&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Description&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Priority&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>在同一个文件夹中，创建一个名为
+                    <Path>tasks-by-priority.html</Path>
+                    的新文件。
+                </p>
+            </step>
+            <step>
+                <p>
+                    打开
+                    <Path>tasks-by-priority.html</Path>
+                    文件并添加以下内容：
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html&gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;Tasks By Priority &lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Tasks With Priority &lt;span th:text=&quot;${priority}&quot;&gt;&lt;/span&gt;&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&#10;        &lt;th&gt;Description&lt;/th&gt;&#10;        &lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr th:each=&quot;task: ${tasks}&quot;&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="添加对 POST 请求的支持" id="add-post-requests">
+        <p>
+            接下来，您将向 <code>/tasks</code> 添加一个 POST 请求处理程序，以执行以下操作：
+        </p>
+        <list>
+            <li>从表单参数中提取信息。</li>
+            <li>使用仓库添加一个新任务。</li>
+            <li>通过复用
+                <control>all-tasks</control>
+                模板来显示任务。
+            </li>
+        </list>
+        <procedure>
+            <step>
+                导航至位于
+                <Path>src/main/kotlin</Path>
+                中的
+                <Path>Routing.kt</Path>
+                文件。
+            </step>
+            <step>
+                <p>
+                    在 <code>.configureRouting()</code> 方法中添加以下 <code>post</code> 请求路由：
+                </p>
+                <code-block lang="kotlin" code="            post {&#10;                val formContent = call.receiveParameters()&#10;                val params = Triple(&#10;                    formContent[&quot;name&quot;] ?: &quot;&quot;,&#10;                    formContent[&quot;description&quot;] ?: &quot;&quot;,&#10;                    formContent[&quot;priority&quot;] ?: &quot;&quot;&#10;                )&#10;                if (params.toList().any { it.isEmpty() }) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@post&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(params.third)&#10;                    TaskRepository.addTask(&#10;                        Task(&#10;                            params.first,&#10;                            params.second,&#10;                            priority&#10;                        )&#10;                    )&#10;                    val tasks = TaskRepository.allTasks()&#10;                    call.respond(&#10;                        ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks))&#10;                    )&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                } catch (ex: IllegalStateException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }"/>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，点击重新运行按钮 (<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 重新运行图标"/>) 以重新启动应用程序。
+                </p>
+            </step>
+            <step>
+                在浏览器中导航至 <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a>。
+            </step>
+            <step>
+                <p>
+                    在
+                    <control>Create or edit a task</control>
+                    表单中输入新任务详情。
+                </p>
+                <img src="server_create_web_app_new_task.png"
+                     alt="显示 HTML 表单的 Web 浏览器" border-effect="rounded" width="706"/>
+            </step>
+            <step>
+                <p>点击
+                    <control>Submit</control>
+                    按钮提交表单。
+                    然后，您将看到新任务显示在所有任务的列表中：
+                </p>
+                <img src="server_create_web_app_new_task_added.png"
+                     alt="显示任务列表的 Web 浏览器" border-effect="rounded" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="下一步" id="next-steps">
+        <p>
+            恭喜！您现在已完成将任务管理器重新构建为 Web 应用程序，并学习了如何使用 Thymeleaf 模板。</p>
+        <p>
+            继续阅读<Links href="//server-create-websocket-application" summary="了解如何利用 WebSockets 的强大功能发送和接收内容。">下一篇教程</Links>，学习如何处理 WebSockets。
+        </p>
+    </chapter>
+</topic>

--- a/docs/ktor/server-create-websocket-application.md
+++ b/docs/ktor/server-create-websocket-application.md
@@ -1,0 +1,446 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="在 Kotlin 中使用 Ktor 创建 WebSocket 应用程序" id="server-create-websocket-application">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <var name="example_name" value="tutorial-server-websockets"/>
+    <p>
+        <b>代码示例</b>：
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+    <p>
+        <b>使用的插件</b>：<Links href="//server-static-content" summary="了解如何提供静态内容，如样式表、脚本、图像等。">Static Content</Links>、
+        <Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">Content Negotiation</Links>、<Links href="//server-websockets" summary="Websockets 插件允许您在服务器和客户端之间创建多路通信会话。">Ktor Server 中的 WebSockets</Links>、
+        <a href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>
+    </p>
+</tldr>
+<card-summary>
+    了解如何利用 WebSockets 的强大功能来发送和接收内容。
+</card-summary>
+<link-summary>
+    了解如何利用 WebSockets 的强大功能来发送和接收内容。
+</link-summary>
+<web-summary>
+    了解如何在 Kotlin 中使用 Ktor 构建 WebSocket 应用程序。本教程将引导您完成通过 WebSockets 将后端服务与客户端连接的过程。
+</web-summary>
+<p>
+    本文将指导您如何在 Kotlin 中使用 Ktor 创建 WebSocket 应用程序。它基于 <Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 构建后端服务，其中包含一个生成 JSON 文件的 RESTful API 示例。">创建 RESTful API</Links> 教程中的材料。
+</p>
+<p>本文将教您如何执行以下操作：</p>
+<list>
+    <li>创建使用 JSON 序列化的服务。</li>
+    <li>通过 WebSocket 连接发送和接收内容。</li>
+    <li>同时向多个客户端广播内容。</li>
+</list>
+<chapter title="先决条件" id="prerequisites">
+    <p>您可以独立完成本教程，但我们建议您先完成
+        <Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 构建后端服务，其中包含一个生成 JSON 文件的 RESTful API 示例。">创建 RESTful API</Links> 教程，以熟悉 <Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">内容协商</Links> 和 REST。
+    </p>
+    <p>我们建议您安装 <a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA</a>，但您也可以使用其他您喜欢的 IDE。
+    </p>
+</chapter>
+<chapter title="你好 WebSockets" id="hello-websockets">
+    <p>
+        在本教程中，您将通过添加通过 WebSocket 连接与客户端交换 <code>Task</code> 对象的功能，扩展在 <Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 构建后端服务，其中包含一个生成 JSON 文件的 RESTful API 示例。">创建 RESTful API</Links> 教程中开发的任务管理器服务。为此，您需要添加 <Links href="//server-websockets" summary="Websockets 插件允许您在服务器和客户端之间创建多路通信会话。">WebSockets 插件</Links>。虽然您可以手动将其添加到现有项目中，但为了本教程起见，您将从头开始创建一个新项目。
+    </p>
+    <chapter title="创建带有插件的初始项目" id="create=project">
+        <procedure>
+            <step>
+                <p>
+                    导航至
+                    <a href="https://start.ktor.io/">Ktor 项目生成器</a>。
+                </p>
+            </step>
+            <step>
+                <p>在
+                    <control>Project artifact</control>
+                    字段中，输入
+                    <Path>com.example.ktor-websockets-task-app</Path>
+                    作为项目工件的名称。
+                    <img src="tutorial_server_websockets_project_artifact.png"
+                         alt="在 Ktor 项目生成器中命名项目工件"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    在插件部分搜索并通过点击
+                    <control>Add</control>
+                    按钮添加以下插件：
+                </p>
+                <list type="bullet">
+                    <li>Content Negotiation</li>
+                    <li>kotlinx.serialization</li>
+                    <li>WebSockets</li>
+                    <li>Static Content</li>
+                </list>
+                <p>
+                    <img src="ktor_project_generator_add_plugins.gif"
+                         alt="在 Ktor 项目生成器中添加插件"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    添加插件后，它们将显示在插件部分的右上角。
+                </p>
+                <p>然后您将看到将添加到项目中的所有插件列表：
+                    <img src="tutorial_server_websockets_project_plugins.png"
+                         alt="Ktor 项目生成器中的插件列表"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    点击
+                    <control>Download</control>
+                    按钮以生成并下载您的 Ktor 项目。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="添加起始代码" id="add-starter-code">
+        <p>下载完成后，在 IntelliJ IDEA 中打开您的项目并按照以下步骤操作：</p>
+        <procedure>
+            <step>
+                导航至
+                <Path>src/main/kotlin</Path>
+                并创建一个名为
+                <Path>model</Path>
+                的新子软件包。
+            </step>
+            <step>
+                <p>
+                    在
+                    <Path>model</Path>
+                    软件包内创建一个新的
+                    <Path>Task.kt</Path>
+                    文件。
+                </p>
+            </step>
+            <step>
+                <p>
+                    打开
+                    <Path>Task.kt</Path>
+                    文件并添加一个 <code>enum</code> 来表示优先级，以及一个 <code>data class</code> 来表示任务：
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+                <p>
+                    请注意，<code>Task</code> 类使用了来自 <code>kotlinx.serialization</code> 库的 <code>Serializable</code> 注解。这意味着实例可以转换为 JSON 以及从 JSON 转换，从而允许通过网络传输其内容。
+                </p>
+                <p>
+                    因为您包含了 WebSockets 插件，生成器已经在
+                    <Path>src/main/kotlin</Path>
+                    目录下的
+                    <Path>Websockets.kt</Path>
+                    文件中添加了配置，并在
+                    <Path>Routing.kt</Path> 文件中添加了 <code>webSocket</code> 路由。
+                </p>
+            </step>
+            <step>
+                打开
+                <Path>Websockets.kt</Path>
+                文件，并将现有的 <code>.configureWebsockets()</code> 函数替换为以下内容：
+                <code-block lang="kotlin" code="                        fun Application.configureWebsockets() {&#10;                            install(WebSockets) {&#10;                                contentConverter = KotlinxWebsocketSerializationConverter(Json)&#10;                                pingPeriod = 15.seconds&#10;                                timeout = 15.seconds&#10;                                maxFrameSize = Long.MAX_VALUE&#10;                                masking = false&#10;                            }&#10;                        }"/>
+                <list>
+                    <li>安装 WebSockets 插件并使用标准设置进行配置。</li>
+                    <li>设置了 <code>contentConverter</code> 属性，使插件能够通过 <a
+                                href="https://github.com/Kotlin/kotlinx.serialization"><code>kotlinx.serialization</code></a> 库对发送和接收的对象进行序列化。
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    打开
+                    <Path>Routing.kt</Path>
+                    文件，并将现有的 <code>Application.configureRouting()</code> 函数替换为下面的实现：
+                </p>
+                <code-block lang="kotlin" code="                    fun Application.configureRouting() {&#10;                        routing {&#10;                            webSocket(&quot;/tasks&quot;) {&#10;                                val tasks = listOf(&#10;                                    Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                                    Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                                    Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                                    Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;                                )&#10;&#10;                                for (task in tasks) {&#10;                                    sendSerialized(task)&#10;                                    delay(1000.milliseconds)&#10;                                }&#10;&#10;                                close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;                            }&#10;                            staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;                        }&#10;                    }"/>
+                <list>
+                    <li>路由配置了一个单一端点，其相对 URL 为 <code>/tasks</code>。
+                    </li>
+                    <li>在收到请求后，任务列表会通过 WebSocket 连接进行序列化发送。</li>
+                    <li>一旦所有项目发送完毕，服务器将关闭连接。</li>
+                </list>
+                <p>
+                    出于演示目的，在发送任务之间引入了一秒钟的延迟。这允许您观察任务在客户端中逐步出现的过程。如果没有这个延迟，该示例看起来将与之前文章中开发的 <Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 构建后端服务，其中包含一个生成 JSON 文件的 RESTful API 示例。">RESTful 服务</Links> 和 <Links href="//server-create-website" summary="了解如何使用 Kotlin、Ktor 和 Thymeleaf 模板构建网站。">Web 应用程序</Links> 完全相同。
+                </p>
+                <p>
+                    此迭代的最后一步是为此端点创建一个客户端。因为您包含了
+                    <Links href="//server-static-content" summary="了解如何提供静态内容，如样式表、脚本、图像等。">Static Content</Links> 插件，Ktor 项目生成器已在
+                    <Path>src/main/resources/static</Path>
+                    中添加了一个
+                    <Path>index.html</Path>
+                    文件。
+                </p>
+            </step>
+            <step>
+                <p>
+                    打开
+                    <Path>index.html</Path>
+                    文件并将现有内容替换为以下内容：
+                </p>
+                <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;Using Ktor WebSockets&lt;/title&gt;&#10;    &lt;script&gt;&#10;        function readAndDisplayAllTasks() {&#10;            clearTable();&#10;&#10;            const serverURL = 'ws://0.0.0.0:8080/tasks';&#10;            const socket = new WebSocket(serverURL);&#10;&#10;            socket.onopen = logOpenToConsole;&#10;            socket.onclose = logCloseToConsole;&#10;            socket.onmessage = readAndDisplayTask;&#10;        }&#10;&#10;        function readAndDisplayTask(event) {&#10;            let task = JSON.parse(event.data);&#10;            logTaskToConsole(task);&#10;            addTaskToTable(task);&#10;        }&#10;&#10;        function logTaskToConsole(task) {&#10;            console.log(`Received ${task.name}`);&#10;        }&#10;&#10;        function logCloseToConsole() {&#10;            console.log(&quot;Web socket connection closed&quot;);&#10;        }&#10;&#10;        function logOpenToConsole() {&#10;            console.log(&quot;Web socket connection opened&quot;);&#10;        }&#10;&#10;        function tableBody() {&#10;            return document.getElementById(&quot;tasksTableBody&quot;);&#10;        }&#10;&#10;        function clearTable() {&#10;            tableBody().innerHTML = &quot;&quot;;&#10;        }&#10;&#10;        function addTaskToTable(task) {&#10;            tableBody().appendChild(taskRow(task));&#10;        }&#10;&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Viewing Tasks Via WebSockets&lt;/h1&gt;&#10;&lt;form action=&quot;javascript:readAndDisplayAllTasks()&quot;&gt;&#10;    &lt;input type=&quot;submit&quot; value=&quot;View The Tasks&quot;&gt;&#10;&lt;/form&gt;&#10;&lt;table rules=&quot;all&quot;&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+                <p>
+                    该页面使用了所有现代浏览器中都可用的 <a href="https://websockets.spec.whatwg.org//#websocket"><code>WebSocket</code> 类型</a>。您在 JavaScript 中创建此对象，并将端点的 URL 传递到构造函数中。随后，您为 <code>onopen</code>、<code>onclose</code> 和 <code>onmessage</code> 事件附加事件处理程序。在触发 <code>onmessage</code> 事件时，您使用 document 对象的方法向表格追加一行。
+                </p>
+            </step>
+            <step>
+                <p>在 IntelliJ IDEA 中，点击运行按钮
+                    (<img src="intellij_idea_gutter_icon.svg"
+                          style="inline" height="16" width="16"
+                          alt="IntelliJ IDEA 运行图标"/>)
+                    以启动应用程序。</p>
+            </step>
+            <step>
+                <p>
+                    导航至 <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a>。您应该会看到一个带有一个按钮的表单和一个空表格：
+                </p>
+                <img src="tutorial_server_websockets_iteration_1.png"
+                     alt="显示包含一个按钮的 HTML 表单的网页浏览器页面"
+                     border-effect="rounded"
+                     width="706"/>
+                <p>
+                    当您点击表单时，任务会从服务器加载，并以每秒一个的速度出现。因此，表格会被增量填充。您还可以通过打开浏览器 <control>Developer Tools</control> 中的 <control>JavaScript Console</control> 来查看记录的消息。
+                </p>
+                <img src="tutorial_server_websockets_iteration_1_click.gif"
+                     alt="点击按钮时显示列表项的网页浏览器页面"
+                     border-effect="rounded"
+                     width="706"/>
+                <p>
+                    至此，服务的表现符合预期。WebSocket 连接已打开，项目已发送到客户端，然后连接关闭。底层网络中存在很多复杂性，但 Ktor 默认处理了所有这些复杂性。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+</chapter>
+<chapter title="了解 WebSockets" id="understanding-websockets">
+    <p>
+        在进行下一次迭代之前，回顾一下 WebSockets 的一些基础知识可能会有所帮助。如果您已经熟悉 WebSockets，可以继续 <a href="#improve-design">改进服务的设计</a>。
+    </p>
+    <p>
+        在之前的教程中，您的客户端发送 HTTP 请求并接收 HTTP 响应。这种模式运行良好，使互联网具备了可扩展性和弹性。
+    </p>
+    <p>然而，它不适用于以下场景：</p>
+    <list>
+        <li>内容是随时间增量生成的。</li>
+        <li>内容根据事件频繁更改。</li>
+        <li>客户端需要在内容产生时与服务器交互。</li>
+        <li>一个客户端发送的数据需要迅速传播给其他客户端。</li>
+    </list>
+    <p>
+        这些场景的示例包括股票交易、购买电影和音乐会门票、在线拍卖出价以及社交媒体中的聊天功能。WebSockets 的开发就是为了处理这些情况。
+    </p>
+    <p>
+        WebSocket 连接是建立在 TCP 之上的，可以持续很长时间。该连接提供<emphasis>全双工通信</emphasis>，这意味着客户端可以同时向服务器发送消息并从中接收消息。
+    </p>
+    <p>
+        WebSocket API 定义了四个事件（open、message、close 和 error）和两个操作（send 和 close）。如何访问此功能可能因不同的语言和库而异。例如，在 Kotlin 中，您可以将传入消息序列作为 <a
+            href="https://kotlinlang.org/docs/flow.html"><code>Flow</code></a> 来消费。
+    </p>
+</chapter>
+<chapter title="改进设计" id="improve-design">
+    <p>接下来，您将重构现有代码，为更高级的示例腾出空间。</p>
+    <procedure>
+        <step>
+            <p>
+                在
+                <Path>model</Path>
+                软件包中，创建一个新的
+                <Path>TaskRepository.kt</Path>
+                文件。
+            </p>
+        </step>
+        <step>
+            <p>
+                打开
+                <Path>TaskRepository.kt</Path>
+                并添加 <code>TaskRepository</code> 类型：
+            </p>
+            <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&#10;        tasks.add(task)&#10;    }&#10;&#10;    fun removeTask(name: String): Boolean {&#10;        return tasks.removeIf { it.name == name }&#10;    }&#10;}"/>
+            <p>您可能还记得之前教程中的这段代码。</p>
+        </step>
+        <step>
+            导航至
+            <Path>src/main/kotlin</Path>
+            并打开
+            <Path>Routing.kt</Path>
+            文件。
+        </step>
+        <step>
+            <p>
+                您现在可以通过利用 <code>TaskRepository</code> 来简化 <code>Application.configureRouting()</code> 中的路由：
+            </p>
+            <code-block lang="kotlin" code="                    routing {&#10;                        webSocket(&quot;/tasks&quot;) {&#10;                            for (task in TaskRepository.allTasks()) {&#10;                                sendSerialized(task)&#10;                                delay(1000.milliseconds)&#10;                            }&#10;                            close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;                        }&#10;                        // ...&#10;                    }"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="通过 WebSockets 发送消息" id="send-messages">
+    <p>
+        为了展示 WebSockets 的强大功能，您将创建一个新端点，其中：
+    </p>
+    <list>
+        <li>
+            当客户端启动时，它会收到所有现有任务。
+        </li>
+        <li>
+            客户端可以创建并发送任务。
+        </li>
+        <li>
+            当一个客户端发送任务时，其他客户端会收到通知。
+        </li>
+    </list>
+    <procedure>
+        <step>
+            <p>
+                在
+                <Path>Routing.kt</Path>
+                文件中，将当前的 <code>.configureRouting()</code> 方法替换为下面的实现：
+            </p>
+            <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        val sessions =&#10;            Collections.synchronizedList&lt;WebSocketServerSession&gt;(ArrayList())&#10;&#10;        webSocket(&quot;/tasks&quot;) {&#10;            sendAllTasks()&#10;            close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;        }&#10;&#10;        webSocket(&quot;/tasks2&quot;) {&#10;            sessions.add(this)&#10;            sendAllTasks()&#10;&#10;            while(true) {&#10;                ensureActive()&#10;                val newTask = receiveDeserialized&lt;Task&gt;()&#10;                TaskRepository.addTask(newTask)&#10;                for(session in sessions) {&#10;                    session.sendSerialized(newTask)&#10;                }&#10;            }&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;    }&#10;}&#10;&#10;private suspend fun DefaultWebSocketServerSession.sendAllTasks() {&#10;    for (task in TaskRepository.allTasks()) {&#10;        sendSerialized(task)&#10;        delay(1000.milliseconds)&#10;    }&#10;}"/>
+            <p>通过这段代码，您完成了以下工作：</p>
+            <list>
+                <li>
+                    将发送所有现有任务的功能重构为一个辅助方法。
+                </li>
+                <li>
+                    在 <code>routing {}</code> 块中，您创建了一个线程安全的 <code>session</code> 对象列表，以跟踪所有客户端。
+                </li>
+                <li>
+                    添加了一个相对 URL 为 <code>/tasks2</code> 的新端点。当客户端连接到此端点时，相应的 <code>session</code> 对象将被添加到列表中。然后服务器进入无限循环，等待接收新任务。收到新任务后，服务器将其存储在仓库中，并将副本发送给所有客户端（包括当前客户端）。
+                </li>
+            </list>
+            <p>
+                为了测试此功能，您将创建一个扩展 <Path>index.html</Path> 功能的新页面。
+            </p>
+        </step>
+        <step>
+            <p>
+                在
+                <Path>src/main/resources/static</Path>
+                内创建一个名为
+                <Path>wsClient.html</Path>
+                的新 HTML 文件。
+            </p>
+        </step>
+        <step>
+            <p>
+                打开
+                <Path>wsClient.html</Path>
+                并添加以下内容：
+            </p>
+            <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;WebSocket Client&lt;/title&gt;&#10;    &lt;script&gt;&#10;        let serverURL;&#10;        let socket;&#10;&#10;        function setupSocket() {&#10;            serverURL = 'ws://0.0.0.0:8080/tasks2';&#10;            socket = new WebSocket(serverURL);&#10;&#10;            socket.onopen = logOpenToConsole;&#10;            socket.onclose = logCloseToConsole;&#10;            socket.onmessage = readAndDisplayTask;&#10;        }&#10;&#10;        function readAndDisplayTask(event) {&#10;            let task = JSON.parse(event.data);&#10;            logTaskToConsole(task);&#10;            addTaskToTable(task);&#10;        }&#10;&#10;        function logTaskToConsole(task) {&#10;            console.log(`Received ${task.name}`);&#10;        }&#10;&#10;        function logCloseToConsole() {&#10;            console.log(&quot;Web socket connection closed&quot;);&#10;        }&#10;&#10;        function logOpenToConsole() {&#10;            console.log(&quot;Web socket connection opened&quot;);&#10;        }&#10;&#10;        function tableBody() {&#10;            return document.getElementById(&quot;tasksTableBody&quot;);&#10;        }&#10;&#10;        function addTaskToTable(task) {&#10;            tableBody().appendChild(taskRow(task));&#10;        }&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;&#10;        function getFormValue(name) {&#10;            return document.forms[0][name].value&#10;        }&#10;&#10;        function buildTaskFromForm() {&#10;            return {&#10;                name: getFormValue(&quot;newTaskName&quot;),&#10;                description: getFormValue(&quot;newTaskDescription&quot;),&#10;                priority: getFormValue(&quot;newTaskPriority&quot;)&#10;            }&#10;        }&#10;&#10;        function logSendingToConsole(data) {&#10;            console.log(&quot;About to send&quot;,data);&#10;        }&#10;&#10;        function sendTaskViaSocket(data) {&#10;            socket.send(JSON.stringify(data));&#10;        }&#10;&#10;        function sendTaskToServer() {&#10;            let data = buildTaskFromForm();&#10;            logSendingToConsole(data);&#10;            sendTaskViaSocket(data);&#10;            //prevent form submission&#10;            return false;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body onload=&quot;setupSocket()&quot;&gt;&#10;&lt;h1&gt;Viewing Tasks Via WebSockets&lt;/h1&gt;&#10;&lt;table rules=&quot;all&quot;&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;Create a new task&lt;/h3&gt;&#10;    &lt;form onsubmit=&quot;return sendTaskToServer()&quot;&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskName&quot;&gt;Name: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;newTaskName&quot;&#10;                   name=&quot;newTaskName&quot; size=&quot;10&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskDescription&quot;&gt;Description: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;newTaskDescription&quot;&#10;                   name=&quot;newTaskDescription&quot; size=&quot;20&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskPriority&quot;&gt;Priority: &lt;/label&gt;&#10;            &lt;select id=&quot;newTaskPriority&quot; name=&quot;newTaskPriority&quot;&gt;&#10;                &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;                &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;                &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;                &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;            &lt;/select&gt;&#10;        &lt;/div&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            <p>
+                这个新页面引入了一个 HTML 表单，用户可以在其中输入新任务的信息。提交表单后，将调用 <code>sendTaskToServer()</code> 事件处理程序。这将构建一个包含表单数据的 JavaScript 对象，并使用 WebSocket 对象的 <code>.send()</code> 方法将其发送到服务器。
+            </p>
+        </step>
+        <step>
+            <p>
+                在 IntelliJ IDEA 中，点击重新运行按钮 (<img src="intellij_idea_rerun_icon.svg"
+                                                               style="inline" height="16" width="16"
+                                                               alt="IntelliJ IDEA 重新运行图标"/>) 以重启应用程序。
+            </p>
+        </step>
+        <step>
+            <p>要测试此功能，请并排打开两个浏览器，并按照以下步骤操作。</p>
+            <list type="decimal">
+                <li>
+                    在浏览器 A 中，导航至
+                    <a href="http://0.0.0.0:8080/static/wsClient.html">http://0.0.0.0:8080/static/wsClient.html</a>。您应该会看到显示的默认任务。
+                </li>
+                <li>
+                    在浏览器 A 中添加一个新任务。新任务应该出现在该页面的表格中。
+                </li>
+                <li>
+                    在浏览器 B 中，导航至
+                    <a href="http://0.0.0.0:8080/static/wsClient.html">http://0.0.0.0:8080/static/wsClient.html</a>。您应该会看到默认任务，以及您在浏览器 A 中添加的任何新任务。
+                </li>
+                <li>
+                    在任一浏览器中添加任务。您应该会看到新项目同时出现在两个页面上。
+                </li>
+            </list>
+            <img src="tutorial_server_websockets_iteration_2_test.gif"
+                 alt="并排显示两个网页浏览器页面，演示通过 HTML 表单创建新任务"
+                 border-effect="rounded"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="添加自动化测试" id="add-automated-tests">
+    <p>
+        为了简化您的 QA 流程并使其快速、可复现且无需人工干预，您可以使用 Ktor 内置的 <Links href="//server-testing" summary="了解如何使用特殊的测试引擎测试您的服务器应用程序。">自动化测试支持</Links>。请按照以下步骤操作：
+    </p>
+    <procedure>
+        <step>
+            <p>
+                将以下依赖项添加到
+                <Path>build.gradle.kts</Path>
+                中，以便您在 Ktor Client 中配置对 <Links href="//server-serialization" summary="ContentNegotiation 插件有两个主要用途：在客户端和服务器之间协商媒体类型，以及以特定格式序列化/反序列化内容。">内容协商</Links> 的支持：
+            </p>
+            <code-block lang="kotlin" code="    testImplementation(ktorLibs.client.contentNegotiation)"/>
+        </step>
+        <step>
+            <p>
+                <p>在 IntelliJ IDEA 中，点击编辑器右侧的 Gradle 通知图标
+                    (<img alt="IntelliJ IDEA Gradle 图标"
+                          src="intellij_idea_gradle_icon.svg" width="16" height="26"/>)
+                    以加载 Gradle 更改。</p>
+            </p>
+        </step>
+        <step>
+            <p>
+                导航至
+                <Path>src/test/kotlin</Path>
+                并打开
+                <Path>ServerTest.kt</Path>
+                文件。
+            </p>
+        </step>
+        <step>
+            <p>
+                将生成的测试类替换为以下实现：
+            </p>
+            <code-block lang="kotlin" code="import com.example.model.Priority&#10;import com.example.model.Task&#10;import io.ktor.client.plugins.contentnegotiation.ContentNegotiation&#10;import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession&#10;import io.ktor.client.plugins.websocket.WebSockets&#10;import io.ktor.client.plugins.websocket.converter&#10;import io.ktor.client.plugins.websocket.webSocket&#10;import io.ktor.serialization.deserialize&#10;import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter&#10;import io.ktor.serialization.kotlinx.json.json&#10;import io.ktor.server.testing.testApplication&#10;import kotlinx.coroutines.flow.consumeAsFlow&#10;import kotlinx.coroutines.flow.map&#10;import kotlinx.coroutines.flow.scan&#10;import kotlinx.serialization.json.Json&#10;import kotlin.test.Test&#10;import kotlin.test.assertEquals&#10;&#10;class ServerTest {&#10;    @Test&#10;    fun testRoot() = testApplication {&#10;        configure()&#10;&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;            install(WebSockets) {&#10;                contentConverter =&#10;                    KotlinxWebsocketSerializationConverter(Json)&#10;            }&#10;        }&#10;&#10;        val expectedTasks = listOf(&#10;            Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;            Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;            Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;            Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;        )&#10;        var actualTasks = emptyList&lt;Task&gt;()&#10;&#10;        client.webSocket(&quot;/tasks&quot;) {&#10;            consumeTasksAsFlow().collect { allTasks -&gt;&#10;                actualTasks = allTasks&#10;            }&#10;        }&#10;&#10;        assertEquals(expectedTasks.size, actualTasks.size)&#10;        expectedTasks.forEachIndexed { index, task -&gt;&#10;            assertEquals(task, actualTasks[index])&#10;        }&#10;    }&#10;&#10;    private fun DefaultClientWebSocketSession.consumeTasksAsFlow() = incoming&#10;        .consumeAsFlow()&#10;        .map {&#10;            converter!!.deserialize&lt;Task&gt;(it)&#10;        }&#10;        .scan(emptyList&lt;Task&gt;()) { list, task -&gt;&#10;            list + task&#10;        }&#10;}"/>
+            <p>
+                通过此设置，您可以：
+            </p>
+            <list>
+                <li>
+                    配置您的服务在测试环境中运行，并启用与生产环境相同的功能，包括 JSON 序列化和 WebSockets。
+                </li>
+                <li>
+                    在 <Links href="//client-create-and-configure" summary="了解如何创建和配置 Ktor 客户端。">Ktor Client</Links> 中配置内容协商和 WebSocket 支持。如果没有这些配置，客户端在通过 WebSocket 连接时将不知道如何将对象 (反) 序列化为 JSON。
+                </li>
+                <li>
+                    声明您期望服务返回的 <code>Tasks</code> 列表。
+                </li>
+                <li>
+                    使用 <code>client</code> 对象的 <code>.webSocket</code> 函数向 <code>/tasks</code> 发送请求。
+                </li>
+                <li>
+                    将传入的任务作为 <code>Flow</code> 消费，并将其增量添加到列表中。
+                </li>
+                <li>
+                    收到所有任务后，以常规方式将 <code>expectedTasks</code> 与 <code>actualTasks</code> 进行比较。
+                </li>
+            </list>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="后续步骤" id="next-steps">
+    <p>
+        做得好！通过将 WebSocket 通信和 Ktor Client 的自动化测试结合起来，您已经显著增强了任务管理器服务。
+    </p>
+    <p>
+        继续阅读 <Links href="//server-integrate-database" summary="了解使用 Exposed SQL 库将 Ktor 服务连接到数据库仓库的过程。">下一篇教程</Links>，探索您的服务如何使用 Exposed 库与关系型数据库无缝交互。
+    </p>
+</chapter>
+</topic>

--- a/docs/ktor/server-dependencies.md
+++ b/docs/ktor/server-dependencies.md
@@ -1,0 +1,219 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="添加服务器依赖项"
+       id="server-dependencies" help-id="Gradle">
+    <show-structure for="chapter" depth="2"/>
+    <link-summary>了解如何向现有的 Gradle/Maven 项目中添加 Ktor Server 依赖项。</link-summary>
+    <p>
+        在本主题中，我们将向您展示如何向现有的 Gradle/Maven 项目中添加 Ktor Server 所需的依赖项。
+    </p>
+    <chapter title="配置仓库" id="repositories">
+        <p>
+            在添加 Ktor 依赖项之前，您需要为该项目配置仓库：
+        </p>
+        <list>
+            <li>
+                <p>
+                    <control>生产版</control>
+                </p>
+                <p>
+                    Ktor 的生产版本可在 Maven 中央仓库中获取。
+                    您可以按如下方式在构建脚本中声明此仓库：
+                </p>
+                <Tabs group="languages">
+                    <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                        <code-block lang="Kotlin" code="                            repositories {&#10;                                mavenCentral()&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Gradle (Groovy)" group-key="groovy">
+                        <code-block lang="Groovy" code="                            repositories {&#10;                                mavenCentral()&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Maven" group-key="maven">
+                        <note>
+                            <p>
+                                您不需要在 <Path>pom.xml</Path> 文件中添加 Maven 中央仓库，因为您的项目会从 <a href="https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#super-pom">Super POM</a> 继承该中央仓库。
+                            </p>
+                        </note>
+                    </TabItem>
+                </Tabs>
+            </li>
+            <li>
+                <p>
+                    <control>抢先体验计划 (EAP)</control>
+                </p>
+                <p>
+                    要访问 Ktor 的 <a href="https://ktor.io/eap/">EAP</a> 版本，您需要引用 <a href="https://redirector.kotlinlang.org/maven/ktor-eap/io/ktor/">Space 仓库</a>：
+                </p>
+                <Tabs group="languages">
+                    <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                        <code-block lang="Kotlin" code="                            repositories {&#10;                                maven {&#10;                                    url = uri(&quot;https://redirector.kotlinlang.org/maven/ktor-eap&quot;)&#10;                                }&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Gradle (Groovy)" group-key="groovy">
+                        <code-block lang="Groovy" code="                            repositories {&#10;                                maven {&#10;                                    url &quot;https://redirector.kotlinlang.org/maven/ktor-eap&quot;&#10;                                }&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Maven" group-key="maven">
+                        <code-block lang="XML" code="                            &lt;repositories&gt;&#10;                                &lt;repository&gt;&#10;                                    &lt;id&gt;ktor-eap&lt;/id&gt;&#10;                                    &lt;url&gt;https://redirector.kotlinlang.org/maven/ktor-eap&lt;/url&gt;&#10;                                &lt;/repository&gt;&#10;                            &lt;/repositories&gt;"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    请注意，Ktor EAP 可能需要 <a href="https://redirector.kotlinlang.org/maven/dev">Kotlin 开发仓库</a>：
+                </p>
+                <Tabs group="languages">
+                    <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                        <code-block lang="Kotlin" code="                            repositories {&#10;                                maven {&#10;                                    url = uri(&quot;https://redirector.kotlinlang.org/maven/dev&quot;)&#10;                                }&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Gradle (Groovy)" group-key="groovy">
+                        <code-block lang="Groovy" code="                            repositories {&#10;                                maven {&#10;                                    url &quot;https://redirector.kotlinlang.org/maven/dev&quot;&#10;                                }&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Maven" group-key="maven">
+                        <code-block lang="XML" code="                            &lt;repositories&gt;&#10;                                &lt;repository&gt;&#10;                                    &lt;id&gt;ktor-eap&lt;/id&gt;&#10;                                    &lt;url&gt;https://redirector.kotlinlang.org/maven/dev&lt;/url&gt;&#10;                                &lt;/repository&gt;&#10;                            &lt;/repositories&gt;"/>
+                    </TabItem>
+                </Tabs>
+            </li>
+        </list>
+    </chapter>
+    <chapter title="添加依赖项" id="add-ktor-dependencies">
+        <chapter title="核心依赖项" id="core-dependencies">
+            <p>
+                每个 Ktor 应用程序至少需要以下依赖项：
+            </p>
+            <list>
+                <li>
+                    <p>
+                        <code>ktor-server-core</code>：包含 Ktor 核心功能。
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        一个<Links href="//server-engines" summary="了解处理网络请求的引擎。">引擎</Links>（例如 <code>ktor-server-netty</code>）的依赖项。
+                    </p>
+                </li>
+            </list>
+            <p>
+                针对不同的平台，Ktor 提供了带有后缀（如 <code>-jvm</code>）的平台特定构件，例如 <code>ktor-server-core-jvm</code> 或 <code>ktor-server-netty-jvm</code>。
+                请注意，Gradle 会解析适用于给定平台的构件，而 Maven 则不支持此功能。
+                这意味着对于 Maven，您需要手动添加平台特定后缀。
+                一个基础 Ktor 应用程序的 <code>dependencies</code> 块可能如下所示：
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                        dependencies {&#10;                            implementation(&quot;io.ktor:ktor-server-core:%ktor_version%&quot;)&#10;                            implementation(&quot;io.ktor:ktor-server-netty:%ktor_version%&quot;)&#10;                        }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                        dependencies {&#10;                            implementation &quot;io.ktor:ktor-server-core:%ktor_version%&quot;&#10;                            implementation &quot;io.ktor:ktor-server-netty:%ktor_version%&quot;&#10;                        }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <code-block lang="XML" code="                        &lt;dependencies&gt;&#10;                            &lt;dependency&gt;&#10;                                &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                                &lt;artifactId&gt;ktor-server-core-jvm&lt;/artifactId&gt;&#10;                                &lt;version&gt;%ktor_version%&lt;/version&gt;&#10;                            &lt;/dependency&gt;&#10;                            &lt;dependency&gt;&#10;                                &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                                &lt;artifactId&gt;ktor-server-netty-jvm&lt;/artifactId&gt;&#10;                                &lt;version&gt;%ktor_version%&lt;/version&gt;&#10;                            &lt;/dependency&gt;&#10;                        &lt;/dependencies&gt;"/>
+                </TabItem>
+            </Tabs>
+        </chapter>
+        <chapter title="日志依赖项" id="logging-dependency">
+            <p>
+                Ktor 使用 SLF4J API 作为各种日志框架（例如 Logback 或 Log4j）的门面，并允许您记录应用程序事件。
+                要了解如何添加所需的构件，请参阅<a href="server-logging.md#add_dependencies">添加记录器依赖项</a>。
+            </p>
+        </chapter>
+        <chapter title="插件依赖项" id="plugin-dependencies">
+            <p>
+                扩展 Ktor 功能的<Links href="//server-plugins" summary="插件提供了通用功能，例如序列化、内容编码、压缩等。">插件</Links>可能需要额外的依赖项。
+                您可以从相应主题中了解更多信息。
+            </p>
+        </chapter>
+    </chapter>
+    <var name="target_module" value="server"/>
+    <chapter title="确保 Ktor 版本一致性" id="ensure-version-consistency">
+        <chapter id="using-gradle-plugin" title="使用 Ktor Gradle 插件">
+            <p>
+                应用 <a href="https://github.com/ktorio/ktor-build-plugins">Ktor Gradle 插件</a>会隐式添加 Ktor BOM 依赖项，并允许您确保所有 Ktor 依赖项的版本一致。在这种情况下，在依赖 Ktor 构件时，您不再需要指定版本：
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                        plugins {&#10;                            // ...&#10;                            id(&quot;io.ktor.plugin&quot;) version &quot;%ktor_version%&quot;&#10;                        }&#10;                        dependencies {&#10;                            implementation(&quot;io.ktor:ktor-%target_module%-core&quot;)&#10;                            // ...&#10;                        }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                        plugins {&#10;                            // ...&#10;                            id &quot;io.ktor.plugin&quot; version &quot;%ktor_version%&quot;&#10;                        }&#10;                        dependencies {&#10;                            implementation &quot;io.ktor:ktor-%target_module%-core&quot;&#10;                            // ...&#10;                        }"/>
+                </TabItem>
+            </Tabs>
+        </chapter>
+        <chapter id="using-version-catalog" title="使用发布的版本目录">
+            <p>
+                您还可以通过使用发布的版本目录来集中管理 Ktor 依赖项声明。
+                此方法具有以下优点：
+            </p>
+            <list id="published-version-catalog-benefits">
+                <li>
+                    无需在您自己的目录中手动声明 Ktor 版本。
+                </li>
+                <li>
+                    在单个命名空间下公开每个 Ktor 模块。
+                </li>
+            </list>
+            <p>
+                要声明目录，请在 <Path>settings.gradle.kts</Path> 中创建一个具有您所选名称的版本目录：
+            </p>
+            <code-block lang="kotlin" code="                dependencyResolutionManagement {&#10;                    versionCatalogs {&#10;                        create(&quot;ktorLibs&quot;) {&#10;                            from(&quot;io.ktor:ktor-version-catalog:%ktor_version%&quot;)&#10;                        }&#10;                    }&#10;                }"/>
+            <p>
+                然后，您可以通过引用目录名称在模块的 <Path>build.gradle.kts</Path> 中添加依赖项：
+            </p>
+            <code-block lang="kotlin" code="                dependencies {&#10;                    implementation(ktorLibs.%target_module%.core)&#10;                    // ...&#10;                }"/>
+        </chapter>
+    </chapter>
+    <chapter title="创建运行应用程序的入口点" id="create-entry-point">
+        <p>
+            使用 Gradle/Maven <Links href="//server-run" summary="了解如何运行服务器 Ktor 应用程序。">运行</Links> Ktor 服务器取决于<Links href="//server-create-and-configure" summary="了解如何根据您的应用程序部署需求创建服务器。">创建服务器</Links>的方式。
+            您可以通过以下方式之一指定应用程序主类：
+        </p>
+        <list>
+            <li>
+                <p>
+                    如果您使用 <a href="#embedded-server">embeddedServer</a>，请按如下方式指定主类：
+                </p>
+                <Tabs group="languages">
+                    <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                        <code-block lang="Kotlin" code="                            application {&#10;                                mainClass.set(&quot;com.example.ApplicationKt&quot;)&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Gradle (Groovy)" group-key="groovy">
+                        <code-block lang="Groovy" code="                            application {&#10;                                mainClass = &quot;com.example.ApplicationKt&quot;&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Maven" group-key="maven">
+                        <code-block lang="XML" code="                            &lt;properties&gt;&#10;                                &lt;main.class&gt;com.example.ApplicationKt&lt;/main.class&gt;&#10;                            &lt;/properties&gt;"/>
+                    </TabItem>
+                </Tabs>
+            </li>
+            <li>
+                <p>
+                    如果您使用 <a href="#engine-main">EngineMain</a>，则需要将其配置为主类。
+                    对于 Netty，它将如下所示：
+                </p>
+                <Tabs group="languages">
+                    <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                        <code-block lang="Kotlin" code="                            application {&#10;                                mainClass.set(&quot;io.ktor.server.netty.EngineMain&quot;)&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Gradle (Groovy)" group-key="groovy">
+                        <code-block lang="Groovy" code="                            application {&#10;                                mainClass = &quot;io.ktor.server.netty.EngineMain&quot;&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Maven" group-key="maven">
+                        <code-block lang="XML" code="                            &lt;properties&gt;&#10;                                &lt;main.class&gt;io.ktor.server.netty.EngineMain&lt;/main.class&gt;&#10;                            &lt;/properties&gt;"/>
+                    </TabItem>
+                </Tabs>
+            </li>
+        </list>
+        <note>
+            <p>
+                如果您打算将应用程序打包为 Fat JAR，那么在配置相应插件时，您还需要考虑创建服务器的方式。
+                请通过以下主题了解更多信息：
+            </p>
+            <list>
+                <li>
+                    <p>
+                        <Links href="//server-fatjar" summary="了解如何使用 Ktor Gradle 插件创建和运行可执行的 Fat JAR。">使用 Ktor Gradle 插件创建 Fat JAR</Links>
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <Links href="//maven-assembly-plugin" summary="示例项目：tutorial-server-get-started-maven">使用 Maven Assembly 插件创建 Fat JAR</Links>
+                    </p>
+                </li>
+            </list>
+        </note>
+    </chapter>
+</topic>

--- a/docs/ktor/server-development-mode.md
+++ b/docs/ktor/server-development-mode.md
@@ -1,0 +1,77 @@
+<topic xmlns="" xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="server-development-mode" title="开发模式"
+       help-id="development_mode;development-mode">
+<show-structure for="chapter" depth="2"/>
+<p>
+    Ktor 提供了一种专门针对开发的特殊模式。此模式启用了以下功能：
+</p>
+<list>
+    <li>用于在不重启服务器的情况下重新加载应用程序类的<Links href="//server-auto-reload" summary="了解如何使用自动重载在代码更改时重新加载应用程序类。">自动重载</Links>。
+    </li>
+    <li>用于调试<a href="#pipelines">流水线</a>的扩展信息（带堆栈跟踪）。
+    </li>
+    <li>在发生 <emphasis>5**</emphasis> 服务器错误时，在<Links href="//server-status-pages" summary="%plugin_name% 允许 Ktor 应用程序根据抛出的异常或状态码对任何失败状态做出适当响应。">响应页面</Links>上提供扩展的调试信息。
+    </li>
+</list>
+<note>
+    <p>
+        请注意，开发模式会影响性能，不应在生产环境中使用。
+    </p>
+</note>
+<chapter title="启用开发模式" id="enable">
+    <p>
+        您可以通过不同方式启用开发模式：在应用程序配置文件中、使用专用系统属性或环境变量。
+    </p>
+    <chapter title="配置文件" id="application-conf">
+        <p>
+            要在<Links href="//server-configuration-file" summary="了解如何在配置文件中配置各种服务器参数。">配置文件</Links>中启用开发模式，请将 <code>development</code> 选项设置为 <code>true</code>：
+        </p>
+        <Tabs group="config">
+            <TabItem title="application.conf" group-key="hocon">
+                <code-block code="                        ktor {&#10;                            development = true&#10;                        }"/>
+            </TabItem>
+            <TabItem title="application.yaml" group-key="yaml">
+                <code-block lang="yaml" code="                        ktor:&#10;                            development: true"/>
+            </TabItem>
+        </Tabs>
+    </chapter>
+    <chapter title="'io.ktor.development' 系统属性" id="system-property">
+        <p>
+            <control>io.ktor.development</control>
+            <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">系统属性</a>允许您在运行应用程序时启用开发模式。
+        </p>
+        <p>
+            要在使用 IntelliJ IDEA 运行应用程序时开启开发模式，请将带有 <code>-D</code> 标志的 <code>io.ktor.development</code> 传递给 <a href="https://www.jetbrains.com/help/idea/run-debug-configuration-kotlin.html#1">VM 选项</a>：
+        </p>
+        <code-block code="                -Dio.ktor.development=true"/>
+        <p>
+            如果您使用 <Links href="//server-dependencies" summary="了解如何向现有 Gradle/Maven 项目添加 Ktor 服务器依赖项。">Gradle</Links> 任务运行应用程序，可以通过以下两种方式之一启用开发模式：
+        </p>
+        <list>
+            <li>
+                <p>
+                    在您的 <Path>build.gradle.kts</Path> 文件中配置 <code>ktor</code> 块：
+                </p>
+                <code-block lang="Kotlin" code="                        ktor {&#10;                            development = true&#10;                        }"/>
+            </li>
+            <li>
+                <p>
+                    通过传递 Gradle CLI 标志来为单次运行启用开发模式：
+                </p>
+                <code-block lang="bash" code="                          ./gradlew run -Pio.ktor.development=true"/>
+            </li>
+        </list>
+        <tip>
+            <p>
+                您也可以使用 <code>-ea</code> 标志来启用开发模式。
+                请注意，使用 <code>-D</code> 标志传递的 <code>io.ktor.development</code> 系统属性的优先级高于 <code>-ea</code>。
+            </p>
+        </tip>
+    </chapter>
+    <chapter title="'io.ktor.development' 环境变量" id="environment-variable">
+        <p>
+            要为 <a href="#native">原生客户端</a> 启用开发模式，请使用 <code>io.ktor.development</code> 环境变量。
+        </p>
+    </chapter>
+</chapter>
+</topic>

--- a/docs/zh-Hant/ktor/FAQ.md
+++ b/docs/zh-Hant/ktor/FAQ.md
@@ -1,0 +1,166 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="常見問題"
+       id="FAQ">
+    <chapter title="Ktor 的正確發音是什麼？" id="pronounce">
+        <p>
+            <emphasis>/keɪ-tor/</emphasis>
+        </p>
+    </chapter>
+    <chapter title='「Ktor」這個名稱代表什麼意思？' id="name-meaning">
+        <p>
+            Ktor這個名稱源自縮寫<code>ctor</code>（建構函式），並將第一個字母替換為代表Kotlin的「K」。
+        </p>
+    </chapter>
+    <chapter title="我該如何提出問題、回報錯誤、聯繫你們、進行貢獻或提供意見回饋等？" id="feedback">
+        <p>
+            請前往<a href="https://ktor.io/support/">支援</a>頁面以進一步了解可用的支援管道。
+            <a href="https://github.com/ktorio/ktor/blob/main/CONTRIBUTING.md">如何貢獻</a>指南說明了您可以為Ktor做出貢獻的方式。
+        </p>
+    </chapter>
+    <chapter title="CIO 代表什麼意思？" id="cio">
+        <p>
+            CIO代表
+            <emphasis>基於協同程式的I/O</emphasis>
+            （Coroutine-based I/O）。
+            通常我們將其稱為一種使用Kotlin和協同程式來實作IETF RFC或其他協定邏輯的引擎，且不依賴外部基於JVM的程式庫。
+        </p>
+    </chapter>
+    <chapter title="如何修復未解決的（紅色）Ktor 匯入？" id="ktor-artifact">
+        <p>
+            請確保在建置指令碼中加入了相對應的<Links href="//server-dependencies" summary="了解如何將 Ktor Server 相依性新增至現有的 Gradle/Maven 專案。">Ktor構件</Links>。
+        </p>
+    </chapter>
+    <chapter
+            title="Ktor 是否提供擷取 IPC 訊號（例如 SIGTERM 或 SIGINT）的方法，以便平滑地處理伺服器關閉？"
+            id="sigterm">
+        <p>
+            如果您正在執行<a href="#engine-main">EngineMain</a>，它將會被自動處理。
+            否則，您需要手動處理。
+            您可以使用JVM提供的<code>Runtime.getRuntime().addShutdownHook</code>設施。
+        </p>
+    </chapter>
+    <chapter title="在代理伺服器後方如何獲取用戶端 IP？" id="proxy-ip">
+        <p>
+            如果代理伺服器提供了正確的標頭，且已安裝<Links href="//server-forward-headers" summary="所需的相依性：io.ktor:%artifact_name%">ForwardedHeader</Links>外掛程式，則<code>call.request.origin</code>屬性會提供關於原始呼叫者（代理伺服器）的<a href="#request_information">連線資訊</a>。
+        </p>
+    </chapter>
+    <chapter title="我該如何測試 main 分支上最新的提交？" id="bleeding-edge">
+        <p>
+            您可以從<code>jetbrains.space</code>獲取Ktor每晚建置版本。
+            請從<a href="https://ktor.io/eap/">早期體驗計劃</a>了解更多資訊。
+        </p>
+    </chapter>
+    <chapter title="我該如何確認我正在使用的是哪個版本的 Ktor？" id="ktor-version-used">
+        <p>
+            您可以使用<Links href="//server-default-headers" summary="所需的相依性：io.ktor:%artifact_name%">DefaultHeaders</Links>外掛程式，它會發送包含Ktor版本的<code>Server</code>回應標頭，例如：
+        </p>
+        <code-block code="            Server: ktor-server-core/%ktor_version%"/>
+    </chapter>
+    <chapter title="我的路由未被執行。我該如何偵錯？" id="route-not-executing">
+        <p>
+            Ktor提供了一種追蹤機制來協助排查路由決策問題。
+            請參閱<a href="#trace_routes">追蹤路由</a>章節。
+        </p>
+    </chapter>
+    <chapter title="如何解決「Response has already been sent」錯誤？" id="response-already-sent">
+        <p>
+            這表示您、或是某個外掛程式或攔截器已經呼叫過<code>call.respond&#42; </code>函式，而您正試圖再次呼叫它。
+        </p>
+    </chapter>
+    <chapter title="我該如何訂閱 Ktor 事件？" id="ktor-events">
+        <p>
+            請參閱<Links href="//server-events" summary="">應用程式監控</Links>頁面以了解更多資訊。
+        </p>
+    </chapter>
+    <chapter title="如何解決「No configuration setting found for key ktor」錯誤？" id="cannot-find-application-conf">
+        <p>
+            這表示Ktor無法找到<Links href="//server-configuration-file" summary="了解如何在設定檔中配置各種伺服器參數。">設定檔</Links>。
+            請確保<code>resources</code>資料夾中存在設定檔，且該<code>resources</code>資料夾已被正確標記。
+            建議使用<a href="https://start.ktor.io/">Ktor專案產生器</a>或<a href="https://plugins.jetbrains.com/plugin/16008-ktor">IntelliJ IDEA Ultimate 的 Ktor 外掛程式</a>來建立專案，以獲得一個可運作的專案基底。如需更多資訊，請參閱<Links href="//server-create-a-new-project" summary="了解如何使用 Ktor 開啟、執行和測試伺服器應用程式。">建立、開啟並執行新的 Ktor 專案</Links>。
+        </p>
+    </chapter>
+    <chapter title="我可以在 Android 上使用 Ktor 嗎？" id="android-support">
+        <p>
+            可以，已知Ktor伺服器和用戶端可在Android 5（API 21）或更高版本上運作，至少在使用Netty引擎時是如此。
+        </p>
+    </chapter>
+    <chapter title="為什麼「CURL -I」會傳回「404 Not Found」？" id="curl-head-not-found">
+        <p>
+            <code>CURL -I</code>是<code>CURL --head</code>的別名，用於執行<code>HEAD</code>請求。
+            預設情況下，Ktor不會為<code>GET</code>處理常式處理<code>HEAD</code>請求。
+            若要啟用此功能，請安裝<Links href="//server-autoheadresponse" summary="%plugin_name% 能夠針對每個已定義 GET 的路由自動回應 HEAD 請求。">AutoHeadResponse</Links>外掛程式。
+        </p>
+    </chapter>
+    <chapter title="如何解決使用「HttpsRedirect」外掛程式時的無限重定向問題？" id="infinite-redirect">
+        <p>
+            最可能的原因是您的後端位於反向代理或負載平衡器之後，而該中間設備正向您的後端發送一般的HTTP請求，因此Ktor後端內的<code>HttpsRedirect</code>外掛程式認為這是一個一般的HTTP請求，並以重定向作為回應。
+        </p>
+        <p>
+            通常，反向代理會發送一些描述原始請求的標頭（例如原本是否為HTTPS或原始IP位址），而<Links href="//server-forward-headers" summary="所需的相依性：io.ktor:%artifact_name%">ForwardedHeader</Links>外掛程式可以解析這些標頭，讓<Links href="//server-https-redirect" summary="所需的相依性：io.ktor:%artifact_name%">HttpsRedirect</Links>外掛程式知道原始請求是HTTPS。
+        </p>
+    </chapter>
+    <chapter title="如何在 Windows 上安裝「curl」以便在 Kotlin/Native 上使用對應的引擎？" id="native-curl">
+        <p>
+            <a href="#curl">Curl</a>用戶端引擎需要安裝
+            <code>curl</code>程式庫。
+            在Windows上，您可以考慮使用MinGW/MSYS2的<code>curl</code>二進位檔。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    按照<a href="https://www.msys2.org/">MinGW/MSYS2</a>中的說明安裝MinGW/MSYS2。
+                </p>
+            </step>
+            <step>
+                <p>
+                    使用以下指令安裝<code>libcurl</code>：
+                </p>
+                <code-block lang="shell" code="                    pacman -S mingw-w64-x86_64-curl"/>
+            </step>
+            <step>
+                <p>
+                    如果您將MinGW/MSYS2安裝在預設位置，請將
+                    <Path>C:\\msys64\\mingw64\\bin\\</Path>
+                    新增至<code>PATH</code>環境變數中。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="如何解決「NoTransformationFoundException」？" id="no-transformation-found-exception">
+        <p>
+            <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.call/-no-transformation-found-exception/index.html">NoTransformationFoundException</a>
+            代表無法為<i>接收的主體</i>找到合適的轉換，無法將<b>結果</b>型別轉換為用戶端<b>預期</b>的型別。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    檢查請求中的<code>Accept</code>標頭是否指定了所需的內容類型，以及伺服器回應中的<code>Content-Type</code>標頭是否與用戶端預期的型別相符。
+                </p>
+            </step>
+            <step>
+                <p>
+                    為您正在處理的特定內容類型註冊必要的內容轉換。
+                </p>
+                <p>
+                    您可以在用戶端使用<a href="https://ktor.io/docs/serialization-client.html">ContentNegotiation</a>
+                    外掛程式。
+                    此外掛程式允許您指定如何針對不同的內容類型進行序列化和反序列化資料。
+                </p>
+                <code-block lang="kotlin" code="                    val client = HttpClient(CIO) {&#10;                        install(ContentNegotiation) {&#10;                            json() // 範例：註冊 JSON 內容轉換&#10;                            // 根據需要為其他內容類型新增更多轉換&#10;                        }&#10;                    }"/>
+            </step>
+            <step>
+                <p>
+                    確保您安裝了所有需要的外掛程式。可能缺少的功能包括：
+                </p>
+                <list type="bullet">
+                    <li>用戶端<a href="https://ktor.io/docs/websocket-client.html">WebSockets</a>與
+                        伺服器<a href="https://ktor.io/docs/websocket.html">WebSockets</a></li>
+                    <li>用戶端<a href="https://ktor.io/docs/serialization-client.html">ContentNegotiation</a>與
+                        伺服器<a href="https://ktor.io/docs/server-serialization.html">ContentNegotiation</a></li>
+                    <li><a href="https://ktor.io/docs/compression.html">Compression</a></li>
+                </list>
+            </step>
+        </procedure>
+    </chapter>
+</topic>

--- a/docs/zh-Hant/ktor/client-create-new-application.md
+++ b/docs/zh-Hant/ktor/client-create-new-application.md
@@ -1,0 +1,329 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="建立用戶端應用程式"
+       id="client-create-new-application"
+       help-id="getting_started_ktor_client;client-getting-started;client-get-started;client-create-a-new-application">
+    <show-structure for="chapter" depth="2"/>
+    <tldr>
+        <var name="example_name" value="tutorial-client-get-started"/>
+        <p>
+            <b>程式碼範例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+    </tldr>
+    <link-summary>
+        建立你的第一個用戶端應用程式，用於傳送請求並接收回應。
+    </link-summary>
+    <p>
+        Ktor 包含一個多平台非同步 HTTP client，這讓你可以<Links href="//client-requests" summary="了解如何發送請求並指定各種請求參數：請求 URL、HTTP 方法、標頭及請求主體。">發送請求</Links>並<Links href="//client-responses" summary="了解如何接收回應、取得回應主體以及獲取回應參數。">處理回應</Links>，
+        並透過<Links href="//client-plugins" summary="了解如何使用用戶端外掛程式來加入常用功能，例如記錄、序列化和授權。">外掛程式</Links>擴充其功能，例如<Links href="//client-auth" summary="Auth 外掛程式在你的用戶端應用程式中處理身份驗證與授權。">身分驗證</Links>、
+        <Links href="//client-serialization" summary="ContentNegotiation 外掛程式有兩個主要目的：在用戶端與伺服器之間協商媒體類型，以及在傳送請求與接收回應時，以特定格式序列化/反序列化內容。">JSON 序列化</Links>等。
+    </p>
+    <p>
+        在本教學中，我們將向你展示如何建立第一個 Ktor 用戶端應用程式，該程式會傳送請求並列印出回應。
+    </p>
+    <chapter title="前置需求" id="prerequisites">
+        <p>
+            在開始本教學之前，請先
+            <a href="https://www.jetbrains.com/help/idea/installation-guide.html">安裝 IntelliJ IDEA Community 或
+                Ultimate</a>。
+        </p>
+    </chapter>
+    <chapter title="建立新專案" id="new-project">
+        <p>
+            你可以在現有專案中手動<Links href="//client-create-and-configure" summary="了解如何建立與配置 Ktor 用戶端。">建立與配置</Links> Ktor Client，然而，從頭開始最方便的方式是使用 IntelliJ IDEA 內建的 Kotlin 外掛程式產生一個新專案。
+        </p>
+        <p>
+            若要建立新的 Kotlin 專案，請
+            <a href="https://www.jetbrains.com/help/idea/run-for-the-first-time.html">開啟 IntelliJ IDEA</a> 並遵循以下步驟：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    在歡迎畫面中，點擊 <control>New Project</control>。
+                </p>
+                <p>
+                    或者，從主選單中選擇 <ui-path>File | New | Project</ui-path>。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在
+                    <control>New Project</control>
+                    精靈中，從左側選單選擇
+                    <control>Kotlin</control>。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在右側面板，指定以下設定：
+                </p>
+                <img src="client_get_started_new_project.png" alt="IntelliJ IDEA 中的新 Kotlin 專案視窗"
+                     border-effect="rounded"
+                     width="706"/>
+                <list id="kotlin_app_settings">
+                    <li>
+                        <p>
+                            <control>Name</control>
+                            ：指定專案名稱。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Location</control>
+                            ：指定專案的目錄。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Build system</control>
+                            ：確保已選擇
+                            <control>Gradle</control>。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Gradle DSL</control>
+                            ：選擇
+                            <control>Kotlin</control>。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Add sample code</control>
+                            ：選擇此選項以在產生的專案中包含範例程式碼。
+                        </p>
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    點擊
+                    <control>Create</control>
+                    並等待 IntelliJ IDEA 產生專案並安裝相依性。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="加入相依性" id="add-dependencies">
+        <p>
+            讓我們加入 Ktor 用戶端所需的相依性。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    開啟
+                    <Path>gradle.properties</Path>
+                    檔案並加入以下行以指定 Ktor 版本：
+                </p>
+                <code-block lang="kotlin" code="                    ktor_version=%ktor_version%"/>
+                <note id="eap-note">
+                    <p>
+                        若要使用 EAP 版本的 Ktor，你需要加入 <a href="#repositories">Space 儲存庫</a>。
+                    </p>
+                </note>
+            </step>
+            <step>
+                <p>
+                    開啟
+                    <Path>build.gradle.kts</Path>
+                    檔案並將以下構件加入到 dependencies 區塊中：
+                </p>
+                <code-block lang="kotlin" code="val ktor_version: String by project&#10;&#10;dependencies {&#10;    implementation(&quot;io.ktor:ktor-client-core:$ktor_version&quot;)&#10;    implementation(&quot;io.ktor:ktor-client-cio:$ktor_version&quot;)&#10;}"/>
+                <list>
+                    <li><code>ktor-client-core</code> 是一個核心相依性，提供了主要的用戶端功能。
+                    </li>
+                    <li>
+                        <code>ktor-client-cio</code> 是處理網路請求之<Links href="//client-engines" summary="了解處理網路請求的引擎。">引擎</Links>的相依性。
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    點擊
+                    <Path>build.gradle.kts</Path>
+                    檔案右上角的
+                    <control>Load Gradle Changes</control>
+                    圖示，以安裝新加入的相依性。
+                </p>
+                <img src="client_get_started_load_gradle_changes_name.png" alt="載入 Gradle 變更" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="建立用戶端" id="create-client">
+        <p>
+            若要加入用戶端實作，請導覽至
+            <Path>src/main/kotlin</Path>
+            並遵循以下步驟：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    開啟
+                    <Path>Main.kt</Path>
+                    檔案並將現有程式碼替換為以下實作：
+                </p>
+                <code-block lang="kotlin" code="                    import io.ktor.client.*&#10;                    import io.ktor.client.engine.cio.*&#10;&#10;                    fun main() {&#10;                        val client = HttpClient(CIO)&#10;                    }"/>
+                <p>
+                    在 Ktor 中，用戶端由 <a
+                        href="https://api.ktor.io/ktor-client-core/io.ktor.client/-http-client/index.html">HttpClient</a>
+                    類別表示。
+                </p>
+            </step>
+            <step>
+                <p>
+                    使用 <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.request/get.html"><code>HttpClient.get()</code></a> 方法來<Links href="//client-requests" summary="了解如何發送請求並指定各種請求參數：請求 URL、HTTP 方法、標頭及請求主體。">發送一個 GET 請求</Links>。
+                    <Links href="//client-responses" summary="了解如何接收回應、取得回應主體以及獲取回應參數。">回應</Links>將以 <code>HttpResponse</code> 類別物件的形式接收。
+                </p>
+                <code-block lang="kotlin" code="                    import io.ktor.client.*&#10;                    import io.ktor.client.engine.cio.*&#10;                    import io.ktor.client.request.*&#10;                    import io.ktor.client.statement.*&#10;&#10;                    fun main() {&#10;                        val client = HttpClient(CIO)&#10;                        val response: HttpResponse = client.get(&quot;https://ktor.io/&quot;)&#10;                    }"/>
+                <p>
+                    加入上述程式碼後，IDE 會針對 <code>get()</code> 函式顯示以下錯誤：
+                    <emphasis>Suspend function 'get' should be called only from a coroutine or another suspend
+                        function
+                    </emphasis>（暫停函式 'get' 應僅從協同程式或其他暫停函式中呼叫）。
+                </p>
+                <img src="client_get_started_suspend_error.png" alt="暫停函式錯誤" width="706"/>
+                <p>
+                    若要修正此問題，你需要將 <code>main()</code> 函式設為暫停函式。
+                </p>
+                <tip>
+                    若要進一步了解呼叫 <code>suspend</code> 函式，請參閱 <a
+                        href="https://kotlinlang.org/docs/coroutines-basics.html">協同程式基礎</a>。
+                </tip>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，點擊定義旁邊的紅色燈泡圖示，然後選擇
+                    <control>Make main suspend</control>。
+                </p>
+                <img src="client_get_started_suspend_error_fix.png" alt="將 main 改為 suspend" width="706"/>
+            </step>
+            <step>
+                <p>
+                    使用 <code>println()</code> 函式來列印伺服器傳回的<a href="#status">狀態碼</a>，並使用 <code>close()</code> 函式來關閉串流並釋放與其相關的所有資源。
+                    <Path>Main.kt</Path>
+                    檔案內容應如下所示：
+                </p>
+                <code-block lang="kotlin" code="import io.ktor.client.*&#10;import io.ktor.client.engine.cio.*&#10;import io.ktor.client.request.*&#10;import io.ktor.client.statement.*&#10;&#10;suspend fun main() {&#10;    val client = HttpClient(CIO)&#10;    val response: HttpResponse = client.get(&quot;https://ktor.io/&quot;)&#10;    println(response.status)&#10;    client.close()&#10;}"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="執行你的應用程式" id="make-request">
+        <p>
+            若要執行你的應用程式，請導覽至
+            <Path>Main.kt</Path>
+            檔案並遵循以下步驟：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，點擊 <code>main()</code> 函式旁邊的裝訂邊圖示，然後選擇
+                    <control>Run 'MainKt'</control>。
+                </p>
+                <img src="client_get_started_run_main.png" alt="執行應用程式" width="706"/>
+            </step>
+            <step>
+                等待 IntelliJ IDEA 執行應用程式。
+            </step>
+            <step>
+                <p>
+                    你將在 IDE 底部的
+                    <control>Run</control>
+                    面板中看到顯示的輸出。
+                </p>
+                <img src="client_get_started_run_output_with_warning.png" alt="伺服器回應" width="706"/>
+                <p>
+                    雖然伺服器回應了 <code>200 OK</code> 訊息，
+                    你也會看到一條錯誤訊息，指出 SLF4J 未能找到
+                    <code>StaticLoggerBinder</code> 類別，並預設為無操作 (NOP) 記錄器實作。這實際上表示記錄功能已被停用。
+                </p>
+                <p>
+                    你現在已經有一個可運作的用戶端應用程式。然而，為了修正此警告並能夠透過記錄功能偵錯 HTTP 呼叫，還需要<a href="#enable-logging">額外的步驟</a>。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="啟用記錄" id="enable-logging">
+        <p>
+            因為 Ktor 在 JVM 上使用 SLF4J 抽象層進行記錄，若要啟用記錄，你需要
+            <a href="#jvm">提供一個記錄架構</a>，例如
+            <a href="https://logback.qos.ch/">Logback</a>。
+        </p>
+        <procedure id="enable-logging-procedure">
+            <step>
+                <p>
+                    在
+                    <Path>gradle.properties</Path>
+                    檔案中，指定記錄架構的版本：
+                </p>
+                <code-block lang="kotlin" code="                    logback_version=%logback_version%"/>
+            </step>
+            <step>
+                <p>
+                    開啟
+                    <Path>build.gradle.kts</Path>
+                    檔案並將以下構件加入到 dependencies 區塊中：
+                </p>
+                <code-block lang="kotlin" code="                    //...&#10;                    val logback_version: String by project&#10;&#10;                    dependencies {&#10;                        //...&#10;                        implementation(&quot;ch.qos.logback:logback-classic:$logback_version&quot;)&#10;                    }"/>
+            </step>
+            <step>
+                點擊
+                <control>Load Gradle Changes</control>
+                圖示以安裝新加入的相依性。
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，點擊重新執行按鈕（<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 重新執行圖示"/>）以重新啟動應用程式。
+                </p>
+            </step>
+            <step>
+                <p>
+                    你應該不再看到該錯誤，而是在 IDE 底部的
+                    <control>Run</control>
+                    面板中顯示相同的 <code>200 OK</code> 訊息。
+                </p>
+                <img src="client_get_started_run_output.png" alt="伺服器回應" width="706"/>
+                <p>
+                    至此，你已經啟用了記錄功能。若要開始看到記錄內容，你需要加入記錄配置。
+                </p>
+            </step>
+            <step>
+                <p>導覽至
+                    <Path>src/main/resources</Path>
+                    並建立一個新的
+                    <Path>logback.xml</Path>
+                    檔案，內容實作如下：
+                </p>
+                <code-block lang="xml" ignore-vars="true" code="                    &lt;configuration&gt;&#10;                        &lt;appender name=&quot;APPENDER&quot; class=&quot;ch.qos.logback.core.ConsoleAppender&quot;&gt;&#10;                            &lt;encoder&gt;&#10;                                &lt;pattern&gt;%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n&lt;/pattern&gt;&#10;                            &lt;/encoder&gt;&#10;                        &lt;/appender&gt;&#10;                        &lt;root level=&quot;trace&quot;&gt;&#10;                            undefined&#10;                        &lt;/root&gt;&#10;                    &lt;/configuration&gt;"/>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，點擊重新執行按鈕（<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 重新執行圖示"/>）以重新啟動應用程式。
+                </p>
+            </step>
+            <step>
+                <p>
+                    你現在應該能夠在
+                    <control>Run</control>
+                    面板中看到列印出的回應上方出現追蹤（trace）記錄：
+                </p>
+                <img src="client_get_started_run_output_with_logs.png" alt="伺服器回應" width="706"/>
+            </step>
+        </procedure>
+        <tip>
+            Ktor 透過 <Links href="//client-logging" summary="所需相依性：io.ktor:ktor-client-logging">Logging</Links> 外掛程式提供了一種簡單直覺的方式來為 HTTP 呼叫加入記錄，而加入配置檔案則讓你在複雜的應用程式中精確調整記錄行為。
+        </tip>
+    </chapter>
+    <chapter title="後續步驟" id="next-steps">
+        <p>
+            為了更深入理解並擴充此配置，請探索如何
+            <Links href="//client-create-and-configure" summary="了解如何建立與配置 Ktor 用戶端。">建立與配置 Ktor 用戶端</Links>。
+        </p>
+    </chapter>
+</topic>

--- a/docs/zh-Hant/ktor/client-server-sent-events.md
+++ b/docs/zh-Hant/ktor/client-server-sent-events.md
@@ -1,0 +1,207 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="client-server-sent-events" title="Ktor Client 中的 Server-Sent Events" help-id="sse_client">
+    <show-structure for="chapter" depth="2"/>
+    <primary-label ref="client-plugin"/>
+    <tldr>
+        <var name="example_name" value="client-sse"/>
+        <p>
+            <b>程式碼範例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+    </tldr>
+    <link-summary>
+        SSE 外掛程式允許用戶端透過 HTTP 連線從伺服器接收基於事件的更新。
+    </link-summary>
+    <p>
+        Server-Sent Events (SSE) 是一種允許伺服器透過 HTTP 連線持續將事件推送到用戶端的技術。當伺服器需要發送基於事件的更新而不需要用戶端重複輪詢伺服器時，這項技術特別有用。
+    </p>
+    <p>
+        Ktor 支援的 SSE 外掛程式提供了一種簡單的方法，用於在伺服器和用戶端之間建立單向連線。
+    </p>
+    <tip>
+        <p>若要進一步了解用於伺服器端支援的 SSE 外掛程式，請參閱
+            <Links href="//server-server-sent-events" summary="SSE 外掛程式允許伺服器透過 HTTP 連線向用戶端發送基於事件的更新。">SSE 伺服器外掛程式</Links>
+            。
+        </p>
+    </tip>
+    <chapter title="新增相依性" id="add_dependencies">
+        <p>
+            <code>SSE</code> 僅需要 <Links href="//client-dependencies" summary="了解如何向現有專案新增用戶端相依性。">ktor-client-core</Links> 構件，不需要任何特定的相依性。
+        </p>
+    </chapter>
+    <chapter title="安裝 SSE" id="install_plugin">
+        <p>
+            要安裝 <code>SSE</code> 外掛程式，請將其傳遞給 <a href="#configure-client">用戶端配置區塊</a> 內的 <code>install</code> 函式：
+        </p>
+        <code-block lang="kotlin" code="            import io.ktor.client.*&#10;            import io.ktor.client.engine.cio.*&#10;            import io.ktor.client.plugins.sse.*&#10;&#10;            //...&#10;            val client = HttpClient(CIO) {&#10;                install(SSE)&#10;            }"/>
+    </chapter>
+    <chapter title="配置 SSE 外掛程式" id="configure">
+        <p>
+            您可以選擇性地在 <code>install</code> 區塊中，透過設定
+            <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-s-s-e-config/index.html">SSEConfig</a>
+            類別支援的屬性來配置 SSE 外掛程式。
+        </p>
+        <chapter title="SSE 重新連線" id="sse-reconnect">
+            <p>
+                要啟用自動重新連線，請將 
+                <code>maxReconnectionAttempts</code> 設定為大於 <code>0</code> 的值。您也可以使用 <code>reconnectionTime</code> 來配置兩次嘗試之間的延遲：
+            </p>
+            <code-block lang="kotlin" code="                install(SSE) {&#10;                    maxReconnectionAttempts = 4&#10;                    reconnectionTime = 2.seconds&#10;                }"/>
+            <p>
+                如果與伺服器的連線中斷，用戶端將在嘗試重新連線之前等待指定的
+                <code>reconnectionTime</code>。它最多會進行
+                指定的 <code>maxReconnectionAttempts</code> 次嘗試來重新建立連線。
+            </p>
+        </chapter>
+        <chapter title="篩選事件" id="filter-events">
+            <p>
+                在以下範例中，SSE 外掛程式已安裝到 HTTP 用戶端中，並配置為在傳入流中僅包含包含註解的事件，以及僅包含 <code>retry</code> 欄位的事件：
+            </p>
+            <code-block lang="kotlin" code="        install(SSE) {&#10;            showCommentEvents()&#10;            showRetryEvents()&#10;        }"/>
+        </chapter>
+        <chapter title="回應緩衝" id="response-buffering">
+            <p>
+                SSE 回應在本質上是流式的，這使得擷取完整內容主體並不切實際。您可以啟用診斷緩衝區，以便在 SSE 流失敗時安全地檢索回應主體。該緩衝區僅包含已經處理過的資料（不從網路重新讀取），旨在用於失敗情況下的記錄和錯誤分析。
+            </p>
+            <code-block lang="kotlin" code="                install(SSE) {&#10;                    bufferPolicy = SSEBufferPolicy.LastEvents(10)&#10;                }"/>
+            <p>
+                您也可以針對每次呼叫進行配置：
+            </p>
+            <code-block lang="kotlin" code="                client.sse(url, {&#10;                    bufferPolicy(SSEBufferPolicy.All)&#10;                }) {&#10;                    // ...&#10;                }"/>
+            <chapter title="緩衝策略" id="buffer-policies">
+                <p>
+                    <code>SSEBufferPolicy</code> 型別提供了幾種儲存已處理 SSE 資料的策略。這些策略控制了流中有多少內容保留在記憶體中，並在發生錯誤時可供使用。
+                </p>
+                <deflist>
+                    <def id="buffer-off">
+                        <title><code>Off</code>（預設）</title>
+                        不進行緩衝。
+                    </def>
+                    <def id="buffer-lastlines">
+                        <title><code>LastLines(n)</code></title>
+                        保留最後 n 行。
+                    </def>
+                    <def id="buffer-lastevent">
+                        <title><code>LastEvent</code></title>
+                        保留最後一個完成的 SSE 事件。
+                    </def>
+                    <def id="buffer-lastevents">
+                        <title><code>LastEvents(n)</code></title>
+                        保留最後 n 個完成的 SSE 事件。
+                    </def>
+                    <def id="buffer-all">
+                        <title><code>All</code></title>
+                        保留目前為止所有已處理的事件。
+                        <note>對於長效流，請謹慎使用。</note>
+                    </def>
+                </deflist>
+                <p>
+                    發生失敗時，您可以使用 <code>response?.bodyAsText()</code> 存取緩衝區，而無需從網路重新讀取。
+                </p>
+            </chapter>
+        </chapter>
+    </chapter>
+    <chapter title="處理 SSE 工作階段" id="handle-sse-sessions">
+        <p>
+            用戶端的 SSE 工作階段由
+            <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session/index.html">
+                <code>ClientSSESession</code>
+            </a>
+            介面表示。此介面公開了允許您從伺服器接收伺服器傳送事件的 API。
+        </p>
+        <chapter title="存取 SSE 工作階段" id="access-sse-session">
+            <p><code>HttpClient</code> 允許您透過以下方式之一存取 SSE 工作階段：</p>
+            <list>
+                <li>
+                    <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/sse.html">
+                        <code>sse()</code>
+                    </a>
+                    函式會建立 SSE 工作階段並允許您對其進行操作。
+                </li>
+                <li>
+                    <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/sse-session.html">
+                        <code>sseSession()</code>
+                    </a>
+                    函式允許您開啟 SSE 工作階段。
+                </li>
+            </list>
+            <p>要指定 URL 端點，您可以從兩個選項中進行選擇：</p>
+            <list>
+                <li>使用 <code>urlString</code> 參數將整個 URL 指定為字串。</li>
+                <li>分別使用 <code>schema</code>、<code>host</code>、<code>port</code> 和 <code>path</code> 參數來指定協定架構、網域名稱、連接埠號和路徑名稱。
+                </li>
+            </list>
+            <code-block lang="kotlin" code="                runBlocking {&#10;                    client.sse(host = &amp;quot;127.0.0.1&amp;quot;, port = 8080, path = &amp;quot;/events&amp;quot;) {&#10;                        // this: ClientSSESession&#10;                    }&#10;                }"/>
+            <note>
+                <code>ClientSSESession</code> 和 <code>ClientSSESessionWithDeserialization</code> 執行個體僅在工作階段持續期間有效。當 <code>serverSentEvents { ... }</code> 區塊完成或連線關閉時，其作用域會自動取消。
+            </note>
+            <p>此外，還有以下參數可用於配置連線：</p>
+            <deflist>
+                <def id="reconnectionTime-param">
+                    <title><code>reconnectionTime</code></title>
+                    設定重新連線延遲。
+                </def>
+                <def id="showCommentEvents-param">
+                    <title><code>showCommentEvents</code></title>
+                    指定是否在傳入流中顯示僅包含註解的事件。
+                </def>
+                <def id="showRetryEvents-param">
+                    <title><code>showRetryEvents</code></title>
+                    指定是否在傳入流中顯示僅包含 <code>retry</code> 欄位的事件。
+                </def>
+                <def id="deserialize-param">
+                    <title><code>deserialize</code></title>
+                    一個反序列化函式，用於將 <code>TypedServerSentEvent</code> 的 <code>data</code> 欄位轉換為物件。如需更多資訊，請參閱 <a href="#deserialization">反序列化</a>。
+                </def>
+            </deflist>
+        </chapter>
+        <chapter title="SSE 工作階段區塊" id="sse-session-block">
+            <p>
+                在 Lambda 引數內，您可以存取
+                <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session/index.html"><code>ClientSSESession</code></a>
+                內容。區塊內提供以下屬性：
+            </p>
+            <deflist>
+                <def id="call">
+                    <title><code>call</code></title>
+                    發起該工作階段的關聯 <code>HttpClientCall</code>。
+                </def>
+                <def id="incoming">
+                    <title><code>incoming</code></title>
+                    一個傳入的伺服器傳送事件流。
+                </def>
+            </deflist>
+            <p>
+                下面的範例建立了一個連接到 <code>events</code> 端點的新 SSE 工作階段，透過 <code>incoming</code> 屬性讀取事件，並列印接收到的
+                <a href="https://api.ktor.io/ktor-sse/io.ktor.sse/-server-sent-event/index.html"><code>ServerSentEvent</code></a>
+                。
+            </p>
+            <code-block lang="kotlin" code="fun main() {&#10;    val client = HttpClient {&#10;        install(SSE) {&#10;            showCommentEvents()&#10;            showRetryEvents()&#10;        }&#10;    }&#10;    runBlocking {&#10;        client.sse(host = &quot;0.0.0.0&quot;, port = 8080, path = &quot;/events&quot;) {&#10;            while (true) {&#10;                incoming.collect { event -&gt;&#10;                    println(&quot;Event from server:&quot;)&#10;                    println(event)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>如需完整範例，請參閱
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-sse">client-sse</a>。
+            </p>
+        </chapter>
+        <chapter title="反序列化" id="deserialization">
+            <p>
+                SSE 外掛程式支援將伺服器傳送事件反序列化為型別安全的 Kotlin 物件。此功能在處理來自伺服器的結構化資料時特別有用。
+            </p>
+            <p>
+                要啟用反序列化，請在 SSE 存取函式上使用 <code>deserialize</code> 參數提供自訂的反序列化函式，並使用 
+                <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.sse/-client-s-s-e-session-with-deserialization/index.html">
+                    <code>ClientSSESessionWithDeserialization</code>
+                </a>
+                類別來處理反序列化後的事件。
+            </p>
+            <p>
+                這是一個使用 <code>kotlinx.serialization</code> 反序列化 JSON 資料的範例：
+            </p>
+            <code-block lang="Kotlin" code="        client.sse({&#10;            url(&quot;http://localhost:8080/serverSentEvents&quot;)&#10;        }, deserialize = {&#10;                typeInfo, jsonString -&gt;&#10;            val serializer = Json.serializersModule.serializer(typeInfo.kotlinType!!)&#10;            Json.decodeFromString(serializer, jsonString)!!&#10;        }) { // `this` is `ClientSSESessionWithDeserialization`&#10;            incoming.collect { event: TypedServerSentEvent&lt;String&gt; -&gt;&#10;                when (event.event) {&#10;                    &quot;customer&quot; -&gt; {&#10;                        val customer: Customer? = deserialize&lt;Customer&gt;(event.data)&#10;                    }&#10;                    &quot;product&quot; -&gt; {&#10;                        val product: Product? = deserialize&lt;Product&gt;(event.data)&#10;                    }&#10;                }&#10;            }&#10;        }"/>
+            <p>如需完整範例，請參閱
+                <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-sse">client-sse</a>。
+            </p>
+        </chapter>
+    </chapter>
+</topic>

--- a/docs/zh-Hant/ktor/client-websockets.md
+++ b/docs/zh-Hant/ktor/client-websockets.md
@@ -1,0 +1,153 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="client-websockets" title="Ktor Client 中的 WebSockets">
+<show-structure for="chapter" depth="3"/>
+<primary-label ref="client-plugin"/>
+<var name="example_name" value="client-websockets"/>
+<var name="artifact_name" value="ktor-client-websockets"/>
+<tldr>
+    <p>
+        <b>必要的相依性</b>：<code>io.ktor:ktor-client-websockets</code>
+    </p>
+    <p>
+        <b>程式碼範例</b>：
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+</tldr>
+<link-summary>
+    Websockets 外掛程式可讓您在伺服器與用戶端之間建立多向通訊工作階段。
+</link-summary>
+WebSocket 是一種協定，可透過單一 TCP 連線在用戶端的瀏覽器與伺服器之間提供全雙工 (full-duplex) 通訊工作階段。對於建立需要與伺服器進行即時資料傳輸的應用程式而言，它特別有用。
+Ktor 在伺服器端與用戶端均支援 WebSocket 協定。
+<p>用於用戶端的 Websockets 外掛程式可讓您處理與伺服器交換訊息的 WebSocket 工作階段。</p>
+<note>
+    <p>並非所有引擎都支援 WebSockets。如需支援引擎的概覽，請參閱<a href="client-engines.md#limitations">限制</a>。</p>
+</note>
+<tip>
+    <p>若要了解伺服器端的 WebSocket 支援，請參閱 <Links href="//server-websockets" summary="Websockets 外掛程式可讓您在伺服器與用戶端之間建立多向通訊工作階段。">Ktor Server 中的 WebSockets</Links>。</p>
+</tip>
+<chapter title="新增相依性" id="add_dependencies">
+    <p>若要使用 <code>WebSockets</code>，您需要在建置指令碼中包含 <code>%artifact_name%</code> 構件：</p>
+    <Tabs group="languages">
+        <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+            <code-block lang="Kotlin" code="                    implementation(&quot;io.ktor:%artifact_name%:$ktor_version&quot;)"/>
+        </TabItem>
+        <TabItem title="Gradle (Groovy)" group-key="groovy">
+            <code-block lang="Groovy" code="                    implementation &quot;io.ktor:%artifact_name%:$ktor_version&quot;"/>
+        </TabItem>
+        <TabItem title="Maven" group-key="maven">
+            <code-block lang="XML" code="                    &lt;dependency&gt;&#10;                        &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                        &lt;artifactId&gt;%artifact_name%-jvm&lt;/artifactId&gt;&#10;                        &lt;version&gt;${ktor_version}&lt;/version&gt;&#10;                    &lt;/dependency&gt;"/>
+        </TabItem>
+    </Tabs>
+    <tip>
+        若要進一步了解 Ktor 用戶端所需的構件，請參閱<Links href="//client-dependencies" summary="了解如何將用戶端相依性新增至現有專案。">新增用戶端相依性</Links>。
+    </tip>
+</chapter>
+<chapter title="安裝 WebSockets" id="install_plugin">
+    <p>若要安裝 <code>WebSockets</code> 外掛程式，請將其傳遞給 <a href="#configure-client">用戶端配置區塊</a>內的 <code>install</code> 函式：</p>
+    <code-block lang="kotlin" code="            import io.ktor.client.*&#10;            import io.ktor.client.engine.cio.*&#10;            import io.ktor.client.plugins.websocket.*&#10;&#10;            //...&#10;            val client = HttpClient(CIO) {&#10;                install(WebSockets)&#10;            }"/>
+</chapter>
+<chapter title="配置" id="configure_plugin">
+    <p>您可以選擇透過在 <code>install</code> 區塊中傳遞 
+        <a href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/-web-sockets/-config/index.html">WebSockets.Config</a> 支援的屬性來配置外掛程式。
+    </p>
+    <deflist>
+        <def id="maxFrameSize">
+            <title><code>maxFrameSize</code></title>
+            設定可以接收或發送的最大 <code>Frame</code> (框架) 大小。
+        </def>
+        <def id="contentConverter">
+            <title><code>contentConverter</code></title>
+            設定序列化/反序列化的轉換器。
+        </def>
+        <def id="pingIntervalMillis">
+            <title><code>pingIntervalMillis</code></title>
+            以 <code>Long</code> 格式指定 ping 之間的持續時間。
+        </def>
+        <def id="pingInterval">
+            <title><code>pingInterval</code></title>
+            以 <code>Duration</code> 格式指定 ping 之間的持續時間。
+        </def>
+    </deflist>
+    <warning>
+        <p><code>pingInterval</code> 與 <code>pingIntervalMillis</code> 屬性不適用於 OkHttp 引擎。若要設定 OkHttp 的 ping 間隔，您可以使用<a href="#okhttp">引擎配置</a>：
+        </p>
+        <code-block lang="kotlin" code="                import io.ktor.client.engine.okhttp.OkHttp&#10;&#10;                val client = HttpClient(OkHttp) {&#10;                    engine {&#10;                        preconfigured = OkHttpClient.Builder()&#10;                            .pingInterval(20, TimeUnit.SECONDS)&#10;                            .build()&#10;                    }&#10;                }"/>
+    </warning>
+    <p>
+        在以下範例中，WebSockets 外掛程式配置了 20 秒（<code>20_000</code> 毫秒）的 ping 間隔，以自動發送 ping 框架並保持 WebSocket 連線：
+    </p>
+    <code-block lang="kotlin" code="    val client = HttpClient(CIO) {&#10;        install(WebSockets) {&#10;            pingIntervalMillis = 20_000&#10;        }&#10;    }"/>
+</chapter>
+<chapter title="使用 WebSocket 工作階段" id="working-wtih-session">
+    <p>用戶端的 WebSocket 工作階段由 
+        <a href="https://api.ktor.io/ktor-websockets/io.ktor.websocket/-default-web-socket-session/index.html">DefaultClientWebSocketSession</a>
+        介面表示。此介面公開了可讓您發送與接收 WebSocket 框架以及關閉工作階段的 API。
+    </p>
+    <chapter title="存取 WebSocket 工作階段" id="access-session">
+        <p>
+            <code>HttpClient</code> 提供兩種主要方式來存取 WebSocket 工作階段：
+        </p>
+        <list>
+            <li>
+                <p><a
+                        href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/web-socket.html">webSocket()</a>
+                    函式接受 <code>DefaultClientWebSocketSession</code> 作為區塊引數。</p>
+                <code-block lang="kotlin" code="                        runBlocking {&#10;                            client.webSocket(&#10;                                method = HttpMethod.Get,&#10;                                host = &quot;127.0.0.1&quot;,&#10;                                port = 8080,&#10;                                path = &quot;/echo&quot;&#10;                            ) {&#10;                                // this: DefaultClientWebSocketSession&#10;                            }&#10;                        }"/>
+            </li>
+            <li>
+                <a
+                    href="https://api.ktor.io/ktor-client-core/io.ktor.client.plugins.websocket/web-socket-session.html">webSocketSession()</a>
+                函式回傳 <code>DefaultClientWebSocketSession</code> 執行個體，並允許您在 <code>runBlocking</code> 或 <code>launch</code> 作用域之外存取工作階段。
+            </li>
+        </list>
+    </chapter>
+    <chapter title="處理 WebSocket 工作階段" id="handle-session">
+        <p>在函式區塊內，您可以為指定的路徑定義處理常式。區塊內可以使用以下函式與屬性：</p>
+        <deflist>
+            <def id="send">
+                <title><code>send()</code></title>
+                使用 <code>send()</code> 函式向伺服器發送文字內容。
+            </def>
+            <def id="outgoing">
+                <title><code>outgoing</code></title>
+                使用 <code>outgoing</code> 屬性存取用於發送 WebSocket 框架的頻道。框架由 <code>Frame</code> 類別表示。
+            </def>
+            <def id="incoming">
+                <title><code>incoming</code></title>
+                使用 <code>incoming</code> 屬性存取用於接收 WebSocket 框架的頻道。框架由 <code>Frame</code> 類別表示。
+            </def>
+            <def id="close">
+                <title><code>close()</code></title>
+                使用 <code>close()</code> 函式發送帶有指定原因的關閉框架。
+            </def>
+        </deflist>
+    </chapter>
+    <chapter title="框架類型" id="frame-types">
+        <p>
+            您可以檢查 WebSocket 框架的類型並進行相應處理。一些常見的框架類型包括：
+        </p>
+        <list>
+            <li><code>Frame.Text</code> 表示文字框架。使用 
+                <code>Frame.Text.readText()</code> 讀取其內容。
+            </li>
+            <li><code>Frame.Binary</code> 表示二進位框架。使用 <code>Frame.Binary.readBytes()</code> 
+                讀取其內容。
+            </li>
+            <li><code>Frame.Close</code> 表示關閉框架。使用 <code>Frame.Close.readReason()</code> 
+                取得工作階段關閉的原因。
+            </li>
+        </list>
+    </chapter>
+    <chapter title="範例" id="example">
+        <p>下面的範例建立了 <code>echo</code> WebSocket 端點，並展示如何向伺服器發送和接收訊息。</p>
+        <code-block lang="kotlin"
+                    include-symbol="main" code="package com.example&#10;&#10;import io.ktor.client.*&#10;import io.ktor.client.engine.cio.*&#10;import io.ktor.client.plugins.websocket.*&#10;import io.ktor.http.*&#10;import io.ktor.websocket.*&#10;import kotlinx.coroutines.*&#10;import java.util.*&#10;&#10;fun main() {&#10;    val client = HttpClient(CIO) {&#10;        install(WebSockets) {&#10;            pingIntervalMillis = 20_000&#10;        }&#10;    }&#10;    runBlocking {&#10;        client.webSocket(method = HttpMethod.Get, host = &quot;127.0.0.1&quot;, port = 8080, path = &quot;/echo&quot;) {&#10;            while(true) {&#10;                val othersMessage = incoming.receive() as? Frame.Text&#10;                println(othersMessage?.readText())&#10;                val myMessage = Scanner(System.`in`).next()&#10;                if(myMessage != null) {&#10;                    send(myMessage)&#10;                }&#10;            }&#10;        }&#10;    }&#10;    client.close()&#10;}"/>
+        <p>如需完整範例，請參閱 
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/client-websockets">client-websockets</a>。
+        </p>
+    </chapter>
+</chapter>
+</topic>

--- a/docs/zh-Hant/ktor/docker-compose.md
+++ b/docs/zh-Hant/ktor/docker-compose.md
@@ -1,0 +1,142 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       id="docker-compose" title="Docker Compose">
+    <show-structure for="chapter" depth="2"/>
+    <tldr>
+        <p>
+            <control>初始專案</control>
+            : <a
+                href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-db-integration">tutorial-server-db-integration</a>
+        </p>
+        <p>
+            <control>最終專案</control>
+            : <a
+                href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/tutorial-server-docker-compose">tutorial-server-docker-compose</a>
+        </p>
+    </tldr>
+    <p>在本主題中，我們將向您展示如何在 <a href="https://docs.docker.com/compose/">Docker Compose</a> 下執行伺服器端 Ktor 應用程式。我們將使用在 <Links href="//server-integrate-database" summary="瞭解使用 Exposed SQL 程式庫將 Ktor 服務連接到資料庫存儲庫的過程。">整合資料庫</Links> 教學中建立的專案，該專案使用 <a href="https://github.com/JetBrains/Exposed">Exposed</a> 連接到 <a href="https://www.postgresql.org/docs/">PostgreSQL</a> 資料庫，其中資料庫和 Web 應用程式分開執行。</p>
+    <chapter title="準備好應用程式" id="prepare-app">
+        <chapter title="擷取資料庫設定" id="extract-db-settings">
+            <p>
+                在 <a href="server-integrate-database.topic#config-db-connection">配置資料庫連線</a> 教學中建立的專案使用硬編碼屬性來建立資料庫連線。</p>
+            <p>
+                讓我們將 PostgreSQL 資料庫的連線設定擷取到 <Links href="//server-configuration-file" summary="瞭解如何在配置檔案中配置各種伺服器參數。">自訂配置群組</Links> 中。
+            </p>
+            <procedure>
+                <step>
+                    <p>開啟 
+                        <Path>src/main/resources</Path> 
+                        中的 
+                        <Path>application.yaml</Path>
+                        檔案，並在 <code>ktor</code> 群組之外新增 <code>storage</code> 群組，如下所示：
+                    </p>
+                    <code-block lang="yaml" code="ktor:&#10;  application:&#10;    modules:&#10;      - com.example.ApplicationKt.module&#10;  deployment:&#10;    port: 8080&#10;storage:&#10;  driverClassName: &quot;org.postgresql.Driver&quot;&#10;  jdbcURL: &quot;jdbc:postgresql://localhost:5432/ktor_tutorial_db&quot;&#10;  user: &quot;postgres&quot;&#10;  password: &quot;password&quot;"/>
+                    <p>這些設定稍後將在 <a href="#configure-docker">
+                        <Path>compose.yml</Path>
+                    </a> 檔案中進行配置。
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        開啟 
+                        <Path>src/main/kotlin/com/example/plugins/</Path>
+                        中的 
+                        <Path>Databases.kt</Path>
+                        檔案，並更新 <code>configureDatabases()</code> 函式以從配置檔案載入儲存設定：
+                    </p>
+                    <code-block lang="kotlin" code="fun Application.configureDatabases(config: ApplicationConfig) {&#10;    val url = config.property(&quot;storage.jdbcURL&quot;).getString()&#10;    val user = config.property(&quot;storage.user&quot;).getString()&#10;    val password = config.property(&quot;storage.password&quot;).getString()&#10;&#10;    Database.connect(&#10;        url,&#10;        user = user,&#10;        password = password&#10;    )&#10;}"/>
+                    <p>
+                        <code>configureDatabases()</code> 函式現在接受 <code>ApplicationConfig</code> 並使用 <code>config.property</code> 來載入自訂設定。
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        開啟 
+                        <Path>src/main/kotlin/com/example/</Path>
+                        中的 
+                        <Path>Application.kt</Path>
+                        檔案，並將 <code>environment.config</code> 傳遞給 <code>configureDatabases()</code>，以便在應用程式啟動時載入連線設定：
+                    </p>
+                    <code-block lang="kotlin" code="fun Application.module() {&#10;    val repository = PostgresTaskRepository()&#10;&#10;    configureSerialization(repository)&#10;    configureDatabases(environment.config)&#10;    configureRouting()&#10;}"/>
+                </step>
+            </procedure>
+        </chapter>
+        <chapter title="配置 Ktor 外掛程式" id="configure-ktor-plugin">
+            <p>為了在 Docker 上執行，應用程式需要將所有必要的檔案部署到容器中。根據您使用的建置系統，有不同的外掛程式可以完成此操作：</p>
+            <list>
+                <li><Links href="//server-fatjar" summary="瞭解如何使用 Ktor Gradle 外掛程式建立和執行可執行的 fat JAR。">使用 Ktor Gradle 外掛程式建立 fat JAR</Links></li>
+                <li><Links href="//maven-assembly-plugin" summary="範例專案：tutorial-server-get-started-maven">使用 Maven Assembly 外掛程式建立 fat JAR</Links></li>
+            </list>
+            <p>在我們的範例中，Ktor 外掛程式已套用於 
+                <Path>build.gradle.kts</Path>
+                檔案。
+            </p>
+            <code-block lang="kotlin" code="plugins {&#10;    application&#10;    kotlin(&quot;jvm&quot;)&#10;    id(&quot;io.ktor.plugin&quot;) version &quot;3.5.1&quot;&#10;    id(&quot;org.jetbrains.kotlin.plugin.serialization&quot;) version &quot;2.2.20&quot;&#10;}"/>
+        </chapter>
+    </chapter>
+    <chapter title="配置 Docker" id="configure-docker">
+        <chapter title="準備 Docker 映像" id="prepare-docker-image">
+            <p>
+                要將應用程式 Docker 化，請在專案的根目錄中建立一個新的 
+                <Path>Dockerfile</Path>
+                並插入以下內容：
+            </p>
+            <code-block lang="Docker" code="# Stage 1: Cache Gradle dependencies&#10;FROM gradle:latest AS cache&#10;RUN mkdir -p /home/gradle/cache_home&#10;ENV GRADLE_USER_HOME=/home/gradle/cache_home&#10;COPY build.gradle.* gradle.properties /home/gradle/app/&#10;COPY gradle /home/gradle/app/gradle&#10;WORKDIR /home/gradle/app&#10;RUN gradle dependencies --no-daemon&#10;&#10;# Stage 2: Build Application&#10;FROM gradle:latest AS build&#10;COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle&#10;COPY --chown=gradle:gradle . /home/gradle/src&#10;WORKDIR /home/gradle/src&#10;# Build the fat JAR, Gradle also supports shadow&#10;# and boot JAR by default.&#10;RUN gradle buildFatJar --no-daemon&#10;&#10;# Stage 3: Create the Runtime Image&#10;FROM amazoncorretto:22 AS runtime&#10;EXPOSE 8080&#10;RUN mkdir /app&#10;COPY --from=build /home/gradle/src/build/libs/*.jar /app/ktor-docker-sample.jar&#10;ENTRYPOINT [&quot;java&quot;,&quot;-jar&quot;,&quot;/app/ktor-docker-sample.jar&quot;]"/>
+            <tip>
+                有關此多階段建置如何運作的更多資訊，請參閱 <a href="docker.md#prepare-docker">準備 Docker 映像</a>。
+            </tip>
+            <p>
+             此範例使用 Amazon Corretto Docker 映像，但您可以將其替換為任何其他合適的替代方案，例如：
+            </p>
+            <list>
+              <li><a href="https://hub.docker.com/_/eclipse-temurin">Eclipse Temurin</a></li>
+              <li><a href="https://hub.docker.com/_/ibm-semeru-runtimes">IBM Semeru</a></li>
+              <li><a href="https://hub.docker.com/_/ibmjava">IBM Java</a></li>
+              <li><a href="https://hub.docker.com/_/sapmachine">SAP Machine JDK</a></li>
+            </list>
+        </chapter>
+        <chapter title="配置 Docker Compose" id="configure-docker-compose">
+            <p>在專案的根目錄中，建立一個新的 
+                <Path>compose.yml</Path>
+                檔案並新增以下內容：
+            </p>
+            <code-block lang="yaml" code="services:&#10;  web:&#10;    build: .&#10;    ports:&#10;      - &quot;8080:8080&quot;&#10;    depends_on:&#10;      db:&#10;        condition: service_healthy&#10;  db:&#10;    image: postgres&#10;    volumes:&#10;      - ./tmp/db:/var/lib/postgresql/data&#10;    environment:&#10;      POSTGRES_DB: ktor_tutorial_db&#10;      POSTGRES_HOST_AUTH_METHOD: trust&#10;    ports:&#10;      - &quot;5432:5432&quot;&#10;    healthcheck:&#10;      test: [ &quot;CMD-SHELL&quot;, &quot;pg_isready -U postgres&quot; ]&#10;      interval: 1s"/>
+            <list>
+                <li><code>web</code> 服務用於執行封裝在 <a href="#prepare-docker-image">映像</a> 內的 Ktor 應用程式。
+                </li>
+                <li><code>db</code> 服務使用 <code>postgres</code> 映像建立 
+                    <code>ktor_tutorial_db</code> 資料庫以儲存任務。
+                </li>
+            </list>
+        </chapter>
+    </chapter>
+    <chapter title="建置並執行服務" id="build-run">
+        <procedure>
+            <step>
+                <p>
+                    執行以下指令以建立包含 Ktor 應用程式的 <a href="#configure-ktor-plugin">fat JAR</a>：
+                </p>
+                <code-block lang="Bash" code="                    ./gradlew :tutorial-server-docker-compose:buildFatJar"/>
+            </step>
+            <step>
+                <p>
+                    使用 <code>docker compose up</code> 指令來建置映像並啟動容器：
+                </p>
+                <code-block lang="Bash" code="                    docker compose --project-directory snippets/tutorial-server-docker-compose up"/>
+            </step>
+            <step>
+                等待 Docker Compose 完成映像建置。
+            </step>
+            <step>
+                <p>
+                    導覽至 <a href="http://localhost:8080/static/index.html">http://localhost:8080/static/index.html</a>
+                    以開啟 Web 應用程式。您應該會看到工作管理員用戶端頁面，其中顯示了三個用於篩選和新增新任務的表單，以及一個任務表格。
+                </p>
+                <img src="tutorial_server_db_integration_manual_test.gif"
+                     alt="顯示工作管理員用戶端的瀏覽器視窗"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+</topic>

--- a/docs/zh-Hant/ktor/full-stack-development-with-kotlin-multiplatform.md
+++ b/docs/zh-Hant/ktor/full-stack-development-with-kotlin-multiplatform.md
@@ -1,0 +1,660 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="使用 Kotlin Multiplatform 構建全端應用程式" id="full-stack-development-with-kotlin-multiplatform">
+<show-structure for="chapter, procedure" depth="2"/>
+<web-summary>
+    學習如何使用 Kotlin 和 Ktor 開發跨平台全端應用程式。在本教學中，您將探索如何使用 Kotlin Multiplatform 為 Android、iOS 和桌面進行構建，並使用 Ktor 輕鬆處理資料。
+</web-summary>
+<link-summary>
+    學習如何使用 Kotlin 和 Ktor 開發跨平台全端應用程式。
+</link-summary>
+<card-summary>
+    學習如何使用 Kotlin 和 Ktor 開發跨平台全端應用程式。
+</card-summary>
+<tldr>
+    <var name="example_name" value="full-stack-task-manager"/>
+    <p>
+        <b>程式碼範例</b>：
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+    <p>
+        <b>使用的外掛程式</b>：<Links href="//server-routing" summary="Routing is a core plugin for handling incoming requests in a server application.">Routing</Links>、
+        <a href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>、
+        <Links href="//server-serialization" summary="The ContentNegotiation plugin serves two primary purposes: negotiating media types between the client and server and serializing/deserializing the content in a specific format.">Content Negotiation</Links>、
+        <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a>、
+        <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">Kotlin Multiplatform</a>
+    </p>
+</tldr>
+<p>
+    在本文中，您將學習如何使用 Kotlin 開發一個能在 Android、iOS、Web 和桌面平台上執行的全端應用程式，同時利用 Ktor 實現無縫資料處理。
+</p>
+<p>在本教學結束時，您將瞭解如何執行以下操作：</p>
+<list>
+    <li>使用 <a
+            href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">
+        Kotlin Multiplatform</a> 建立全端應用程式。
+    </li>
+    <li>瞭解使用 IntelliJ IDEA 產生的專案。
+    </li>
+    <li>建立呼叫 Ktor 服務的 <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a> 用戶端。
+    </li>
+    <li>在設計的不同層級中重複使用共用型別。</li>
+    <li>正確包含並配置多平台連結庫。</li>
+</list>
+<p>
+    在之前的教學中，我們使用任務管理員（Task Manager）範例來
+    <Links href="//server-requests-and-responses" summary="Learn the basics of routing, handling requests, and parameters in Kotlin with Ktor by
+    building a task manager application.">處理請求</Links>、
+    <Links href="//server-create-restful-apis" summary="Learn how to build a backend service using Kotlin and Ktor, featuring an example of a
+    RESTful API that generates JSON files.">建立 RESTful API</Links> 以及
+    <Links href="//server-integrate-database" summary="Learn the process of connecting Ktor services to database repositories with the Exposed SQL Library.">使用 Exposed 整合資料庫</Links>。
+    用戶端應用程式保持最簡化，以便您可以專注於學習 Ktor 的基礎知識。
+</p>
+<p>
+    您將建立一個針對 Android、iOS、Web 和桌面平台的用戶端，並使用 Ktor 服務來獲取要顯示的資料。在可能的情況下，您將在用戶端和伺服器之間共享資料型別，從而加快開發速度並減少潛在錯誤。
+</p>
+<chapter title="先決條件" id="prerequisites">
+    <p>
+        與之前的文章一樣，您將使用 IntelliJ IDEA 作為 IDE。要安裝和配置您的環境，請參閱
+        <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/quickstart.html">
+            Kotlin Multiplatform 快速入門指南
+        </a>
+        。
+    </p>
+    <p>
+        如果這是您第一次使用 Compose Multiplatform，我們建議您在開始本教學之前先完成
+        <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-getting-started.html">
+            Compose Multiplatform 入門
+        </a>
+        教學。為了降低任務的複雜性，您可以專注於單一用戶端平台。例如，如果您從未使用過 iOS，那麼專注於桌面或 Android 開發可能是明智的。
+    </p>
+</chapter>
+<chapter title="建立新專案" id="create-project">
+    <p>
+        不使用 Ktor 專案產生器，而是使用 IntelliJ IDEA 中的 Kotlin Multiplatform 專案精靈。它將建立一個基礎的多平台專案，您可以透過用戶端和服務對其進行擴展。用戶端可以使用原生 UI 連結庫（例如 SwiftUI），但在本教學中，您將使用 <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a> 為所有平台建立共用 UI。
+    </p>
+    <procedure id="generate-project">
+        <step>
+            啟動 IntelliJ IDEA。
+        </step>
+        <step>
+            在 IntelliJ IDEA 中，選擇
+            <ui-path>File | New | Project</ui-path>
+            。
+        </step>
+        <step>
+            在左側面板中，選擇
+            <ui-path>Kotlin Multiplatform</ui-path>
+            。
+        </step>
+        <step>
+            在
+            <ui-path>New Project</ui-path>
+            視窗中指定以下欄位：
+            <list>
+                <li>
+                    <ui-path>Name</ui-path>
+                    : full-stack-task-manager
+                </li>
+                <li>
+                    <ui-path>Project ID</ui-path>
+                    : com.example.ktor
+                </li>
+            </list>
+        </step>
+        <step>
+            <p>
+                選擇
+                <ui-path>Android</ui-path>
+                、
+                <ui-path>Desktop</ui-path>
+                、
+                <ui-path>Web</ui-path>
+                和
+                <ui-path>Server</ui-path>
+                作為目標平台。
+            </p>
+        </step>
+        <step>
+            <p>
+                如果您使用的是 Mac，也請選擇
+                <ui-path>iOS</ui-path>
+                。確保勾選了
+                <ui-path>Share UI</ui-path>
+                選項。
+                <img style="block" src="full_stack_development_tutorial_create_project.png"
+                     alt="Kotlin Multiplatform wizard settings" width="706" border-effect="rounded"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                點擊
+                <control>Create</control>
+                按鈕，等待 IDE 產生並匯入專案。
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="執行服務" id="run-service">
+    <procedure id="run-service-procedure">
+        <step>
+            在 IntelliJ IDEA 中，選擇
+            <Path>ApplicationKt</Path>
+            執行配置。
+            <img src="full_stack_development_tutorial_server_run_configuration.png"
+                 alt="Run &amp; Debug window" width="300"
+                 border-effect="line" style="block"/>
+        </step>
+        <step>
+            點擊
+            <ui-path>Run</ui-path>
+            按鈕
+            (<img src="intellij_idea_run_icon.svg"
+                  style="inline" height="16" width="16"
+                  alt="IntelliJ IDEA run icon"/>)
+            以執行該配置。
+            <p>
+                <ui-path>Run</ui-path>
+                工具視窗中將開啟一個新標籤。
+            </p>
+        </step>
+        <step>
+            <p>
+                導航至 <a href="http://0.0.0.0:8080/">http://0.0.0.0:8080/</a> 以開啟應用程式。您應該會在瀏覽器中看到來自 Ktor 的訊息。
+                <img src="full_stack_development_tutorial_run.png"
+                     alt="A Ktor server browser response" width="706"
+                     border-effect="rounded" style="block"/>
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="檢查專案" id="examine-project">
+    <p>
+        <Path>server</Path>
+        資料夾是專案中的三個 Kotlin 模組之一。另外兩個是
+        <Path>core</Path>
+        和
+        <Path>app</Path>
+        。
+    </p>
+    <p>
+        <Path>server</Path>
+        模組的結構與 <a href="https://start.ktor.io/">Ktor 專案產生器</a> 產生的結構非常相似。您有一個專用的組建檔案來宣告外掛程式和相依性，以及一個包含用於構建和啟動 Ktor 服務的程式碼的原始碼集：
+    </p>
+    <img src="full_stack_development_tutorial_server_folder.png"
+         alt="Contents of the server folder in a Kotlin Multiplatform project" width="300"
+         border-effect="line"/>
+    <p>
+        如果您查看
+        <Path>Application.kt</Path>
+        檔案中的路由指令，您會看到對 <code>sayHello()</code> 函式的呼叫：
+    </p>
+    <code-block lang="kotlin" code="            fun Application.module() {&#10;                routing {&#10;                    get(&quot;/&quot;) {&#10;                        call.respondText(sayHello(&quot;Ktor&quot;))&#10;                    }&#10;                }&#10;            }"/>
+    <p>
+        <code>sayHello()</code> 函式定義在
+        <Path>core</Path>
+        模組中。這是您放置要在伺服器和所有不同用戶端平台之間共享的通用程式碼的地方。
+    </p>
+    <p>
+       開啟 <Path>app/shared/src/commonMain</Path> 模組中的 <Path>Greeting.kt</Path> 檔案，可以看到該處也使用了
+        <code>sayHello()</code> 函式：
+    </p>
+    <code-block lang="kotlin" code="            class Greeting {&#10;                private val platform = getPlatform()&#10;&#10;                fun greet(): String {&#10;                    return sayHello(platform.name)&#10;                }&#10;            }"/>
+    <p>
+        <Path>app</Path>模組包含以下子模組：
+    </p>
+    <list>
+        <li>
+            <Path>androidApp</Path>、<Path>desktopApp</Path>、<Path>iosApp</Path> 和 <Path>webApp</Path> 子模組分別包含 Android、桌面、iOS 和 Web 用戶端應用程式的平台特定程式碼。目前這些用戶端應用程式都沒有連結到 Ktor 服務。
+        </li>
+        <li>
+            <p>
+                <Path>shared</Path>
+                子模組包含您希望提供用戶端的每個平台的原始碼集。這是因為在
+                <Path>commonMain</Path>
+                中宣告的型別需要隨目標平台而異的功能。
+            </p>
+            <p>
+                例如，在 <code>Greeting</code> 型別中，目前平台的名稱是透過平台特定的 API 獲取的，這是透過 <a
+                    href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/multiplatform-connect-to-apis.html">expect 和 actual 宣告</a> 實現的。
+            </p>
+            <p>
+                在
+                <Path>shared</Path>
+                子模組的
+                <Path>commonMain</Path>
+                原始碼集中，<code>getPlatform()</code> 函式使用 <code>expect</code> 關鍵字宣告：
+            </p>
+            <Tabs>
+                <TabItem title="commonMain/Platform.kt" id="commonMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;interface Platform {&#10;    val name: String&#10;}&#10;&#10;expect fun getPlatform(): Platform"/>
+                </TabItem>
+            </Tabs>
+            <p>
+                然後，每個目標平台提供 <code>getPlatform()</code> 函式的 <code>actual</code> 宣告，如下所示：
+            </p>
+            <Tabs>
+                <TabItem title="Platform.ios.kt" id="iosMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import platform.UIKit.UIDevice&#10;&#10;class IOSPlatform : Platform {&#10;    override val name: String = UIDevice.currentDevice.systemName() + &quot; &quot; + UIDevice.currentDevice.systemVersion&#10;}&#10;&#10;actual fun getPlatform(): Platform = IOSPlatform()"/>
+                </TabItem>
+                <TabItem title="Platform.android.kt" id="androidMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import android.os.Build&#10;&#10;class AndroidPlatform : Platform {&#10;    override val name: String = &quot;Android ${Build.VERSION.SDK_INT}&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = AndroidPlatform()"/>
+                </TabItem>
+                <TabItem title="Platform.jvm.kt" id="jvmMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;class JVMPlatform : Platform {&#10;    override val name: String = &quot;Java ${System.getProperty(&quot;java.version&quot;)}&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = JVMPlatform()"/>
+                </TabItem>
+                <TabItem title="Platform.wasmJs.kt" id="wasmJsMain">
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;class WasmPlatform : Platform {&#10;    override val name: String = &quot;Web with Kotlin/Wasm&quot;&#10;}&#10;&#10;actual fun getPlatform(): Platform = WasmPlatform()"/>
+                </TabItem>
+            </Tabs>
+        </li>
+    </list>
+</chapter>
+<chapter title="執行用戶端應用程式" id="run-client-app">
+    <p>
+        您可以透過執行目標的執行配置來執行用戶端應用程式。要在 iOS 模擬器上執行應用程式，請按照以下步驟操作：
+    </p>
+    <procedure id="run-ios-app-procedure">
+        <step>
+            在 IntelliJ IDEA 中，選擇
+            <Path>iosApp</Path>
+            執行配置和一個模擬裝置。
+            <img src="full_stack_development_tutorial_run_configurations.png"
+                 alt="Run &amp; Debug window" width="400"
+                 border-effect="line" style="block"/>
+        </step>
+        <step>
+            點擊
+            <ui-path>Run</ui-path>
+            按鈕
+            (<img src="intellij_idea_run_icon.svg"
+                  style="inline" height="16" width="16"
+                  alt="IntelliJ IDEA run icon"/>)
+            以執行該配置。
+        </step>
+        <step>
+            <p>
+                當您執行 iOS 應用程式時，它會在後台使用 Xcode 進行構建並在 iOS 模擬器中啟動。該應用程式顯示一個按鈕，點擊時會切換圖片。
+                <img style="block" src="full_stack_development_tutorial_run_ios.gif"
+                     alt="Running the app in the iOS Simulator" width="300" border-effect="rounded"/>
+            </p>
+            <p>
+                第一次按下按鈕時，目前平台的詳細資訊會新增到按鈕文字中。實現此功能的程式碼位於
+                <Path>app/shared/src/commonMain/kotlin/com/example/ktor/App.kt</Path>
+                ：
+            </p>
+            <code-block lang="kotlin" code="                @Composable&#10;                @Preview&#10;                fun App() {&#10;                    MaterialTheme {&#10;                        var showContent by remember { mutableStateOf(false) }&#10;                        Column(&#10;                            modifier = Modifier&#10;                                .background(MaterialTheme.colorScheme.primaryContainer)&#10;                                .safeContentPadding()&#10;                                .fillMaxSize(),&#10;                            horizontalAlignment = Alignment.CenterHorizontally,&#10;                        ) {&#10;                            Button(onClick = { showContent = !showContent }) {&#10;                                Text(&quot;Click me!&quot;)&#10;                            }&#10;                            AnimatedVisibility(showContent) {&#10;                                val greeting = remember { Greeting().greet() }&#10;                                Column(&#10;                                    modifier = Modifier.fillMaxWidth(),&#10;                                    horizontalAlignment = Alignment.CenterHorizontally,&#10;                                ) {&#10;                                    Image(painterResource(Res.drawable.compose_multiplatform), null)&#10;                                    Text(&quot;Compose: $greeting&quot;)&#10;                                }&#10;                            }&#10;                        }&#10;                    }&#10;                }"/>
+            <p>
+                這是一個可組合（composable）函式，您稍後將在本文中對其進行修改。目前，唯一重要的是它顯示了一個 UI 並使用了共享的 <code>Greeting</code> 型別，而該型別又使用了實作通用 <code>Platform</code> 介面的平台特定類別。
+            </p>
+        </step>
+    </procedure>
+    <p>
+        既然您已經瞭解了產生專案的結構，就可以逐步新增任務管理員功能。
+    </p>
+</chapter>
+<chapter title="新增模型型別" id="add-model-types">
+    <p>
+        首先，新增模型型別並確保用戶端和伺服器都可以訪問它們。
+    </p>
+    <procedure id="add-model-types-procedure">
+        <step>
+            導航至
+            <Path>gradle/libs.versions.toml</Path>
+            並定義以下 <code>kotlinx.serialization</code> 相依性：
+            <code-block lang="toml" code="[versions]&#10;kotlinx-serialization-json = &quot;1.11.0&quot;&#10;&#10;[libraries]&#10;kotlinx-serialization-json = { module = &quot;org.jetbrains.kotlinx:kotlinx-serialization-json&quot;, version.ref = &quot;kotlinx-serialization-json&quot; }&#10;&#10;[plugins]&#10;kotlinSerialization = { id = &quot;org.jetbrains.kotlin.plugin.serialization&quot;, version.ref = &quot;kotlin&quot; }"/>
+        </step>
+        <step>
+            <p>
+                導航至
+                <Path>core/build.gradle.kts</Path>
+                並新增序列化外掛程式：
+            </p>
+            <code-block lang="kotlin" code="plugins {&#10;    //...&#10;    alias(libs.plugins.kotlinSerialization)&#10;}"/>
+        </step>
+        <step>
+            <p>
+                在同一個檔案中，為
+                <Path>commonMain</Path>
+                原始碼集新增一個新相依性：
+            </p>
+            <code-block lang="kotlin" code="    sourceSets {&#10;        commonMain.dependencies {&#10;            // put your Multiplatform dependencies here&#10;            implementation(libs.kotlinx.serialization.json)&#10;        }&#10;        //...&#10;    }"/>
+        </step>
+        <step>
+            在 IntelliJ IDEA 中，選擇
+            <ui-path>Build | Sync Project with Gradle Files</ui-path>
+            以套用更新。Gradle 匯入完成後，您應該會發現
+            <Path>Task.kt</Path>
+            檔案可以編譯成功。
+        </step>
+        <step>
+            導航至
+            <Path>core/src/commonMain/kotlin/com/example/ktor</Path>
+            並建立一個名為
+            <Path>model</Path>
+            的新封裝。
+        </step>
+        <step>
+            在新封裝中，建立一個名為
+            <Path>Task.kt</Path>
+            的新檔案。
+        </step>
+        <step>
+            <p>
+                新增一個列舉來表示優先級（priorities），以及一個類別來表示任務。
+                <code>Task</code>
+                類別使用了來自
+                <code>kotlinx.serialization</code>
+                連結庫的 <code>Serializable</code> 註解：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="建立伺服器" id="create-server">
+    <p>
+        下一階段是為任務管理員建立伺服器端實作。
+    </p>
+    <procedure id="create-server-procedure">
+        <step>
+            導航至
+            <Path>server/src/main/kotlin/com/example/ktor</Path>
+            資料夾並建立一個名為
+            <Path>model</Path>
+            的子封裝。
+        </step>
+        <step>
+            <p>
+                在此封裝中，建立一個新的
+                <Path>TaskRepository.kt</Path>
+                檔案，並為儲存庫新增以下介面：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;interface TaskRepository {&#10;    fun allTasks(): List&lt;Task&gt;&#10;    fun tasksByPriority(priority: Priority): List&lt;Task&gt;&#10;    fun taskByName(name: String): Task?&#10;    fun addOrUpdateTask(task: Task)&#10;    fun removeTask(name: String): Boolean&#10;}"/>
+        </step>
+        <step>
+            <p>
+                在同一個封裝中，建立一個名為
+                <Path>InMemoryTaskRepository.kt</Path>
+                的新檔案，包含以下類別：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.model&#10;&#10;class InMemoryTaskRepository : TaskRepository {&#10;    private var tasks = listOf(&#10;        Task(&quot;Cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;Gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;Shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;Painting&quot;, &quot;Paint the fence&quot;, Priority.Low),&#10;        Task(&quot;Cooking&quot;, &quot;Cook the dinner&quot;, Priority.Medium),&#10;        Task(&quot;Relaxing&quot;, &quot;Take a walk&quot;, Priority.High),&#10;        Task(&quot;Exercising&quot;, &quot;Go to the gym&quot;, Priority.Low),&#10;        Task(&quot;Learning&quot;, &quot;Read a book&quot;, Priority.Medium),&#10;        Task(&quot;Snoozing&quot;, &quot;Go for a nap&quot;, Priority.High),&#10;        Task(&quot;Socializing&quot;, &quot;Go to a party&quot;, Priority.High)&#10;    )&#10;&#10;    override fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    override fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    override fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    override fun addOrUpdateTask(task: Task) {&#10;        var notFound = true&#10;&#10;        tasks = tasks.map {&#10;            if (it.name == task.name) {&#10;                notFound = false&#10;                task&#10;            } else {&#10;                it&#10;            }&#10;        }&#10;        if (notFound) {&#10;            tasks = tasks.plus(task)&#10;        }&#10;    }&#10;&#10;    override fun removeTask(name: String): Boolean {&#10;        val oldTasks = tasks&#10;        tasks = tasks.filterNot { it.name == name }&#10;        return oldTasks.size &gt; tasks.size&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                導航至
+                <Path>server/src/main/kotlin/.../Application.kt</Path>
+                並將現有程式碼替換為以下實作：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import com.example.ktor.model.InMemoryTaskRepository&#10;import com.example.ktor.model.Priority&#10;import com.example.ktor.model.Task&#10;import io.ktor.http.*&#10;import io.ktor.serialization.*&#10;import io.ktor.serialization.kotlinx.json.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.plugins.contentnegotiation.*&#10;import io.ktor.server.plugins.cors.routing.*&#10;import io.ktor.server.request.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;, module = Application::module)&#10;        .start(wait = true)&#10;}&#10;&#10;fun Application.module() {&#10;    install(ContentNegotiation) {&#10;        json()&#10;    }&#10;    install(CORS) {&#10;        allowHeader(HttpHeaders.ContentType)&#10;        allowMethod(HttpMethod.Delete)&#10;        // For ease of demonstration we allow any connections.&#10;        // Don't do this in production.&#10;        anyHost()&#10;    }&#10;    val repository = InMemoryTaskRepository()&#10;&#10;    routing {&#10;        route(&quot;/tasks&quot;) {&#10;            get {&#10;                val tasks = repository.allTasks()&#10;                call.respond(tasks)&#10;            }&#10;            get(&quot;/byName/{taskName}&quot;) {&#10;                val name = call.parameters[&quot;taskName&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                val task = repository.taskByName(name)&#10;                if (task == null) {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                    return@get&#10;                }&#10;                call.respond(task)&#10;            }&#10;            get(&quot;/byPriority/{priority}&quot;) {&#10;                val priorityAsText = call.parameters[&quot;priority&quot;]&#10;                if (priorityAsText == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(priorityAsText)&#10;                    val tasks = repository.tasksByPriority(priority)&#10;&#10;&#10;                    if (tasks.isEmpty()) {&#10;                        call.respond(HttpStatusCode.NotFound)&#10;                        return@get&#10;                    }&#10;                    call.respond(tasks)&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;            post {&#10;                try {&#10;                    val task = call.receive&lt;Task&gt;()&#10;                    repository.addOrUpdateTask(task)&#10;                    call.respond(HttpStatusCode.NoContent)&#10;                } catch (ex: IllegalStateException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                } catch (ex: JsonConvertException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;            delete(&quot;/{taskName}&quot;) {&#10;                val name = call.parameters[&quot;taskName&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@delete&#10;                }&#10;                if (repository.removeTask(name)) {&#10;                    call.respond(HttpStatusCode.NoContent)&#10;                } else {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                此實作與之前教學中的實作非常相似，不同之處在於現在為了簡化，我們將所有路由程式碼都放在 <code>Application.module()</code> 函式中。
+            </p>
+            <p>
+                輸入此程式碼並新增匯入後，您會發現多個編譯器錯誤，因為程式碼使用了多個需要作為相依性包含的 Ktor 外掛程式，包括用於與 Web 用戶端互動的 <Links href="//server-cors" summary="Required dependencies: io.ktor:%artifact_name%">CORS</Links> 外掛程式。
+            </p>
+        </step>
+        <step>
+            開啟
+            <Path>gradle/libs.versions.toml</Path>
+            檔案並定義以下連結庫：
+            <code-block lang="toml" code="[libraries]&#10;ktor-serialization-kotlinx-json-jvm = { module = &quot;io.ktor:ktor-serialization-kotlinx-json-jvm&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-server-content-negotiation-jvm = { module = &quot;io.ktor:ktor-server-content-negotiation-jvm&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-server-cors-jvm = { module = &quot;io.ktor:ktor-server-cors-jvm&quot;, version.ref = &quot;ktor&quot; }"/>
+        </step>
+        <step>
+            <p>
+                開啟伺服器模組組建檔案（
+                <Path>server/build.gradle.kts</Path>
+                ）並新增以下相依性：
+            </p>
+            <code-block lang="kotlin" code="dependencies {&#10;    //...&#10;    implementation(libs.ktor.serialization.kotlinx.json.jvm)&#10;    implementation(libs.ktor.server.content.negotiation.jvm)&#10;    implementation(libs.ktor.server.cors.jvm)&#10;}"/>
+        </step>
+        <step>
+            再次在主功能表中執行 <ui-path>Build | Sync Project with Gradle Files</ui-path>。匯入完成後，您應該會發現 <code>ContentNegotiation</code> 型別和 <code>json()</code> 函式的匯入工作正常。
+        </step>
+        <step>
+            重新執行伺服器。您應該會發現路由可以從瀏覽器訪問。
+        </step>
+        <step>
+            <p>
+                導航至 <a href="http://0.0.0.0:8080/tasks"></a>
+                和 <a href="http://0.0.0.0:8080/tasks/byPriority/Medium"></a>
+                以查看 JSON 格式的任務伺服器回應。
+                <img style="block" src="full_stack_development_tutorial_run_server.gif"
+                     width="707" border-effect="rounded" alt="Server response in browser"/>
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="建立用戶端" id="create-client">
+    <p>
+        為了讓您的用戶端能夠訪問伺服器，您需要包含 Ktor 用戶端。這涉及三種類型的相依性：
+    </p>
+    <list>
+        <li>Ktor 用戶端的核心功能。</li>
+        <li>處理網路的平台特定引擎。</li>
+        <li>對內容協商（content negotiation）和序列化的支援。</li>
+    </list>
+    <procedure id="create-client-procedure">
+        <step>
+            在
+            <Path>gradle/libs.versions.toml</Path>
+            檔案中，新增以下連結庫：
+            <code-block lang="toml" code="[libraries]&#10;ktor-client-android = { module = &quot;io.ktor:ktor-client-android&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-cio = { module = &quot;io.ktor:ktor-client-cio&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-content-negotiation = { module = &quot;io.ktor:ktor-client-content-negotiation&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-core = { module = &quot;io.ktor:ktor-client-core&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-darwin = { module = &quot;io.ktor:ktor-client-darwin&quot;, version.ref = &quot;ktor&quot; }&#10;ktor-client-wasm = { module = &quot;io.ktor:ktor-client-js-wasm-js&quot;, version.ref = &quot;ktor&quot;}&#10;ktor-serialization-kotlinx-json = { module = &quot;io.ktor:ktor-serialization-kotlinx-json&quot;, version.ref = &quot;ktor&quot; }"/>
+        </step>
+        <step>
+            導航至
+            <Path>app/shared/build.gradle.kts</Path>
+            並新增以下相依性：
+            <code-block lang="kotlin" code="kotlin {&#10;    //...&#10;    sourceSets {&#10;        androidMain.dependencies {&#10;            //...&#10;            implementation(libs.ktor.client.android)&#10;        }&#10;        commonMain.dependencies {&#10;            //...&#10;            implementation(libs.ktor.client.core)&#10;            implementation(libs.ktor.client.content.negotiation)&#10;            implementation(libs.ktor.serialization.kotlinx.json)&#10;        }&#10;        jvmMain.dependencies {&#10;            implementation(libs.ktor.client.cio)&#10;        }&#10;        iosMain.dependencies {&#10;            implementation(libs.ktor.client.darwin)&#10;        }&#10;        wasmJsMain.dependencies {&#10;            implementation(libs.ktor.client.wasm)&#10;        }&#10;    }&#10;}"/>
+            <p>
+                完成此操作後，您可以新增一個 <code>TaskApi</code> 型別，作為您的用戶端對 Ktor 用戶端的薄包裝函式。
+            </p>
+        </step>
+        <step>
+            在主功能表中選擇
+            <ui-path>Build | Sync Project with Gradle Files</ui-path>
+            以匯入組建檔案中的變更。
+        </step>
+        <step>
+            導航至
+            <Path>app/shared/src/commonMain/kotlin/com/example/ktor</Path>
+            並建立一個名為
+            <Path>network</Path>
+            的新封裝。
+        </step>
+        <step>
+            <p>
+                在新封裝中，建立一個新的
+                <Path>HttpClientManager.kt</Path>
+                檔案用於用戶端配置：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.network&#10;&#10;import io.ktor.client.HttpClient&#10;import io.ktor.client.plugins.contentnegotiation.ContentNegotiation&#10;import io.ktor.client.plugins.defaultRequest&#10;import io.ktor.serialization.kotlinx.json.json&#10;import kotlinx.serialization.json.Json&#10;&#10;fun createHttpClient() = HttpClient {&#10;    install(ContentNegotiation) {&#10;        json(Json {&#10;            encodeDefaults = true&#10;            isLenient = true&#10;            coerceInputValues = true&#10;            ignoreUnknownKeys = true&#10;        })&#10;    }&#10;    defaultRequest {&#10;        host = &quot;1.2.3.4&quot; // Replace with the IP address of your current machine.&#10;        port = 8080&#10;    }&#10;}"/>
+            <p>
+                將 <code>1.2.3.4</code> 替換為您目前電腦的 IP 地址。您將無法從在 Android 虛擬裝置或 iOS 模擬器上執行的程式碼中呼叫 <code>0.0.0.0</code> 或 <code>localhost</code>。
+            </p>
+            <tip>
+                <p><b>尋找您的 IP 地址：</b></p>
+                <p>
+                    由於行動模擬器無法訪問 <code>localhost</code>，您需要電腦的實際 IP 地址。要尋找您的 IP 地址，請執行以下命令之一：
+                </p>
+                <list>
+                    <li><b>macOS:</b> <code>ifconfig | grep "inet " | grep -v 127.0.0.1</code></li>
+                    <li><b>Linux:</b> <code>hostname -I | awk '{print $1}'</code></li>
+                    <li><b>Windows:</b> <code>ipconfig</code> 並尋找 "IPv4 Address"</li>
+                </list>
+            </tip>
+        </step>
+        <step>
+            <p>
+                在同一個
+                <Path>app/shared/.../network</Path>
+                封裝中，建立一個具有以下實作的新
+                <Path>TaskApi.kt</Path>
+                檔案：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor.network&#10;&#10;import com.example.ktor.model.Task&#10;import io.ktor.client.HttpClient&#10;import io.ktor.client.call.body&#10;import io.ktor.client.request.delete&#10;import io.ktor.client.request.get&#10;import io.ktor.client.request.post&#10;import io.ktor.client.request.setBody&#10;import io.ktor.http.ContentType&#10;import io.ktor.http.contentType&#10;&#10;class TaskApi(private val httpClient: HttpClient) {&#10;&#10;    suspend fun getAllTasks(): List&lt;Task&gt; {&#10;        return httpClient.get(&quot;tasks&quot;).body()&#10;    }&#10;&#10;    suspend fun removeTask(task: Task) {&#10;        httpClient.delete(&quot;tasks/${task.name}&quot;)&#10;    }&#10;&#10;    suspend fun updateTask(task: Task) {&#10;        httpClient.post(&quot;tasks&quot;) {&#10;            contentType(ContentType.Application.Json)&#10;            setBody(task)&#10;        }&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                導航至
+                <Path>app/shared/.../App.kt</Path>
+                並將程式碼替換為以下實作。這將使用 <code>TaskApi</code> 型別從伺服器獲取任務列表，然後在列中顯示每個任務的名稱：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import com.example.ktor.network.TaskApi&#10;import com.example.ktor.network.createHttpClient&#10;import com.example.ktor.model.Task&#10;import androidx.compose.foundation.layout.Column&#10;import androidx.compose.foundation.layout.fillMaxSize&#10;import androidx.compose.foundation.layout.safeContentPadding&#10;import androidx.compose.material3.Button&#10;import androidx.compose.material3.MaterialTheme&#10;import androidx.compose.material3.Text&#10;import androidx.compose.runtime.*&#10;import androidx.compose.ui.Alignment&#10;import androidx.compose.ui.Modifier&#10;import kotlinx.coroutines.launch&#10;&#10;@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        val tasks = remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;&#10;        Column(&#10;            modifier = Modifier&#10;                .safeContentPadding()&#10;                .fillMaxSize(),&#10;            horizontalAlignment = Alignment.CenterHorizontally,&#10;        ) {&#10;            Button(onClick = {&#10;                scope.launch {&#10;                    tasks.value = taskApi.getAllTasks()&#10;                }&#10;            }) {&#10;                Text(&quot;Fetch Tasks&quot;)&#10;            }&#10;            for (task in tasks.value) {&#10;                Text(task.name)&#10;            }&#10;        }&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                在伺服器執行的同時，透過執行 <ui-path>iosApp</ui-path> 執行配置來測試 iOS 應用程式。
+            </p>
+        </step>
+        <step>
+            <p>
+                點擊
+                <control>Fetch Tasks</control>
+                按鈕以顯示任務列表：
+                <img style="block" src="full_stack_development_tutorial_run_iOS.png"
+                     alt="App running on iOS" width="363" border-effect="rounded"/>
+            </p>
+            <note>
+                在本次演示中，為了清晰起見，我們簡化了流程。在現實世界的應用程式中，避免透過網路發送未加密的資料至關重要。
+            </note>
+        </step>
+        <step>
+            <p>
+                在 Android 平台上，您需要明確地授予應用程式網路權限，並允許其以明文形式發送和接收資料。要啟用這些權限，請開啟
+                <Path>app/androidApp/src/main/AndroidManifest.xml</Path>
+                並新增以下設定：
+            </p>
+            <code-block lang="xml" code="                    &lt;manifest&gt;&#10;                        ...&#10;                        &lt;application&#10;                                android:usesCleartextTraffic=&quot;true&quot;&gt;&#10;                        ...&#10;                        ...&#10;                        &lt;/application&gt;&#10;                        &lt;uses-permission android:name=&quot;android.permission.INTERNET&quot;/&gt;&#10;                    &lt;/manifest&gt;"/>
+        </step>
+        <step>
+            <p>
+                使用 <ui-path>app.androidApp</ui-path> 執行配置來執行 Android 應用程式。您現在應該會發現您的 Android 用戶端也可以正常執行：
+                <img style="block" src="full_stack_development_tutorial_run_android.png"
+                     alt="App running on Android" width="350" />
+            </p>
+        </step>
+        <step>
+            <p>
+                對於桌面用戶端，您將為容器視窗分配尺寸和標題。開啟檔案
+                <Path>app/desktopApp/src/.../main.kt</Path>
+                並透過變更 <code>title</code> 並設定 <code>state</code> 屬性來修改程式碼：
+            </p>
+            <code-block lang="kotlin" code="package com.example.ktor&#10;&#10;import androidx.compose.ui.unit.DpSize&#10;import androidx.compose.ui.unit.dp&#10;import androidx.compose.ui.window.Window&#10;import androidx.compose.ui.window.WindowPosition&#10;import androidx.compose.ui.window.WindowState&#10;import androidx.compose.ui.window.application&#10;&#10;fun main() = application {&#10;    val state = WindowState(&#10;        size = DpSize(400.dp, 600.dp),&#10;        position = WindowPosition(200.dp, 100.dp)&#10;    )&#10;    Window(&#10;        title = &quot;Task Manager (Desktop)&quot;,&#10;        state = state,&#10;        onCloseRequest = ::exitApplication,&#10;    ) {&#10;        App()&#10;    }&#10;}"/>
+        </step>
+        <step>
+            <p>
+                使用 <ui-path>app [hot] 🔥</ui-path> 執行配置執行桌面應用程式：
+                <img style="block" src="full_stack_development_tutorial_run_desktop_resized.png"
+                     alt="App running on desktop" width="400" border-effect="rounded"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                使用以下執行配置之一執行 Web 用戶端：
+            </p>
+            <list>
+                <li>
+                    <ui-path>app [js]</ui-path>: 執行您的 Kotlin/JS 應用程式。
+                </li>
+                <li>
+                    <ui-path>app [wasmJs]</ui-path>: 執行您的 Kotlin/Wasm 應用程式。
+                </li>
+            </list>
+            <img style="block" src="full_stack_development_tutorial_run_web.png"
+                 alt="App running on web" width="400" border-effect="rounded"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="改進 UI" id="improve-ui">
+    <p>
+        用戶端現在正在與伺服器通信，但這顯然稱不上是一個美觀的 UI。
+    </p>
+    <procedure id="improve-ui-procedure">
+        <step>
+            <p>
+                開啟位於
+                <Path>app/shared/src/commonMain/.../ktor</Path>
+                的
+                <Path>App.kt</Path>
+                檔案，並將現有的 <code>App</code> 替換為下面的 <code>App</code> 和 <code>TaskCard</code> 可組合項：
+            </p>
+            <code-block lang="kotlin" collapsed-title-line-number="31" collapsible="true" code="package com.example.ktor&#10;&#10;import com.example.ktor.network.TaskApi&#10;import com.example.ktor.model.Priority&#10;import com.example.ktor.model.Task&#10;import androidx.compose.foundation.layout.Column&#10;import androidx.compose.foundation.layout.Row&#10;import androidx.compose.foundation.layout.Spacer&#10;import androidx.compose.foundation.layout.fillMaxSize&#10;import androidx.compose.foundation.layout.fillMaxWidth&#10;import androidx.compose.foundation.layout.padding&#10;import androidx.compose.foundation.layout.safeContentPadding&#10;import androidx.compose.foundation.layout.width&#10;import androidx.compose.foundation.lazy.LazyColumn&#10;import androidx.compose.foundation.lazy.items&#10;import androidx.compose.foundation.shape.CornerSize&#10;import androidx.compose.foundation.shape.RoundedCornerShape&#10;import androidx.compose.material3.Card&#10;import androidx.compose.material3.MaterialTheme&#10;import androidx.compose.material3.OutlinedButton&#10;import androidx.compose.material3.Text&#10;import androidx.compose.runtime.*&#10;import androidx.compose.ui.Modifier&#10;import androidx.compose.ui.text.font.FontWeight&#10;import androidx.compose.ui.unit.dp&#10;import androidx.compose.ui.unit.sp&#10;import com.example.ktor.network.createHttpClient&#10;import kotlinx.coroutines.launch&#10;&#10;@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        var tasks by remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;&#10;        LaunchedEffect(Unit) {&#10;            tasks = taskApi.getAllTasks()&#10;        }&#10;&#10;        LazyColumn(&#10;            modifier = Modifier&#10;                .safeContentPadding()&#10;                .fillMaxSize()&#10;        ) {&#10;            items(tasks) { task -&gt;&#10;                TaskCard(&#10;                    task,&#10;                    onDelete = {&#10;                        scope.launch {&#10;                            taskApi.removeTask(it)&#10;                            tasks = taskApi.getAllTasks()&#10;                        }&#10;                    },&#10;                    onUpdate = {&#10;                    }&#10;                )&#10;            }&#10;        }&#10;    }&#10;}&#10;&#10;@Composable&#10;fun TaskCard(&#10;    task: Task,&#10;    onDelete: (Task) -&gt; Unit,&#10;    onUpdate: (Task) -&gt; Unit&#10;) {&#10;    fun pickWeight(priority: Priority) = when (priority) {&#10;        Priority.Low -&gt; FontWeight.SemiBold&#10;        Priority.Medium -&gt; FontWeight.Bold&#10;        Priority.High, Priority.Vital -&gt; FontWeight.ExtraBold&#10;    }&#10;&#10;    Card(&#10;        modifier = Modifier.fillMaxWidth().padding(4.dp),&#10;        shape = RoundedCornerShape(CornerSize(4.dp))&#10;    ) {&#10;        Column(modifier = Modifier.padding(10.dp)) {&#10;            Text(&#10;                &quot;${task.name}: ${task.description}&quot;,&#10;                fontSize = 20.sp,&#10;                fontWeight = pickWeight(task.priority)&#10;            )&#10;&#10;            Row {&#10;                OutlinedButton(onClick = { onDelete(task) }) {&#10;                    Text(&quot;Delete&quot;)&#10;                }&#10;                Spacer(Modifier.width(8.dp))&#10;                OutlinedButton(onClick = { onUpdate(task) }) {&#10;                    Text(&quot;Update&quot;)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                透過此實作，您的用戶端現在具備了一些基本功能。
+            </p>
+            <p>
+                透過使用 <code>LaunchedEffect</code> 型別，所有任務都會在啟動時載入，而 <code>LazyColumn</code> 可組合項允許使用者捲動任務列表。
+            </p>
+            <p>
+                最後，建立了一個單獨的 <code>TaskCard</code> 可組合項，它轉而使用 <code>Card</code> 來顯示每個 <code>Task</code> 的詳細資訊。還新增了用於刪除和更新任務的按鈕。
+            </p>
+        </step>
+        <step>
+            <p>
+                重新執行用戶端應用程式 — 例如 Android 應用程式。您現在可以捲動任務、查看其詳細資訊並將其刪除：
+                <img style="block" src="full_stack_development_tutorial_improved_ui.gif"
+                     alt="App running on Android with improved UI" width="350" border-effect="rounded"/>
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="新增更新功能" id="add-update-functionality">
+    <p>
+        為了完成用戶端，請加入允許更新任務詳細資訊的功能。
+    </p>
+    <procedure id="add-update-func-procedure">
+        <step>
+            導航至
+            <Path>app/shared/src/commonMain/.../ktor</Path>
+            中的
+            <Path>App.kt</Path>
+            檔案。
+        </step>
+        <step>
+            <p>
+                新增 <code>UpdateTaskDialog</code> 可組合項和必要的匯入，如下所示：
+            </p>
+            <code-block lang="kotlin" code="import androidx.compose.material3.TextField&#10;import androidx.compose.material3.TextFieldDefaults&#10;import androidx.compose.ui.graphics.Color&#10;import androidx.compose.ui.window.Dialog&#10;&#10;@Composable&#10;fun UpdateTaskDialog(&#10;    task: Task,&#10;    onConfirm: (Task) -&gt; Unit&#10;) {&#10;    var description by remember { mutableStateOf(task.description) }&#10;    var priorityText by remember { mutableStateOf(task.priority.toString()) }&#10;    val colors = TextFieldDefaults.colors(&#10;        focusedTextColor = Color.Blue,&#10;        focusedContainerColor = Color.White,&#10;    )&#10;&#10;    Dialog(onDismissRequest = {}) {&#10;        Card(&#10;            modifier = Modifier.fillMaxWidth().padding(4.dp),&#10;            shape = RoundedCornerShape(CornerSize(4.dp))&#10;    ) {&#10;            Column(modifier = Modifier.padding(10.dp)) {&#10;                Text(&quot;Update ${task.name}&quot;, fontSize = 20.sp)&#10;                TextField(&#10;                    value = description,&#10;                    onValueChange = { description = it },&#10;                    label = { Text(&quot;Description&quot;) },&#10;                    colors = colors&#10;                )&#10;                TextField(&#10;                    value = priorityText,&#10;                    onValueChange = { priorityText = it },&#10;                    label = { Text(&quot;Priority&quot;) },&#10;                    colors = colors&#10;                )&#10;                OutlinedButton(onClick = {&#10;                    val newTask = Task(&#10;                        task.name,&#10;                        description,&#10;                        try {&#10;                            Priority.valueOf(priorityText)&#10;                        } catch (e: IllegalArgumentException) {&#10;                            Priority.Low&#10;                        }&#10;                    )&#10;                    onConfirm(newTask)&#10;                }) {&#10;                    Text(&quot;Update&quot;)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                這是一個使用對話方塊顯示 <code>Task</code> 詳細資訊的可組合項。<code>description</code> 和 <code>priority</code> 被放置在 <code>TextField</code> 可組合項中，以便它們可以被更新。當使用者按下更新按鈕時，它會觸發 <code>onConfirm()</code> 回呼。
+            </p>
+        </step>
+        <step>
+            <p>
+                更新同一個檔案中的 <code>App</code> 可組合項：
+            </p>
+            <code-block lang="kotlin" code="@Composable&#10;fun App() {&#10;    MaterialTheme {&#10;        val httpClient = createHttpClient()&#10;        val taskApi = remember { TaskApi(httpClient) }&#10;        var tasks by remember { mutableStateOf(emptyList&lt;Task&gt;()) }&#10;        val scope = rememberCoroutineScope()&#10;        var currentTask by remember { mutableStateOf&lt;Task?&gt;(null) }&#10;&#10;        LaunchedEffect(Unit) {&#10;            tasks = taskApi.getAllTasks()&#10;        }&#10;&#10;        if (currentTask != null) {&#10;            UpdateTaskDialog(&#10;                currentTask!!,&#10;                onConfirm = {&#10;                    scope.launch {&#10;                        taskApi.updateTask(it)&#10;                        tasks = taskApi.getAllTasks()&#10;                    }&#10;                    currentTask = null&#10;                }&#10;            )&#10;        }&#10;&#10;        LazyColumn(modifier = Modifier&#10;            .safeContentPadding()&#10;            .fillMaxSize()&#10;        ) {&#10;            items(tasks) { task -&gt;&#10;                TaskCard(&#10;                    task,&#10;                    onDelete = {&#10;                        scope.launch {&#10;                            taskApi.removeTask(it)&#10;                            tasks = taskApi.getAllTasks()&#10;                        }&#10;                    },&#10;                    onUpdate = {&#10;                        currentTask = task&#10;                    }&#10;                )&#10;            }&#10;        }&#10;    }&#10;}"/>
+            <p>
+                您正在儲存一個額外的狀態，即當前選取的任務。如果此值不為 null，那麼我們將調用我們的 <code>UpdateTaskDialog</code> 可組合項，並將 <code>onConfirm()</code> 回呼設定為使用 <code>TaskApi</code> 向伺服器發送 POST 請求。
+            </p>
+            <p>
+                最後，當您建立 <code>TaskCard</code> 可組合項時，您使用 <code>onUpdate()</code> 回呼來設定 <code>currentTask</code> 狀態變數。
+            </p>
+        </step>
+        <step>
+            重新執行用戶端應用程式。您現在應該能夠透過使用按鈕來更新每個任務的詳細資訊。
+            <img style="block" src="full_stack_development_tutorial_update_task.gif"
+                 alt="Deleting tasks on Android" width="350" border-effect="rounded"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="後續步驟" id="next-steps">
+    <p>
+        在本文中，您已在 Kotlin Multiplatform 應用程式的內容中使用了 Ktor。您現在可以建立一個包含多個服務和用戶端，並針對一系列不同平台的專案。
+    </p>
+    <p>
+        正如您所看到的，構建功能時無需任何程式碼重複或冗餘。專案所有層級所需的型別都可以放置在
+        <Path>core</Path>
+        多平台模組中。僅服務需要的功能放在
+        <Path>server</Path>
+        模組中，而僅用戶端需要的功能則放在
+        <Path>app</Path>
+        模組中。
+    </p>
+    <p>
+        這種開發必然需要用戶端和伺服器技術的知識。但您可以使用 <a href="https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html">Kotlin Multiplatform</a> 連結庫和 <a href="https://www.jetbrains.com/lp/compose-multiplatform/">Compose Multiplatform</a> 來最大限度地減少您需要學習的新內容。即使您最初只專注於單一平台，隨著對應用程式需求的成長，您也可以輕鬆新增其他平台。
+    </p>
+</chapter>
+</topic>

--- a/docs/zh-Hant/ktor/migration-from-express-js.md
+++ b/docs/zh-Hant/ktor/migration-from-express-js.md
@@ -1,0 +1,988 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="從 Express 遷移至 Ktor"
+       id="migration-from-express-js" help-id="express-js;migrating-from-express-js">
+<show-structure for="chapter" depth="2"/>
+<link-summary>本指南介紹如何建立、執行和測試簡單的 Ktor 應用程式。</link-summary>
+<tldr>
+    <p>
+        <b>程式碼範例</b>：
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express">migrating-express</a>
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor">migrating-express-ktor</a>
+    </p>
+</tldr>
+<p>
+    在本指南中，我們將探討在基本情境下如何將 Express 應用程式遷移至 Ktor：
+    從產生應用程式與撰寫您的第一個應用程式，到建立用於擴充應用程式功能的中介軟體。
+</p>
+<chapter title="產生應用程式" id="generate">
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    您可以使用 <code>express-generator</code> 工具來產生新的 Express 應用程式：
+                </p>
+                <code-block lang="shell" code="                        npx express-generator"/>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor 提供以下幾種方式來產生應用程式骨架：
+                </p>
+                <list>
+                    <li>
+                        <p>
+                            <a href="https://start.ktor.io/">Ktor 專案產生器 (Ktor Project Generator)</a> — 使用網頁版產生器。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <a href="https://github.com/ktorio/ktor-cli">
+                                Ktor CLI 工具
+                            </a> — 透過命令列介面使用 <code>ktor new</code> 指令產生 Ktor 專案：
+                        </p>
+                        <code-block lang="shell" code="                                ktor new ktor-sample"/>
+                    </li>
+                    <li>
+                        <p>
+                            <a href="https://www.npmjs.com/package/generator-ktor">
+                                Yeoman 產生器
+                            </a>
+                            — 以互動方式配置專案設定並選取所需的外掛程式：
+                        </p>
+                        <code-block lang="shell" code="                                yo ktor"/>
+                    </li>
+                    <li>
+                        <p>
+                            <a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 使用內建的 Ktor 專案精靈。
+                        </p>
+                    </li>
+                </list>
+                <p>
+                    如需詳細指示，請參閱 <Links href="//server-create-a-new-project" summary="了解如何使用 Ktor 開啟、執行和測試伺服器應用程式。">建立、開啟並執行新的 Ktor 專案</Links> 教學。
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="Hello world" id="hello">
+    <p>
+        在本節中，我們將探討如何建立最簡單的伺服器應用程式，該程式接收 <code>GET</code> 請求並以預定義的純文字進行回應。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    下方的範例顯示了啟動伺服器並監聽通訊埠 <control>3000</control> 連線的 Express 應用程式。
+                </p>
+                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    在 Ktor 中，您可以使用 <a href="#embedded-server">embeddedServer</a>
+                    函式在程式碼中配置伺服器參數並快速執行應用程式。
+                </p>
+                <code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a>
+                    專案。
+                </p>
+                <p>
+                    您也可以在採用 HOCON 或 YAML 格式的 <a href="#engine-main">外部配置檔案</a> 中指定伺服器設定。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        請注意，上述 Express 應用程式會加入 <control>Date</control>、<control>X-Powered-By</control> 和 <control>ETag</control> 回應標頭，內容可能如下所示：
+    </p>
+    <code-block code="            Date: Fri, 05 Aug 2022 06:30:48 GMT&#10;            X-Powered-By: Express&#10;            ETag: W/&quot;c-Lve95gjOVATpfV8EL5X4nxwjKHE&quot;"/>
+    <p>
+        若要在 Ktor 的每個回應中加入預設的 <control>Server</control> 與 <control>Date</control> 標頭，
+        您需要安裝 <Links href="//server-default-headers" summary="需要的相依性：io.ktor:%artifact_name%">DefaultHeaders</Links> 外掛程式。
+        <Links href="//server-conditional-headers" summary="需要的相依性：io.ktor:%artifact_name%">ConditionalHeaders</Links> 外掛程式則可用於配置 <control>Etag</control> 回應標頭。
+    </p>
+</chapter>
+<chapter title="提供靜態內容" id="static">
+    <p>
+        在本節中，我們將探討如何在 Express 與 Ktor 中提供影像、CSS 檔案與 JavaScript 檔案等靜態檔案。
+        假設我們有一個 <Path>public</Path> 資料夾，其中包含主要的 <Path>index.html</Path> 頁面
+        以及一組連結的資源。
+    </p>
+    <code-block code="            public&#10;            ├── index.html&#10;            ├── ktor_logo.png&#10;            ├── css&#10;            │   └──styles.css&#10;            └── js&#10;                └── script.js"/>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    在 Express 中，將資料夾名稱傳遞給 <control>express.static</control> 函式。
+                </p>
+                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    在 Ktor 中，使用 <a href="#folders"><code>staticFiles()</code></a> 函式將對 <Path>/</Path> 路徑的任何請求對應到 <Path>public</Path> 實體資料夾。
+                    此函式可以遞迴地提供 <Path>public</Path> 資料夾中的所有檔案。
+                </p>
+                <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
+                <p>
+                    如需完整範例，請參閱 <a
+                        href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        提供靜態內容時，Express 會加入數個回應標頭，內容可能如下所示：
+    </p>
+    <code-block code="            Accept-Ranges: bytes&#10;            Cache-Control: public, max-age=0&#10;            ETag: W/&quot;181-1823feafeb1&quot;&#10;            Last-Modified: Wed, 27 Jul 2022 13:49:01 GMT"/>
+    <p>
+        要在 Ktor 中管理這些標頭，您需要安裝以下外掛程式：
+    </p>
+    <list>
+        <li>
+            <p>
+                <control>Accept-Ranges</control>
+                ：<Links href="//server-partial-content" summary="需要的相依性：io.ktor:%artifact_name% 伺服器範例：download-file，用戶端範例：client-download-file-range">PartialContent</Links>
+            </p>
+        </li>
+        <li>
+            <p>
+                <control>Cache-Control</control>
+                ：<Links href="//server-caching-headers" summary="需要的相依性：io.ktor:%artifact_name%">CachingHeaders</Links>
+            </p>
+        </li>
+        <li>
+            <p>
+                <control>ETag</control>
+                與
+                <control>Last-Modified</control>
+                ：
+                <Links href="//server-conditional-headers" summary="需要的相依性：io.ktor:%artifact_name%">ConditionalHeaders</Links>
+            </p>
+        </li>
+    </list>
+</chapter>
+<chapter title="路由" id="routing">
+    <p>
+        <Links href="//server-routing" summary="路由是伺服器應用程式中處理傳入請求的核心外掛程式。">路由 (Routing)</Links> 允許處理傳送到特定端點的請求，
+        端點由特定的 HTTP 請求方法（<code>GET</code>、<code>POST</code> 等）與路徑定義。
+        下方的範例展示如何處理傳送到 <Path>/</Path> 路徑的 <code>GET</code> 與 <code>POST</code> 請求。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
+                <tip>
+                    <p>
+                        請參閱 <a href="#receive-request">接收請求</a> 以了解如何接收 <code>POST</code>、<code>PUT</code> 或 <code>PATCH</code> 請求的請求主體。
+                    </p>
+                </tip>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        以下範例示範如何依路徑分組路由處理常式。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    在 Express 中，您可以使用 <code>app.route()</code> 為路由路徑建立可鏈式呼叫的路由處理常式。
+                </p>
+                <code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor 提供 <code>route</code> 函式，
+                    您可以在其中定義路徑，然後將該路徑的動詞作為巢狀函式放置在內。
+                </p>
+                <code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        這兩個架構都允許您將相關路由分組在單個檔案中。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    Express 提供 <code>express.Router</code> 類別來建立可掛載的路由處理常式。
+                    假設我們在應用程式目錄中有一個 <Path>birds.js</Path> 路由檔案。
+                    此路由模組可以按照 <Path>app.js</Path> 所示載入到應用程式中：
+                </p>
+                <Tabs>
+                    <TabItem title="birds.js">
+                        <code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
+                    </TabItem>
+                    <TabItem title="app.js">
+                        <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    在 Ktor 中，常見的模式是在 <code>Routing</code> 型別上使用擴充函式來定義實際路由。
+                    下方的範例 (<Path>Birds.kt</Path>) 定義了 <code>birdsRoutes</code> 擴充函式。
+                    您可以透過在 <code>routing</code> 區塊內呼叫此函式，將對應的路由包含在應用程式 (<Path>Application.kt</Path>) 中：
+                </p>
+                <Tabs>
+                    <TabItem title="Birds.kt" id="birds-kt">
+                        <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
+                    </TabItem>
+                    <TabItem title="Application.kt" id="application-kt">
+                        <code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        除了將 URL 路徑指定為字串外，Ktor 還包含實作 <Links href="//server-resources" summary="Resources 外掛程式允許您實作型別安全路由。">型別安全路由</Links> 的功能。
+    </p>
+</chapter>
+<chapter title="路由與查詢參數" id="route-query-param">
+    <p>
+        本節將展示如何存取路由參數與查詢參數。
+    </p>
+    <p>
+        路由（或路徑）參數是具名的 URL 片段，用於擷取在 URL 中該位置指定的值。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    要在 Express 中存取路由參數，您可以使用 <code>Request.params</code>。
+                    例如，下方程式碼片段中的 <code>req.parameters["login"]</code> 對於 <Path>/user/admin</Path> 路徑將傳回 <emphasis>admin</emphasis>：
+                </p>
+                <code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    在 Ktor 中，路由參數是使用 <code>{param}</code> 語法定義的。
+                    您可以使用 <code>call.parameters</code> 在路由處理常式中存取路由參數：
+                </p>
+                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+    </table>
+    <p>
+        下表比較了如何存取查詢字串的參數。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    要在 Express 中存取路由參數，您可以使用 <code>Request.params</code>。
+                    例如，下方程式碼片段中的 <code>req.parameters["login"]</code> 對於 <Path>/user/admin</Path> 路徑將傳回 <emphasis>admin</emphasis>：
+                </p>
+                <code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    在 Ktor 中，路由參數是使用 <code>{param}</code> 語法定義的。
+                    您可以使用 <code>call.parameters</code> 在路由處理常式中存取路由參數：
+                </p>
+                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="傳送回應" id="send-response">
+    <p>
+        在之前的章節中，我們已經看過如何以純文字內容進行回應。
+        讓我們來看看如何傳送 JSON、檔案與重新導向回應。
+    </p>
+    <chapter title="JSON" id="send-json">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中傳送具有適當內容類型的 JSON 回應，請呼叫 <code>res.json</code> 函式：
+                    </p>
+                    <code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，您需要安裝 <Links href="//server-serialization" summary="ContentNegotiation 外掛程式有兩個主要目的：在用戶端與伺服器之間協商媒體類型，以及以特定格式對內容進行序列化／還原序列化。">ContentNegotiation</Links> 外掛程式並配置 JSON 序列化器：
+                    </p>
+                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
+                    <p>
+                        要將資料序列化為 JSON，您需要建立一個帶有 <code>@Serializable</code> 註解的資料類別：
+                    </p>
+                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+                    <p>
+                        然後，您可以使用 <code>call.respond</code> 在回應中傳送此類別的物件：
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="檔案" id="send-file">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中以檔案回應，請使用 <code>res.sendFile</code>：
+                    </p>
+                    <code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor 提供 <code>call.respondFile</code> 函式用於將檔案傳送至用戶端：
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+        <p>
+            Express 應用程式在以檔案回應時，會加入 <control>Accept-Ranges</control> HTTP 回應標頭。
+            伺服器使用此標頭向用戶端宣告其支援部分請求以進行檔案下載。
+            在 Ktor 中，您需要安裝 <Links href="//server-partial-content" summary="需要的相依性：io.ktor:%artifact_name% 伺服器範例：download-file，用戶端範例：client-download-file-range">PartialContent</Links> 外掛程式以支援部分請求。
+        </p>
+    </chapter>
+    <chapter title="檔案附件" id="send-file-attachment">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        <code>res.download</code> 函式會將指定的檔案作為附件傳輸：
+                    </p>
+                    <code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，您需要手動配置 <control>Content-Disposition</control> 標頭以將檔案作為附件傳輸：
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="重新導向" id="redirect">
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中產生重新導向回應，請呼叫 <code>redirect</code> 函式：
+                    </p>
+                    <code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，使用 <code>respondRedirect</code> 來傳送重新導向回應：
+                    </p>
+                    <code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+</chapter>
+<chapter title="範本" id="templates">
+    <p>
+        Express 與 Ktor 都能夠配合範本引擎來處理檢視 (views)。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    假設我們在 <Path>views</Path> 資料夾中有以下的 Pug 範本：
+                </p>
+                <code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
+                <p>
+                    要以該範本回應，請呼叫 <code>res.render</code>：
+                </p>
+                <code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor 支援數種 <Links href="//server-templating" summary="了解如何處理使用 HTML/CSS 或 JVM 範本引擎建構的檢視。">JVM 範本引擎</Links>，
+                    如 FreeMarker、Velocity 等。
+                    例如，如果您需要以放置在應用程式資源中的 FreeMarker 範本回應，
+                    請安裝並配置 <code>FreeMarker</code> 外掛程式，然後使用 <code>call.respond</code> 傳送範本：
+                </p>
+                <code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="接收請求" id="receive-request">
+    <p>
+        本節將展示如何接收不同格式的請求主體。
+    </p>
+    <chapter title="原始文字" id="receive-raw-text">
+        <p>
+            下方的 <code>POST</code> 請求向伺服器傳送文字資料：
+        </p>
+        <code-block lang="http" code="POST http://0.0.0.0:3000/text&#10;Content-Type: text/plain&#10;&#10;Hello, world!"/>
+        <p>
+            讓我們來看看如何在伺服器端將此請求的主體作為純文字接收。
+        </p>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中剖析傳入的請求主體，您需要加入 <code>body-parser</code>：
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
+                    <p>
+                        在 <code>post</code> 處理常式中，
+                        您需要傳遞文字剖析器 (<code>bodyParser.text</code>)。
+                        請求主體將可透過 <code>req.body</code> 屬性取得：
+                    </p>
+                    <code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，您可以使用 <code>call.receiveText</code> 將主體作為文字接收：
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="JSON" id="receive-json">
+        <p>
+            在本節中，我們將探討如何接收 JSON 主體。
+            下方的範例顯示了一個在其主體中帶有 JSON 物件的 <code>POST</code> 請求：
+        </p>
+        <code-block lang="http" code="POST http://0.0.0.0:3000/json&#10;Content-Type: application/json&#10;&#10;{&#10;  &quot;type&quot;: &quot;Fiat&quot;,&#10;  &quot;model&quot; : &quot;500&quot;,&#10;  &quot;color&quot;: &quot;white&quot;&#10;}"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中接收 JSON，請使用 <code>bodyParser.json</code>：
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，您需要安裝 <Links href="//server-serialization" summary="ContentNegotiation 外掛程式有兩個主要目的：在用戶端與伺服器之間協商媒體類型，以及以特定格式對內容進行序列化／還原序列化。">ContentNegotiation</Links> 外掛程式並配置 <code>Json</code> 序列化器：
+                    </p>
+                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
+                    <p>
+                        要將接收到的資料還原序列化為物件，您需要建立一個資料類別：
+                    </p>
+                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+                    <p>
+                        然後，使用接受此資料類別作為參數的 <code>receive</code> 方法：
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="URL 編碼" id="receive-url-encoded">
+        <p>
+            現在讓我們來看看如何接收使用 <control>application/x-www-form-urlencoded</control> 類型傳送的表單資料。
+            下方的程式碼片段顯示了一個帶有表單資料的範例 <code>POST</code> 請求：
+        </p>
+        <code-block lang="http" code="POST http://localhost:3000/urlencoded&#10;Content-Type: application/x-www-form-urlencoded&#10;&#10;username=JetBrains&amp;email=example@jetbrains.com&amp;password=foobar&amp;confirmation=foobar"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        與純文字和 JSON 同樣，Express 需要 <code>body-parser</code>。
+                        您需要將剖析器型別設定為 <code>bodyParser.urlencoded</code>：
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，使用 <code>call.receiveParameters</code> 函式：
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+    </table>
+    </chapter>
+    <chapter title="原始資料" id="receive-raw-data">
+        <p>
+            下一個使用案例是處理二進位資料。
+            下方的請求將帶有 <control>application/octet-stream</control> 類型的 PNG 影像傳送至伺服器：
+        </p>
+        <code-block lang="http" code="POST http://localhost:3000/raw&#10;Content-Type: application/octet-stream&#10;&#10;&lt; ./ktor_logo.png"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        要在 Express 中處理二進位資料，請將剖析器型別設定為 <code>raw</code>：
+                    </p>
+                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        Ktor 提供 <code>ByteReadChannel</code> 與 <code>ByteWriteChannel</code>
+                        用於非同步讀取／寫入位元組序列：
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive
+                            request</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+    <chapter title="多部分 (Multipart)" id="receive-multipart">
+        <p>
+            在最後一節中，讓我們來看看如何處理 <emphasis>多部分 (multipart)</emphasis> 主體。
+            下方的 <code>POST</code> 請求使用 <control>multipart/form-data</control> 類型傳送 PNG 影像與說明：
+        </p>
+        <code-block lang="http" code="POST http://localhost:3000/multipart&#10;Content-Type: multipart/form-data; boundary=WebAppBoundary&#10;&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;description&quot;&#10;Content-Type: text/plain&#10;&#10;Ktor logo&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;image&quot;; filename=&quot;ktor_logo.png&quot;&#10;Content-Type: image/png&#10;&#10;&lt; ./ktor_logo.png&#10;--WebAppBoundary--"/>
+        <table style="header-column">
+            
+<tr>
+<td>
+                    <control>Express</control>
+                </td>
+                <td>
+                    <p>
+                        Express 需要個別的模組來剖析多部分資料。
+                        在下方的範例中，使用了 <control>multer</control> 將檔案上傳至伺服器：
+                    </p>
+                    <code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+            
+<tr>
+<td>
+                    <control>Ktor</control>
+                </td>
+                <td>
+                    <p>
+                        在 Ktor 中，如果您需要接收作為多部分請求的一部分傳送的檔案，
+                        請呼叫 <code>receiveMultipart</code> 函式，然後視需要對每個部分進行迴圈處理。
+                        在下方的範例中，使用 <code>PartData.FileItem</code> 將檔案作為位元組串流接收：
+                    </p>
+                    <code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
+                    <p>
+                        如需完整範例，請參閱
+                        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
+                        專案。
+                    </p>
+                </td>
+</tr>
+
+        </table>
+    </chapter>
+</chapter>
+<chapter title="建立中介軟體" id="middleware">
+    <p>
+        最後我們要探討的是如何建立允許您擴充伺服器功能的中介軟體。
+        下方的範例展示如何使用 Express 與 Ktor 實作請求記錄。
+    </p>
+    <table style="header-column">
+        
+<tr>
+<td>
+                <control>Express</control>
+            </td>
+            <td>
+                <p>
+                    在 Express 中，中介軟體是使用 <code>app.use</code> 綁定到應用程式的函式：
+                </p>
+                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+        
+<tr>
+<td>
+                <control>Ktor</control>
+            </td>
+            <td>
+                <p>
+                    Ktor 允許您使用 <Links href="//server-custom-plugins" summary="了解如何建立您自己的自訂外掛程式。">自訂外掛程式</Links> 來擴充其功能。
+                    下方的程式碼範例展示如何處理 <code>onCall</code> 以實作請求記錄：
+                </p>
+                <code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    如需完整範例，請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a>
+                    專案。
+                </p>
+            </td>
+</tr>
+
+    </table>
+</chapter>
+<chapter title="下一步" id="next">
+    <p>
+        本指南中還有許多未涵蓋的使用案例，
+        如工作階段管理、授權、資料庫整合等。
+        對於大多數功能，Ktor 提供了專用的外掛程式，
+        可以安裝在應用程式中並根據需要進行配置。
+        要繼續您的 Ktor 旅程，
+        請造訪 <control><a href="https://ktor.io/learn/">學習頁面</a></control>，
+        其中提供了一系列的逐步指南與開箱即用的範例。
+    </p>
+</chapter>
+</topic>

--- a/docs/zh-Hant/ktor/migration-from-express-js.md
+++ b/docs/zh-Hant/ktor/migration-from-express-js.md
@@ -17,111 +17,103 @@
 </p>
 <chapter title="產生應用程式" id="generate">
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     您可以使用 <code>express-generator</code> 工具來產生新的 Express 應用程式：
                 </p>
-                <code-block lang="shell" code="                        npx express-generator"/>
-            </td>
+<code-block lang="shell" code="                        npx express-generator"/>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor 提供以下幾種方式來產生應用程式骨架：
                 </p>
-                <list>
-                    <li>
-                        <p>
-                            <a href="https://start.ktor.io/">Ktor 專案產生器 (Ktor Project Generator)</a> — 使用網頁版產生器。
+<list>
+<li>
+<p>
+<a href="https://start.ktor.io/">Ktor 專案產生器 (Ktor Project Generator)</a> — 使用網頁版產生器。
                         </p>
-                    </li>
-                    <li>
-                        <p>
-                            <a href="https://github.com/ktorio/ktor-cli">
+</li>
+<li>
+<p>
+<a href="https://github.com/ktorio/ktor-cli">
                                 Ktor CLI 工具
                             </a> — 透過命令列介面使用 <code>ktor new</code> 指令產生 Ktor 專案：
                         </p>
-                        <code-block lang="shell" code="                                ktor new ktor-sample"/>
-                    </li>
-                    <li>
-                        <p>
-                            <a href="https://www.npmjs.com/package/generator-ktor">
+<code-block lang="shell" code="                                ktor new ktor-sample"/>
+</li>
+<li>
+<p>
+<a href="https://www.npmjs.com/package/generator-ktor">
                                 Yeoman 產生器
                             </a>
                             — 以互動方式配置專案設定並選取所需的外掛程式：
                         </p>
-                        <code-block lang="shell" code="                                yo ktor"/>
-                    </li>
-                    <li>
-                        <p>
-                            <a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 使用內建的 Ktor 專案精靈。
+<code-block lang="shell" code="                                yo ktor"/>
+</li>
+<li>
+<p>
+<a href="https://ktor.io/idea/">IntelliJ IDEA Ultimate</a> — 使用內建的 Ktor 專案精靈。
                         </p>
-                    </li>
-                </list>
-                <p>
+</li>
+</list>
+<p>
                     如需詳細指示，請參閱 <Links href="//server-create-a-new-project" summary="了解如何使用 Ktor 開啟、執行和測試伺服器應用程式。">建立、開啟並執行新的 Ktor 專案</Links> 教學。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="Hello world" id="hello">
     <p>
         在本節中，我們將探討如何建立最簡單的伺服器應用程式，該程式接收 <code>GET</code> 請求並以預定義的純文字進行回應。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     下方的範例顯示了啟動伺服器並監聽通訊埠 <control>3000</control> 連線的 Express 應用程式。
                 </p>
-                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.send('Hello World!')&#10;})&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/1_hello/app.js">1_hello</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     在 Ktor 中，您可以使用 <a href="#embedded-server">embeddedServer</a>
                     函式在程式碼中配置伺服器參數並快速執行應用程式。
                 </p>
-                <code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
-                <p>
+<code-block lang="kotlin" code="import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main() {&#10;    embeddedServer(Netty, port = 8080, host = &quot;0.0.0.0&quot;) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello World!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/1_hello/src/main/kotlin/com/example/Application.kt">1_hello</a>
                     專案。
                 </p>
-                <p>
+<p>
                     您也可以在採用 HOCON 或 YAML 格式的 <a href="#engine-main">外部配置檔案</a> 中指定伺服器設定。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         請注意，上述 Express 應用程式會加入 <control>Date</control>、<control>X-Powered-By</control> 和 <control>ETag</control> 回應標頭，內容可能如下所示：
     </p>
@@ -140,44 +132,40 @@
     </p>
     <code-block code="            public&#10;            ├── index.html&#10;            ├── ktor_logo.png&#10;            ├── css&#10;            │   └──styles.css&#10;            └── js&#10;                └── script.js"/>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     在 Express 中，將資料夾名稱傳遞給 <control>express.static</control> 函式。
                 </p>
-                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;app.use(express.static('public'))&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/2_static/app.js">2_static</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     在 Ktor 中，使用 <a href="#folders"><code>staticFiles()</code></a> 函式將對 <Path>/</Path> 路徑的任何請求對應到 <Path>public</Path> 實體資料夾。
                     此函式可以遞迴地提供 <Path>public</Path> 資料夾中的所有檔案。
                 </p>
-                <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
-                <p>
+<code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.http.content.*&#10;import io.ktor.server.routing.*&#10;import java.io.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        staticFiles(&quot;&quot;, File(&quot;public&quot;), &quot;index.html&quot;)&#10;    }&#10;}"/>
+<p>
                     如需完整範例，請參閱 <a
                         href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/2_static/src/main/kotlin/com/example/Application.kt">2_static</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         提供靜態內容時，Express 會加入數個回應標頭，內容可能如下所示：
     </p>
@@ -216,143 +204,131 @@
         下方的範例展示如何處理傳送到 <Path>/</Path> 路徑的 <code>GET</code> 與 <code>POST</code> 請求。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<code-block lang="javascript" code="app.get('/', (req, res) =&gt; {&#10;    res.send('GET request to the homepage')&#10;})&#10;&#10;app.post('/', (req, res) =&gt; {&#10;    res.send('POST request to the homepage')&#10;})"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
-                <tip>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;GET request to the homepage&quot;)&#10;        }&#10;        post(&quot;/&quot;) {&#10;            call.respondText(&quot;POST request to the homepage&quot;)&#10;        }&#10;    }"/>
+<tip>
+<p>
                         請參閱 <a href="#receive-request">接收請求</a> 以了解如何接收 <code>POST</code>、<code>PUT</code> 或 <code>PATCH</code> 請求的請求主體。
                     </p>
-                </tip>
-                <p>
+</tip>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         以下範例示範如何依路徑分組路由處理常式。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     在 Express 中，您可以使用 <code>app.route()</code> 為路由路徑建立可鏈式呼叫的路由處理常式。
                 </p>
-                <code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
-                <p>
+<code-block lang="javascript" code="app.route('/book')&#10;    .get((req, res) =&gt; {&#10;        res.send('Get a random book')&#10;    })&#10;    .post((req, res) =&gt; {&#10;        res.send('Add a book')&#10;    })&#10;    .put((req, res) =&gt; {&#10;        res.send('Update the book')&#10;    })"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor 提供 <code>route</code> 函式，
                     您可以在其中定義路徑，然後將該路徑的動詞作為巢狀函式放置在內。
                 </p>
-                <code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
-                <p>
+<code-block lang="kotlin" code="    routing {&#10;        route(&quot;book&quot;) {&#10;            get {&#10;                call.respondText(&quot;Get a random book&quot;)&#10;            }&#10;            post {&#10;                call.respondText(&quot;Add a book&quot;)&#10;            }&#10;            put {&#10;                call.respondText(&quot;Update the book&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         這兩個架構都允許您將相關路由分組在單個檔案中。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     Express 提供 <code>express.Router</code> 類別來建立可掛載的路由處理常式。
                     假設我們在應用程式目錄中有一個 <Path>birds.js</Path> 路由檔案。
                     此路由模組可以按照 <Path>app.js</Path> 所示載入到應用程式中：
                 </p>
-                <Tabs>
-                    <TabItem title="birds.js">
-                        <code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
-                    </TabItem>
-                    <TabItem title="app.js">
-                        <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
-                    </TabItem>
-                </Tabs>
-                <p>
+<Tabs>
+<TabItem title="birds.js">
+<code-block lang="javascript" code="const express = require('express')&#10;const router = express.Router()&#10;&#10;router.get('/', (req, res) =&gt; {&#10;    res.send('Birds home page')&#10;})&#10;&#10;router.get('/about', (req, res) =&gt; {&#10;    res.send('About birds')&#10;})&#10;&#10;module.exports = router"/>
+</TabItem>
+<TabItem title="app.js">
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const birds = require('./birds')&#10;const port = 3000&#10;&#10;app.use('/birds', birds)&#10;&#10;app.listen(port, () =&gt; {&#10;    console.log(`Responding at http://0.0.0.0:${port}/`)&#10;})"/>
+</TabItem>
+</Tabs>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/3_router/app.js">3_router</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     在 Ktor 中，常見的模式是在 <code>Routing</code> 型別上使用擴充函式來定義實際路由。
                     下方的範例 (<Path>Birds.kt</Path>) 定義了 <code>birdsRoutes</code> 擴充函式。
                     您可以透過在 <code>routing</code> 區塊內呼叫此函式，將對應的路由包含在應用程式 (<Path>Application.kt</Path>) 中：
                 </p>
-                <Tabs>
-                    <TabItem title="Birds.kt" id="birds-kt">
-                        <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
-                    </TabItem>
-                    <TabItem title="Application.kt" id="application-kt">
-                        <code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
-                    </TabItem>
-                </Tabs>
-                <p>
+<Tabs>
+<TabItem title="Birds.kt" id="birds-kt">
+<code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun Routing.birdsRoutes() {&#10;    route(&quot;/birds&quot;) {&#10;        get {&#10;            call.respondText(&quot;Birds home page&quot;)&#10;        }&#10;        get(&quot;/about&quot;) {&#10;            call.respondText(&quot;About birds&quot;)&#10;        }&#10;    }&#10;}"/>
+</TabItem>
+<TabItem title="Application.kt" id="application-kt">
+<code-block lang="kotlin" code="import com.example.routes.*&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit =&#10;    io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        birdsRoutes()&#10;    }&#10;}"/>
+</TabItem>
+</Tabs>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/3_router/src/main/kotlin/com/example/Application.kt">3_router</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         除了將 URL 路徑指定為字串外，Ktor 還包含實作 <Links href="//server-resources" summary="Resources 外掛程式允許您實作型別安全路由。">型別安全路由</Links> 的功能。
     </p>
@@ -365,88 +341,80 @@
         路由（或路徑）參數是具名的 URL 片段，用於擷取在 URL 中該位置指定的值。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     要在 Express 中存取路由參數，您可以使用 <code>Request.params</code>。
                     例如，下方程式碼片段中的 <code>req.parameters["login"]</code> 對於 <Path>/user/admin</Path> 路徑將傳回 <emphasis>admin</emphasis>：
                 </p>
-                <code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
-                <p>
+<code-block lang="javascript" code="app.get('/user/:login', (req, res) =&gt; {&#10;    if (req.params['login'] === 'admin') {&#10;        res.send('You are logged in as Admin')&#10;    } else {&#10;        res.send('You are logged in as Guest')&#10;    }&#10;})"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     在 Ktor 中，路由參數是使用 <code>{param}</code> 語法定義的。
                     您可以使用 <code>call.parameters</code> 在路由處理常式中存取路由參數：
                 </p>
-                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
-                <p>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/user/{login}&quot;) {&#10;            if (call.parameters[&quot;login&quot;] == &quot;admin&quot;) {&#10;                call.respondText(&quot;You are logged in as Admin&quot;)&#10;            } else {&#10;                call.respondText(&quot;You are logged in as Guest&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
     <p>
         下表比較了如何存取查詢字串的參數。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     要在 Express 中存取路由參數，您可以使用 <code>Request.params</code>。
                     例如，下方程式碼片段中的 <code>req.parameters["login"]</code> 對於 <Path>/user/admin</Path> 路徑將傳回 <emphasis>admin</emphasis>：
                 </p>
-                <code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
-                <p>
+<code-block lang="javascript" code="app.get('/products', (req, res) =&gt; {&#10;    if (req.query['price'] === 'asc') {&#10;        res.send('Products from the lowest price to the highest')&#10;    }&#10;})"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/4_parameters/app.js">4_parameters</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     在 Ktor 中，路由參數是使用 <code>{param}</code> 語法定義的。
                     您可以使用 <code>call.parameters</code> 在路由處理常式中存取路由參數：
                 </p>
-                <code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
-                <p>
+<code-block lang="kotlin" code="    routing {&#10;        get(&quot;/products&quot;) {&#10;            if (call.request.queryParameters[&quot;price&quot;] == &quot;asc&quot;) {&#10;                call.respondText(&quot;Products from the lowest price to the highest&quot;)&#10;            }&#10;        }&#10;    }"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/4_parameters/src/main/kotlin/com/example/Application.kt">4_parameters</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="傳送回應" id="send-response">
     <p>
@@ -455,91 +423,83 @@
     </p>
     <chapter title="JSON" id="send-json">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中傳送具有適當內容類型的 JSON 回應，請呼叫 <code>res.json</code> 函式：
                     </p>
-                    <code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const car = {type:&quot;Fiat&quot;, model:&quot;500&quot;, color:&quot;white&quot;};&#10;app.get('/json', (req, res) =&gt; {&#10;    res.json(car)&#10;})"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，您需要安裝 <Links href="//server-serialization" summary="ContentNegotiation 外掛程式有兩個主要目的：在用戶端與伺服器之間協商媒體類型，以及以特定格式對內容進行序列化／還原序列化。">ContentNegotiation</Links> 外掛程式並配置 JSON 序列化器：
                     </p>
-                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
-                    <p>
+<code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json()&#10;    }"/>
+<p>
                         要將資料序列化為 JSON，您需要建立一個帶有 <code>@Serializable</code> 註解的資料類別：
                     </p>
-                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
-                    <p>
+<code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+<p>
                         然後，您可以使用 <code>call.respond</code> 在回應中傳送此類別的物件：
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/json&quot;) {&#10;            call.respond(Car(&quot;Fiat&quot;, &quot;500&quot;, &quot;white&quot;))&#10;        }"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="檔案" id="send-file">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中以檔案回應，請使用 <code>res.sendFile</code>：
                     </p>
-                    <code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const path = require(&quot;path&quot;)&#10;&#10;app.get('/file', (req, res) =&gt; {&#10;    res.sendFile(path.join(__dirname, 'ktor_logo.png'))&#10;})"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor 提供 <code>call.respondFile</code> 函式用於將檔案傳送至用戶端：
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/file&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.respondFile(file)&#10;        }"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
         <p>
             Express 應用程式在以檔案回應時，會加入 <control>Accept-Ranges</control> HTTP 回應標頭。
             伺服器使用此標頭向用戶端宣告其支援部分請求以進行檔案下載。
@@ -548,83 +508,75 @@
     </chapter>
     <chapter title="檔案附件" id="send-file-attachment">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
-                        <code>res.download</code> 函式會將指定的檔案作為附件傳輸：
+<control>Express</control>
+</td>
+<td>
+<p>
+<code>res.download</code> 函式會將指定的檔案作為附件傳輸：
                     </p>
-                    <code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.get('/file-attachment', (req, res) =&gt; {&#10;    res.download(&quot;ktor_logo.png&quot;)&#10;})"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，您需要手動配置 <control>Content-Disposition</control> 標頭以將檔案作為附件傳輸：
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/file-attachment&quot;) {&#10;            val file = File(&quot;public/ktor_logo.png&quot;)&#10;            call.response.header(&#10;                HttpHeaders.ContentDisposition,&#10;                ContentDisposition.Attachment.withParameter(ContentDisposition.Parameters.FileName, &quot;ktor_logo.png&quot;)&#10;                    .toString()&#10;            )&#10;            call.respondFile(file)&#10;        }"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="重新導向" id="redirect">
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中產生重新導向回應，請呼叫 <code>redirect</code> 函式：
                     </p>
-                    <code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.get('/old', (req, res) =&gt; {&#10;    res.redirect(301, &quot;moved&quot;)&#10;})&#10;&#10;app.get('/moved', (req, res) =&gt; {&#10;    res.send('Moved resource')&#10;})"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/5_send_response/app.js">5_send_response</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，使用 <code>respondRedirect</code> 來傳送重新導向回應：
                     </p>
-                    <code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        get(&quot;/old&quot;) {&#10;            call.respondRedirect(&quot;/moved&quot;, permanent = true)&#10;        }&#10;        get(&quot;/moved&quot;) {&#10;            call.respondText(&quot;Moved resource&quot;)&#10;        }"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/5_send_response/src/main/kotlin/com/example/Application.kt">5_send_response</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
 </chapter>
 <chapter title="範本" id="templates">
@@ -632,50 +584,46 @@
         Express 與 Ktor 都能夠配合範本引擎來處理檢視 (views)。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     假設我們在 <Path>views</Path> 資料夾中有以下的 Pug 範本：
                 </p>
-                <code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
-                <p>
+<code-block code="html&#10;  head&#10;    title= title&#10;  body&#10;    h1= message"/>
+<p>
                     要以該範本回應，請呼叫 <code>res.render</code>：
                 </p>
-                <code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
-                <p>
+<code-block lang="javascript" code="app.set('views', './views')&#10;app.set('view engine', 'pug')&#10;&#10;app.get('/', (req, res) =&gt; {&#10;    res.render('index', { title: 'Hey', message: 'Hello there!' })&#10;})"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/6_templates/app.js">6_templates</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor 支援數種 <Links href="//server-templating" summary="了解如何處理使用 HTML/CSS 或 JVM 範本引擎建構的檢視。">JVM 範本引擎</Links>，
                     如 FreeMarker、Velocity 等。
                     例如，如果您需要以放置在應用程式資源中的 FreeMarker 範本回應，
                     請安裝並配置 <code>FreeMarker</code> 外掛程式，然後使用 <code>call.respond</code> 傳送範本：
                 </p>
-                <code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
-                <p>
+<code-block lang="kotlin" code="fun Application.module() {&#10;    install(FreeMarker) {&#10;        templateLoader = ClassTemplateLoader(this::class.java.classLoader, &quot;views&quot;)&#10;    }&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            val article = Article(&quot;Hey&quot;, &quot;Hello there!&quot;)&#10;            call.respond(FreeMarkerContent(&quot;index.ftl&quot;, mapOf(&quot;article&quot; to article)))&#10;        }&#10;    }&#10;}&#10;&#10;data class Article(val title: String, val message: String)"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/6_templates/src/main/kotlin/com/example/Application.kt">6_templates</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="接收請求" id="receive-request">
     <p>
@@ -690,49 +638,45 @@
             讓我們來看看如何在伺服器端將此請求的主體作為純文字接收。
         </p>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中剖析傳入的請求主體，您需要加入 <code>body-parser</code>：
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')"/>
+<p>
                         在 <code>post</code> 處理常式中，
                         您需要傳遞文字剖析器 (<code>bodyParser.text</code>)。
                         請求主體將可透過 <code>req.body</code> 屬性取得：
                     </p>
-                    <code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="app.post('/text', bodyParser.text(), (req, res) =&gt; {&#10;    let text = req.body&#10;    res.send(text)&#10;})"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，您可以使用 <code>call.receiveText</code> 將主體作為文字接收：
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/text&quot;) {&#10;            val text = call.receiveText()&#10;            call.respondText(text)&#10;        }"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="JSON" id="receive-json">
         <p>
@@ -741,51 +685,47 @@
         </p>
         <code-block lang="http" code="POST http://0.0.0.0:3000/json&#10;Content-Type: application/json&#10;&#10;{&#10;  &quot;type&quot;: &quot;Fiat&quot;,&#10;  &quot;model&quot; : &quot;500&quot;,&#10;  &quot;color&quot;: &quot;white&quot;&#10;}"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中接收 JSON，請使用 <code>bodyParser.json</code>：
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/json', bodyParser.json(), (req, res) =&gt; {&#10;    let car = req.body&#10;    res.send(car)&#10;})"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，您需要安裝 <Links href="//server-serialization" summary="ContentNegotiation 外掛程式有兩個主要目的：在用戶端與伺服器之間協商媒體類型，以及以特定格式對內容進行序列化／還原序列化。">ContentNegotiation</Links> 外掛程式並配置 <code>Json</code> 序列化器：
                     </p>
-                    <code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
-                    <p>
+<code-block lang="kotlin" code="    install(ContentNegotiation) {&#10;        json(Json {&#10;            prettyPrint = true&#10;            isLenient = true&#10;        })&#10;    }"/>
+<p>
                         要將接收到的資料還原序列化為物件，您需要建立一個資料類別：
                     </p>
-                    <code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
-                    <p>
+<code-block lang="kotlin" code="@Serializable&#10;data class Car(val type: String, val model: String, val color: String)"/>
+<p>
                         然後，使用接受此資料類別作為參數的 <code>receive</code> 方法：
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/json&quot;) {&#10;            val car = call.receive&lt;Car&gt;()&#10;            call.respond(car)&#10;        }"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="URL 編碼" id="receive-url-encoded">
         <p>
@@ -794,44 +734,40 @@
         </p>
         <code-block lang="http" code="POST http://localhost:3000/urlencoded&#10;Content-Type: application/x-www-form-urlencoded&#10;&#10;username=JetBrains&amp;email=example@jetbrains.com&amp;password=foobar&amp;confirmation=foobar"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         與純文字和 JSON 同樣，Express 需要 <code>body-parser</code>。
                         您需要將剖析器型別設定為 <code>bodyParser.urlencoded</code>：
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;&#10;app.post('/urlencoded', bodyParser.urlencoded({extended: true}), (req, res) =&gt; {&#10;    let user = req.body&#10;    res.send(`The ${user[&quot;username&quot;]} account is created`)&#10;})"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，使用 <code>call.receiveParameters</code> 函式：
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/urlencoded&quot;) {&#10;            val formParameters = call.receiveParameters()&#10;            val username = formParameters[&quot;username&quot;].toString()&#10;            call.respondText(&quot;The '$username' account is created&quot;)&#10;        }"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-    </table>
+</table>
     </chapter>
     <chapter title="原始資料" id="receive-raw-data">
         <p>
@@ -840,45 +776,41 @@
         </p>
         <code-block lang="http" code="POST http://localhost:3000/raw&#10;Content-Type: application/octet-stream&#10;&#10;&lt; ./ktor_logo.png"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         要在 Express 中處理二進位資料，請將剖析器型別設定為 <code>raw</code>：
                     </p>
-                    <code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const bodyParser = require('body-parser')&#10;const fs = require('fs')&#10;&#10;app.post('/raw', bodyParser.raw({type: () =&gt; true}), (req, res) =&gt; {&#10;    let rawBody = req.body&#10;    fs.createWriteStream('./uploads/ktor_logo.png').write(rawBody)&#10;    res.send('A file is uploaded')&#10;})"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         Ktor 提供 <code>ByteReadChannel</code> 與 <code>ByteWriteChannel</code>
                         用於非同步讀取／寫入位元組序列：
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/raw&quot;) {&#10;            val file = File(&quot;uploads/ktor_logo.png&quot;)&#10;            call.receiveChannel().copyAndClose(file.writeChannel())&#10;            call.respondText(&quot;A file is uploaded&quot;)&#10;        }"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive
                             request</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
     <chapter title="多部分 (Multipart)" id="receive-multipart">
         <p>
@@ -887,46 +819,42 @@
         </p>
         <code-block lang="http" code="POST http://localhost:3000/multipart&#10;Content-Type: multipart/form-data; boundary=WebAppBoundary&#10;&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;description&quot;&#10;Content-Type: text/plain&#10;&#10;Ktor logo&#10;--WebAppBoundary&#10;Content-Disposition: form-data; name=&quot;image&quot;; filename=&quot;ktor_logo.png&quot;&#10;Content-Type: image/png&#10;&#10;&lt; ./ktor_logo.png&#10;--WebAppBoundary--"/>
         <table style="header-column">
-            
 <tr>
 <td>
-                    <control>Express</control>
-                </td>
-                <td>
-                    <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                         Express 需要個別的模組來剖析多部分資料。
                         在下方的範例中，使用了 <control>multer</control> 將檔案上傳至伺服器：
                     </p>
-                    <code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
-                    <p>
+<code-block lang="javascript" code="const multer = require('multer')&#10;&#10;const storage = multer.diskStorage({&#10;    destination: './uploads/',&#10;    filename: function (req, file, cb) {&#10;        cb(null, file.originalname);&#10;    }&#10;})&#10;const upload = multer({storage: storage});&#10;app.post('/multipart', upload.single('image'), function (req, res, next) {&#10;    let fileDescription = req.body[&quot;description&quot;]&#10;    let fileName = req.file.filename&#10;    res.send(`${fileDescription} is uploaded to uploads/${fileName}`)&#10;})"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/7_receive_request/app.js">7_receive_request</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-            
 <tr>
 <td>
-                    <control>Ktor</control>
-                </td>
-                <td>
-                    <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                         在 Ktor 中，如果您需要接收作為多部分請求的一部分傳送的檔案，
                         請呼叫 <code>receiveMultipart</code> 函式，然後視需要對每個部分進行迴圈處理。
                         在下方的範例中，使用 <code>PartData.FileItem</code> 將檔案作為位元組串流接收：
                     </p>
-                    <code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
-                    <p>
+<code-block lang="kotlin" code="        post(&quot;/multipart&quot;) {&#10;            var fileDescription = &quot;&quot;&#10;            var fileName = &quot;&quot;&#10;            val multipartData = call.receiveMultipart()&#10;            multipartData.forEachPart { part -&gt;&#10;                when (part) {&#10;                    is PartData.FormItem -&gt; {&#10;                        fileDescription = part.value&#10;                    }&#10;&#10;                    is PartData.FileItem -&gt; {&#10;                        fileName = part.originalFileName as String&#10;                        val channel = part.provider()&#10;                        SystemFileSystem.sink(Path(&quot;uploads/$fileName&quot;)).use { sink -&gt;&#10;                            while (!channel.exhausted()) {&#10;                                channel.readBuffer().transferTo(sink)&#10;                                sink.flush()&#10;                            }&#10;                        }&#10;                    }&#10;&#10;                    else -&gt; {}&#10;                }&#10;                part.dispose()&#10;            }&#10;            call.respondText(&quot;$fileDescription is uploaded to 'uploads/$fileName'&quot;)&#10;        }"/>
+<p>
                         如需完整範例，請參閱
                         <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/7_receive_request/src/main/kotlin/com/example/Application.kt">7_receive_request</a>
                         專案。
                     </p>
-                </td>
+</td>
 </tr>
-
-        </table>
+</table>
     </chapter>
 </chapter>
 <chapter title="建立中介軟體" id="middleware">
@@ -935,44 +863,40 @@
         下方的範例展示如何使用 Express 與 Ktor 實作請求記錄。
     </p>
     <table style="header-column">
-        
 <tr>
 <td>
-                <control>Express</control>
-            </td>
-            <td>
-                <p>
+<control>Express</control>
+</td>
+<td>
+<p>
                     在 Express 中，中介軟體是使用 <code>app.use</code> 綁定到應用程式的函式：
                 </p>
-                <code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
-                <p>
+<code-block lang="javascript" code="const express = require('express')&#10;const app = express()&#10;const port = 3000&#10;&#10;const requestLogging = function (req, res, next) {&#10;    let scheme = req.protocol&#10;    let host = req.headers.host&#10;    let url = req.url&#10;    console.log(`Request URL: ${scheme}://${host}${url}`)&#10;    next()&#10;}&#10;&#10;app.use(requestLogging)"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express/8_middleware/app.js">8_middleware</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-        
 <tr>
 <td>
-                <control>Ktor</control>
-            </td>
-            <td>
-                <p>
+<control>Ktor</control>
+</td>
+<td>
+<p>
                     Ktor 允許您使用 <Links href="//server-custom-plugins" summary="了解如何建立您自己的自訂外掛程式。">自訂外掛程式</Links> 來擴充其功能。
                     下方的程式碼範例展示如何處理 <code>onCall</code> 以實作請求記錄：
                 </p>
-                <code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
-                <p>
+<code-block lang="kotlin" code="val RequestLoggingPlugin = createApplicationPlugin(name = &quot;RequestLoggingPlugin&quot;) {&#10;    onCall { call -&gt;&#10;        call.request.origin.apply {&#10;            println(&quot;Request URL: $scheme://$localHost:$localPort$uri&quot;)&#10;        }&#10;    }&#10;}"/>
+<p>
                     如需完整範例，請參閱
                     <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/migrating-express-ktor/8_middleware/src/main/kotlin/com/example/Application.kt">8_middleware</a>
                     專案。
                 </p>
-            </td>
+</td>
 </tr>
-
-    </table>
+</table>
 </chapter>
 <chapter title="下一步" id="next">
     <p>

--- a/docs/zh-Hant/ktor/server-auto-reload.md
+++ b/docs/zh-Hant/ktor/server-auto-reload.md
@@ -37,42 +37,32 @@
     <chapter title="限制" id="limitations">
         自動重新載入僅適用於特定的模組宣告。下表顯示了不同版本的支援情況：
         <table>
-            
 <tr>
 <td>模組類型</td>
-                <td>&lt;= 3.2</td>
-                <td>&gt; 3.2</td>
+<td>&lt;= 3.2</td>
+<td>&gt; 3.2</td>
 </tr>
-
-            
 <tr>
 <td>Lambda 初始設定式</td>
-                <td>❌ 不支援</td>
-                <td>❌ 不支援</td>
+<td>❌ 不支援</td>
+<td>❌ 不支援</td>
 </tr>
-
-            
 <tr>
 <td>阻塞函式參考 (Blocking function reference)</td>
-                <td>✅ 已支援</td>
-                <td>❌ 不支援</td>
+<td>✅ 已支援</td>
+<td>❌ 不支援</td>
 </tr>
-
-            
 <tr>
 <td>掛起函式參考 (Suspend function reference)</td>
-                <td>❌ 不支援</td>
-                <td>✅ 已支援</td>
+<td>❌ 不支援</td>
+<td>✅ 已支援</td>
 </tr>
-
-            
 <tr>
 <td>組態參考 (Config reference)</td>
-                <td>✅ 已支援</td>
-                <td>✅ 已支援</td>
+<td>✅ 已支援</td>
+<td>✅ 已支援</td>
 </tr>
-
-        </table>
+</table>
         <chapter title="已支援" id="supported">
             <code-block lang="kotlin" code="                // 掛起函式參考&#10;                embeddedServer(Netty, port = 8080, module = Application::mySuspendModule)&#10;&#10;                // 組態參考&#10;                ktor {&#10;                    application {&#10;                        modules = [ com.example.ApplicationKt.mySuspendModule ]&#10;                    }&#10;                }"/>
         </chapter>

--- a/docs/zh-Hant/ktor/server-auto-reload.md
+++ b/docs/zh-Hant/ktor/server-auto-reload.md
@@ -1,0 +1,194 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="自動重新載入 (Auto-reload)"
+       id="server-auto-reload" help-id="Auto_reload">
+    <tldr>
+        <p>
+            <b>程式碼範例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>,
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-embedded-server">autoreload-embedded-server</a>
+        </p>
+    </tldr>
+    <link-summary>
+        了解如何使用自動重新載入功能，在程式碼變更時重新載入應用程式類別。
+    </link-summary>
+    <p>
+        在開發過程中 <Links href="//server-run" summary="了解如何執行伺服器端 Ktor 應用程式。">重新啟動</Links> 伺服器可能會耗費不少時間。
+        Ktor 允許您透過使用 <emphasis>自動重新載入 (Auto-reload)</emphasis> 來克服此限制，它會在程式碼變更時重新載入應用程式類別，並提供快速的回饋循環。
+        要使用自動重新載入，請遵循以下步驟：
+    </p>
+    <list style="decimal">
+        <li>
+            <p>
+                <a href="#enable">啟用開發模式</a>
+            </p>
+        </li>
+        <li>
+            <p>
+                （選用） <a href="#watch-paths">配置監控路徑</a>
+            </p>
+        </li>
+        <li>
+            <p>
+                <a href="#recompile">在變更時啟用重新編譯</a>
+            </p>
+        </li>
+    </list>
+    <chapter title="限制" id="limitations">
+        自動重新載入僅適用於特定的模組宣告。下表顯示了不同版本的支援情況：
+        <table>
+            
+<tr>
+<td>模組類型</td>
+                <td>&lt;= 3.2</td>
+                <td>&gt; 3.2</td>
+</tr>
+
+            
+<tr>
+<td>Lambda 初始設定式</td>
+                <td>❌ 不支援</td>
+                <td>❌ 不支援</td>
+</tr>
+
+            
+<tr>
+<td>阻塞函式參考 (Blocking function reference)</td>
+                <td>✅ 已支援</td>
+                <td>❌ 不支援</td>
+</tr>
+
+            
+<tr>
+<td>掛起函式參考 (Suspend function reference)</td>
+                <td>❌ 不支援</td>
+                <td>✅ 已支援</td>
+</tr>
+
+            
+<tr>
+<td>組態參考 (Config reference)</td>
+                <td>✅ 已支援</td>
+                <td>✅ 已支援</td>
+</tr>
+
+        </table>
+        <chapter title="已支援" id="supported">
+            <code-block lang="kotlin" code="                // 掛起函式參考&#10;                embeddedServer(Netty, port = 8080, module = Application::mySuspendModule)&#10;&#10;                // 組態參考&#10;                ktor {&#10;                    application {&#10;                        modules = [ com.example.ApplicationKt.mySuspendModule ]&#10;                    }&#10;                }"/>
+        </chapter>
+        <chapter title="不支援" id="not-supported">
+            <code-block lang="kotlin" code="                // Lambda&#10;                embeddedServer(Netty, port = 8080) { configureServer() }&#10;&#10;                // 阻塞函式參考&#10;                embeddedServer(Netty, port = 8080, module = Application::myBlockingModule)"/>
+        </chapter>
+    </chapter>
+    <chapter title="啟用開發模式" id="enable">
+        <p>
+            要使用自動重新載入，您需要先啟用
+            <a href="#enable">開發模式</a>。
+            這取決於您 <Links href="//server-create-and-configure" summary="了解如何根據您的應用程式部署需求建立伺服器。">建立並執行伺服器</Links> 的方式：
+        </p>
+        <list>
+            <li>
+                <p>
+                    如果您使用 <code>EngineMain</code> 來執行伺服器，請在 <a href="#application-conf">組態檔</a> 中啟用開發模式。
+                </p>
+            </li>
+            <li>
+                <p>
+                    如果您使用 <code>embeddedServer</code> 執行伺服器，可以使用
+                    <a href="#system-property"><code>io.ktor.development</code></a>
+                    系統屬性。
+                </p>
+            </li>
+        </list>
+        <p>
+            啟用開發模式後，Ktor 將會自動監控工作目錄中的輸出檔案。
+            如有需要，您可以透過指定 <a href="#watch-paths">監控路徑</a> 來縮小監控資料夾的範圍。
+        </p>
+    </chapter>
+    <chapter title="配置監控路徑" id="watch-paths">
+        <p>
+            當您 <a href="#enable">啟用</a> 開發模式時，
+            Ktor 會開始監控工作目錄中的輸出檔案。
+            例如，對於使用 Gradle 組建的 <Path>ktor-sample</Path> 專案，將會監控以下資料夾：
+        </p>
+        <code-block code="            ktor-sample/build/classes/kotlin/main/META-INF&#10;            ktor-sample/build/classes/kotlin/main/com/example&#10;            ktor-sample/build/classes/kotlin/main/com&#10;            ktor-sample/build/classes/kotlin/main&#10;            ktor-sample/build/resources/main"/>
+        <p>
+            監控路徑允許您縮小監控資料夾的範圍。
+            為此，您可以指定監控路徑的一部分。
+            例如，要監控 <Path>ktor-sample/build/classes</Path> 子資料夾中的變更，
+            請將 <code>classes</code> 作為監控路徑傳遞。
+            根據您執行伺服器的方式，您可以透過以下方式指定監控路徑：
+        </p>
+        <list>
+            <li>
+                <p>
+                    在 <Path>application.conf</Path> 或 <Path>application.yaml</Path> 檔案中，指定 <code>watch</code> 選項：
+                </p>
+                <Tabs group="config">
+                    <TabItem title="application.conf" group-key="hocon">
+                        <code-block code="ktor {&#10;    development = true&#10;    deployment {&#10;        watch = [ classes ]&#10;    }&#10;}"/>
+                    </TabItem>
+                    <TabItem title="application.yaml" group-key="yaml">
+                        <code-block lang="yaml" code="ktor:&#10;    development: true&#10;    deployment:&#10;        watch:&#10;            - classes"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    您也可以指定多個監控路徑，例如：
+                </p>
+                <Tabs group="config">
+                    <TabItem title="application.conf" group-key="hocon">
+                        <code-block code="                            watch = [ classes, resources ]"/>
+                    </TabItem>
+                    <TabItem title="application.yaml" group-key="yaml">
+                        <code-block lang="yaml" code="                            watch:&#10;                                - classes&#10;                                - resources"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    您可以在此處找到完整的範例： <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-engine-main">autoreload-engine-main</a>。
+                </p>
+            </li>
+            <li>
+                <p>
+                    如果您使用的是 <code>embeddedServer</code>，請將監控路徑作為 <code>watchPaths</code> 參數傳遞：
+                </p>
+                <code-block lang="Kotlin" code="fun main() {&#10;    embeddedServer(Netty, port = 8080, watchPaths = listOf(&quot;classes&quot;), host = &quot;0.0.0.0&quot;, module = Application::module)&#10;        .start(wait = true)&#10;}&#10;&#10;fun Application.module() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, world!&quot;)&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    完整範例請參閱
+                    <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/autoreload-embedded-server">
+                        autoreload-embedded-server
+                    </a>
+                    。
+                </p>
+            </li>
+        </list>
+    </chapter>
+    <chapter title="在變更時重新編譯" id="recompile">
+        <p>
+            由於自動重新載入會偵測輸出檔案的變更，
+            因此您需要重新組建專案。
+            您可以在 IntelliJ IDEA 中手動執行此操作，或者
+            使用 <code>-t</code> 命令列選項在 Gradle 中啟用持續建置執行。
+        </p>
+        <list>
+            <li>
+                <p>
+                    要在 IntelliJ IDEA 中手動重新組建專案，從主選單中選擇
+                    <ui-path>Build | Rebuild Project</ui-path>。
+                </p>
+            </li>
+            <li>
+                <p>
+                    要使用 Gradle 自動重新組建專案，
+                    您可以在終端中執行帶有 <code>-t</code> 選項的 <code>build</code> 任務：
+                </p>
+                <code-block lang="Bash" code="                    ./gradlew -t build"/>
+                <tip>
+                    <p>
+                        要在重新載入專案時跳過執行測試，可以將 <code>-x</code> 選項傳遞給 <code>build</code> 任務：
+                    </p>
+                    <code-block lang="Bash" code="                        ./gradlew -t build -x test -i"/>
+                </tip>
+            </li>
+        </list>
+    </chapter>
+</topic>

--- a/docs/zh-Hant/ktor/server-configuration-code.md
+++ b/docs/zh-Hant/ktor/server-configuration-code.md
@@ -1,0 +1,166 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="程式碼中的配置"
+       id="server-configuration-code" help-id="Configuration-code;server-configuration-in-code">
+<show-structure for="chapter"/>
+<link-summary>
+    了解如何在程式碼中配置各種伺服器參數。
+</link-summary>
+<p>
+    Ktor 允許您直接在程式碼中配置各種伺服器參數，包括主機位址、port、<Links href="//server-modules" summary="模組允許您透過分組路由來建構應用程式。">伺服器模組</Links>等等。配置方式取決於您設定伺服器的方式 —— 使用 <Links href="//server-create-and-configure" summary="了解如何根據您的應用程式部署需求建立伺服器。">embeddedServer 或 EngineMain</Links>。
+</p>
+<p>
+    使用 <code>embeddedServer</code> 時，您可以透過將所需的參數直接傳遞給該函式來配置伺服器。
+    <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/embedded-server.html">
+        embeddedServer
+    </a>
+    函式接受用於配置伺服器的不同參數，包括 <Links href="//server-engines" summary="了解處理網路請求的引擎。">伺服器引擎</Links>、伺服器監聽的主機與 port，以及其他配置。
+</p>
+<p>
+    在本節中，我們將查看幾個執行 <code>embeddedServer</code> 的不同範例，說明如何配置伺服器以發揮其優勢。
+</p>
+<chapter title="基本配置" id="embedded-basic">
+    <p>
+        下方的程式碼片段顯示了使用 Netty 引擎與 <code>8080</code> port 的基本伺服器設定。
+    </p>
+    <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(Netty, port = 8080) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+    <p>
+        請注意，您可以將 <code>port</code> 參數設定為 <code>0</code> 以在隨機 port 上執行伺服器。
+        <code>embeddedServer</code> 函式會回傳一個引擎執行個體，因此您可以使用 
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/resolved-connectors.html">
+            ApplicationEngine.resolvedConnectors
+        </a>
+        函式在程式碼中獲取 port 值。
+    </p>
+</chapter>
+<chapter title="引擎配置" id="embedded-engine">
+    <snippet id="embedded-engine-configuration">
+        <p>
+            <code>embeddedServer</code> 函式允許您使用 <code>configure</code> 參數傳遞特定於引擎的選項。此參數包含所有引擎通用的選項，並由 
+            <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/index.html">
+                ApplicationEngine.Configuration
+            </a>
+            類別公開。
+        </p>
+        <p>
+            下方的範例顯示如何使用 <code>Netty</code> 引擎配置伺服器。在 <code>configure</code> 區塊內，我們定義了一個 <code>connector</code> 來指定主機與 port，並自訂各種伺服器參數：
+        </p>
+        <code-block lang="kotlin" code="import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(Netty, configure = {&#10;        connectors.add(EngineConnectorBuilder().apply {&#10;            host = &quot;127.0.0.1&quot;&#10;            port = 8080&#10;        })&#10;        connectionGroupSize = 2&#10;        workerGroupSize = 5&#10;        callGroupSize = 10&#10;        shutdownGracePeriod = 2000&#10;        shutdownTimeout = 3000&#10;    }) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+        <p>
+            <code>connectors.add()</code> 方法定義了一個具有指定主機 (<code>127.0.0.1</code>) 與 port (<code>8080</code>) 的連接器。
+        </p>
+        <p>除了這些選項之外，您還可以配置其他特定於引擎的屬性。</p>
+        <chapter title="Netty" id="netty-code">
+            <p>
+                特定於 Netty 的選項由 
+                <a href="https://api.ktor.io/ktor-server-netty/io.ktor.server.netty/-netty-application-engine/-configuration/index.html">
+                    NettyApplicationEngine.Configuration
+                </a>
+                類別公開。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.netty.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Netty, configure = {&#10;                            requestQueueLimit = 16&#10;                            shareWorkGroup = false&#10;                            configureBootstrap = {&#10;                                // ...&#10;                            }&#10;                            responseWriteTimeoutSeconds = 10&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="Jetty" id="jetty-code">
+            <p>
+                特定於 Jetty 的選項由 
+                <a href="https://api.ktor.io/ktor-server-jetty-jakarta/io.ktor.server.jetty.jakarta/-jetty-application-engine-base/-configuration/index.html">
+                    JettyApplicationEngineBase.Configuration
+                </a>
+                類別公開。
+            </p>
+            <p>您可以在 
+                <a href="https://api.ktor.io/ktor-server-jetty-jakarta/io.ktor.server.jetty.jakarta/-jetty-application-engine-base/-configuration/configure-server.html">
+                    configureServer
+                </a>
+                區塊內配置 Jetty 伺服器，該區塊提供了對 
+                <a href="https://www.eclipse.org/jetty/javadoc/jetty-11/org/eclipse/jetty/server/Server.html">Server</a>
+                執行個體的存取。
+            </p>
+            <p>
+                使用 <code>idleTimeout</code> 屬性指定連線在關閉前可以保持閒置的時間長度。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.jetty.jakarta.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Jetty, configure = {&#10;                            configureServer = { // this: Server -&amp;gt;&#10;                                // ...&#10;                            }&#10;                            idleTimeout = 30.seconds&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="CIO" id="cio-code">
+            <p>特定於 CIO 的選項由 
+                <a href="https://api.ktor.io/ktor-server-cio/io.ktor.server.cio/-c-i-o-application-engine/-configuration/index.html">
+                    CIOApplicationEngine.Configuration
+                </a>
+                類別公開。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.cio.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(CIO, configure = {&#10;                            connectionIdleTimeoutSeconds = 45&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+        <chapter title="Tomcat" id="tomcat-code">
+            <p>如果您使用 Tomcat 作為引擎，可以使用 
+                <a href="https://api.ktor.io/ktor-server-tomcat-jakarta/io.ktor.server.tomcat.jakarta/-tomcat-application-engine/-configuration/configure-tomcat.html">
+                    configureTomcat
+                </a>
+                屬性進行配置，該屬性提供了對 
+                <a href="https://tomcat.apache.org/tomcat-10.1-doc/api/org/apache/catalina/startup/Tomcat.html">Tomcat</a>
+                執行個體的存取。
+            </p>
+            <code-block lang="kotlin" code="                    import io.ktor.server.engine.*&#10;                    import io.ktor.server.tomcat.jakarta.*&#10;&#10;                    fun main() {&#10;                        embeddedServer(Tomcat, configure = {&#10;                            configureTomcat = { // this: Tomcat -&amp;gt;&#10;                                // ...&#10;                            }&#10;                        }) {&#10;                            // ...&#10;                        }.start(true)&#10;                    }"/>
+        </chapter>
+    </snippet>
+</chapter>
+<chapter title="自訂環境" id="embedded-custom">
+    <p>
+        下方的範例顯示如何使用 
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/index.html">
+            ApplicationEngine.Configuration
+        </a>
+        類別代表的自訂配置，執行具有多個連接器端點的伺服器。
+    </p>
+    <code-block lang="kotlin" code="import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main() {&#10;    val appProperties = serverConfig {&#10;        module { module() }&#10;    }&#10;    embeddedServer(Netty, appProperties) {&#10;        envConfig()&#10;    }.start(true)&#10;}&#10;&#10;fun ApplicationEngine.Configuration.envConfig() {&#10;    connector {&#10;        host = &quot;0.0.0.0&quot;&#10;        port = 8080&#10;    }&#10;    connector {&#10;        host = &quot;127.0.0.1&quot;&#10;        port = 9090&#10;    }&#10;}"/>
+    <p>
+        如需完整範例，請參閱 
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server-multiple-connectors">
+            embedded-server-multiple-connectors
+        </a>。
+    </p>
+    <tip>
+        <p>
+            您也可以使用自訂環境來 
+            <a href="#embedded-server">
+                提供 HTTPS 服務
+            </a>。
+        </p>
+    </tip>
+</chapter>
+<chapter id="command-line" title="命令列配置">
+    <p>
+        Ktor 允許您使用命令列引數動態地配置 <code>embeddedServer</code>。這在需要在執行階段指定 port、主機或逾時等配置的情況下特別有用。
+    </p>
+    <p>
+        為此，請使用 
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-command-line-config.html">
+            CommandLineConfig
+        </a>
+        類別將命令列引數解析為配置物件，並將其傳遞至配置區塊中：
+    </p>
+    <code-block lang="kotlin" code="fun main(args: Array&lt;String&gt;) {&#10;    embeddedServer(&#10;        factory = Netty,&#10;        configure = {&#10;            val cliConfig = CommandLineConfig(args)&#10;            takeFrom(cliConfig.engineConfig)&#10;            loadCommonConfiguration(cliConfig.rootConfig.environment.config)&#10;        }&#10;    ) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+    <p>
+        在此範例中，來自 <code>Application.Configuration</code> 的 
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/-application-engine/-configuration/take-from.html">
+            <code>takeFrom()</code>
+        </a>
+        函式用於覆蓋引擎配置值，例如 <code>port</code> 和 <code>host</code>。
+        <a href="https://api.ktor.io/ktor-server-core/io.ktor.server.engine/load-common-configuration.html">
+            <code>loadCommonConfiguration()</code>
+        </a>
+        函式則從根環境載入配置，例如逾時。
+    </p>
+    <p>
+        要執行伺服器，請按以下方式指定引數：
+    </p>
+    <code-block lang="shell" code="            ./gradlew run --args=&quot;-port=8080&quot;"/>
+    <tip>
+        對於靜態配置，您可以使用設定檔或環境變數。
+        若要了解更多，請參閱 
+        <a href="#command-line">
+            檔案中的配置
+        </a>
+        。
+    </tip>
+</chapter>
+</topic>

--- a/docs/zh-Hant/ktor/server-create-a-new-project.md
+++ b/docs/zh-Hant/ktor/server-create-a-new-project.md
@@ -1,0 +1,846 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="建立、開啟並執行新的 Ktor 專案"
+       id="server-create-a-new-project"
+       help-id="server_create_a_new_project">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <var name="example_name" value="tutorial-server-get-started"/>
+    <p>
+        <b>程式碼範例</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+</tldr>
+<link-summary>
+    了解如何使用 Ktor 開啟、執行和測試伺服器應用程式。
+</link-summary>
+<web-summary>
+    開始建置您的第一個 Ktor 伺服器應用程式。在本教學中，您將學習如何建立、開啟並執行新的 Ktor 專案。
+</web-summary>
+<p>
+    在本教學中，您將學習如何建立、開啟並執行您的第一個 Ktor 伺服器專案。一旦啟動並執行，您可以完成一系列任務來熟悉 Ktor。
+</p>
+<p>
+    這是引導您開始使用 Ktor 建置伺服器應用程式系列教學的第一部分。您可以獨立完成每個教學，但我們強烈建議您按照建議的順序進行：
+</p>
+<list type="decimal">
+    <li>建立、開啟並執行新的 Ktor 專案。</li>
+    <li><Links href="//server-requests-and-responses" summary="藉由建置任務管理器應用程式，學習使用 Ktor 在 Kotlin 中進行路由、處理請求和參數的基礎知識。">處理請求並產生回應</Links>。</li>
+    <li><Links href="//server-create-restful-apis" summary="學習如何使用 Kotlin 和 Ktor 建置後端服務，包含一個產生 JSON 檔案的 RESTful API 範例。">建立產生 JSON 的 RESTful API</Links>。</li>
+    <li><Links href="//server-create-website" summary="學習如何使用 Ktor 和 Thymeleaf 範本在 Kotlin 中建置網站。">使用 Thymeleaf 範本建立網站</Links>。</li>
+    <li><Links href="//server-create-websocket-application" summary="學習如何利用 WebSocket 的強大功能來發送和接收內容。">建立 WebSocket 應用程式</Links>。</li>
+    <li><Links href="//server-integrate-database" summary="學習使用 Exposed SQL 程式庫將 Ktor 服務連接到資料庫儲存庫的過程。">使用 Exposed 整合資料庫</Links>。</li>
+</list>
+<chapter id="create-project" title="建立新的 Ktor 專案">
+    <p>
+        建立新 Ktor 專案最快的方法之一是<a href="#create-project-with-the-ktor-project-generator">使用網頁版 Ktor 專案產生器</a>。
+    </p>
+    <p>
+        或者，您可以<a href="#create_project_with_intellij">使用 IntelliJ IDEA Ultimate 專用的 Ktor 外掛程式</a>或 <a href="#create_project_with_ktor_cli_tool">Ktor CLI 工具</a>來產生專案。
+    </p>
+    <chapter title="使用 Ktor 專案產生器"
+             id="create-project-with-the-ktor-project-generator">
+        <p>
+            若要使用 Ktor 專案產生器建立新專案，請按照以下步驟操作：
+        </p>
+        <procedure>
+            <step>
+                <p>導覽至 <a href="https://start.ktor.io/">Ktor 專案產生器</a>。</p>
+            </step>
+            <step>
+                <p>在
+                    <control>Project artifact</control>
+                    欄位中，輸入
+                    <Path>com.example.ktor-sample</Path>
+                    作為您的專案構件名稱。
+                    <img src="ktor_343_project_generator_new_project_artifact_name.png"
+                         alt="Ktor 專案產生器，專案構件名稱為 com.example.ktor-sample"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                </p>
+            </step>
+            <step id="configure-project-step">
+                <p>點擊
+                    <control>Configure</control>
+                    以開啟設定下拉式功能表：
+                    <img src="ktor_343_project_generator_new_project_configure.png"
+                         style="block"
+                         alt="Ktor 專案設定的展開檢視" border-effect="line" width="706"/>
+                </p>
+                <p>
+                    提供以下設定：
+                </p>
+                <list>
+                    <li>
+                        <p>
+                            <control>Build System</control>
+                            ：
+                            選擇所需的 <Links href="//server-dependencies" summary="學習如何將 Ktor 伺服器相依性新增至現有的 Gradle/Maven 專案。">建構系統</Links>。
+                            可以是
+                            <emphasis>Gradle Kotlin</emphasis>、
+                            <emphasis>Gradle Groovy</emphasis>、
+                            <emphasis>Maven</emphasis> 或 <emphasis>Amper</emphasis>。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Engine</control>
+                            ：
+                            選擇用於執行伺服器的<Links href="//server-engines" summary="了解處理網路請求的引擎。">引擎</Links>。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Configuration</control>
+                            ：
+                            選擇是要在 <Links href="//server-configuration-file" summary="學習如何在配置檔案中配置各種伺服器參數。">YAML 或 HOCON 檔案中</Links>，還是在 <Links href="//server-configuration-code" summary="學習如何在程式碼中配置各種伺服器參數。">程式碼中</Links>指定伺服器參數。
+                        </p>
+                        <warning>
+                            目前以 Maven 為基礎的 Ktor 專案不支援 YAML 配置。
+                        </warning>
+                    </li>
+                </list>
+                <p>對於本教學，您可以保留這些設定的預設值。</p>
+            </step>
+            <step>
+                <p>點擊
+                    <control>Done</control>
+                    以儲存配置並關閉功能表。
+                </p>
+            </step>
+            <step>
+                <p>在下方您會發現一組可以新增到專案中的 <Links href="//server-plugins" summary="外掛程式提供常見功能，例如序列化、內容編碼、壓縮等。">外掛程式</Links>。外掛程式是提供 Ktor 應用程式常見功能的建構區塊，例如身份驗證、序列化和內容編碼、壓縮、Cookie 支援等等。
+                </p>
+                <p>就本教學而言，您目前不需要新增任何外掛程式。</p>
+            </step>
+            <step>
+                <p>
+                    點擊
+                    <control>Download</control>
+                    按鈕以產生並下載您的 Ktor 專案。
+                    <img src="ktor_343_project_generator_new_project_download.png"
+                         alt="Ktor 專案產生器下載按鈕"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                </p>
+            </step>
+            <p>您的下載應該會自動開始。</p>
+        </procedure>
+        <p>既然您已經產生了新專案，請繼續<a href="#unpacking">解包並執行您的 Ktor 專案</a>。</p>
+    </chapter>
+    <chapter title="使用 IntelliJ IDEA Ultimate 的 Ktor 外掛程式" id="create_project_with_intellij"
+             collapsible="true">
+        <p>
+            本節說明如何使用 IntelliJ IDEA Ultimate 的 <a
+                href="https://plugins.jetbrains.com/plugin/16008-ktor">Ktor 外掛程式</a>進行專案設定。
+        </p>
+        <p>
+            若要建立新的 Ktor 專案，請<a href="https://www.jetbrains.com/help/idea/run-for-the-first-time.html">開啟 IntelliJ IDEA</a> 並按照以下步驟操作：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    在歡迎畫面，點擊 <control>New Project</control>。
+                </p>
+                <p>
+                    或者，從主功能表選擇 <ui-path>File | New | Project</ui-path>。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在
+                    <control>New Project</control>
+                    精靈中，從左側列表選擇
+                    <control>Ktor</control>。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在右側窗格中，您可以指定以下設定：
+                </p>
+                <img src="ktor_idea_new_project_settings.png" alt="Ktor 專案設定" width="706"
+                     border-effect="rounded"/>
+                <list>
+                    <li>
+                        <p>
+                            <control>Name</control>：指定專案名稱。輸入
+                            <Path>ktor-sample</Path>
+                            作為您的專案名稱。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Location</control>：指定您的專案目錄。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Website</control>
+                            ：
+                            指定用於產生套件名稱的網域。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Artifact</control>
+                            ：
+                            此欄位顯示產生的構件名稱。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Engine</control>
+                            ：
+                            選擇用於執行伺服器的<Links href="//server-engines" summary="了解處理網路請求的引擎。">引擎</Links>。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Include samples</control>
+                            ：
+                            保持啟用此選項以新增外掛程式的範例程式碼。
+                        </p>
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    點擊
+                    <control>Advanced Settings</control>
+                    以展開額外的設定功能表：
+                </p>
+                <img src="ktor_idea_new_project_advanced_settings.png" alt="Ktor 專案進階設定"
+                     width="706" border-effect="rounded"/>
+                <p>
+                    提供以下設定：
+                </p>
+                <list>
+                    <li>
+                        <p>
+                            <control>Build System</control>
+                            ：
+                            選擇所需的 <Links href="//server-dependencies" summary="學習如何將 Ktor 伺服器相依性新增至現有的 Gradle/Maven 專案。">建構系統</Links>。
+                            可以是
+                            <emphasis>Gradle Kotlin</emphasis>、
+                            <emphasis>Gradle Groovy</emphasis>、
+                            <emphasis>Maven</emphasis> 或 <emphasis>Amper</emphasis>。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Ktor version</control>
+                            ：
+                            選擇所需的 Ktor 版本。
+                        </p>
+                    </li>
+                    <li>
+                        <p>
+                            <control>Configuration</control>
+                            ：
+                            選擇是要在 <Links href="//server-configuration-file" summary="學習如何在配置檔案中配置各種伺服器參數。">YAML 或 HOCON 檔案中</Links>，還是在 <Links href="//server-configuration-code" summary="學習如何在程式碼中配置各種伺服器參數。">程式碼中</Links>指定伺服器參數。
+                        </p>
+                        <warning>
+                            目前以 Maven 為基礎的 Ktor 專案不支援 YAML 配置。
+                        </warning>
+                    </li>
+                </list>
+                <p>就本教學而言，您可以保留這些設定的預設值。</p>
+            </step>
+            <step>
+                <p>
+                    點擊
+                    <control>Next</control>
+                    以前往下一頁。
+                </p>
+                <img src="ktor_idea_new_project_plugins_list.png" alt="Ktor 外掛程式" width="706"
+                     border-effect="rounded"/>
+                <p>
+                    在此頁面上，您可以選擇一組 <Links href="//server-plugins" summary="外掛程式提供常見功能，例如序列化、內容編碼、壓縮等。">外掛程式</Links> — 這些是提供 Ktor 應用程式常見功能的建構區塊，例如身份驗證、序列化和內容編碼、壓縮、Cookie 支援等等。
+                </p>
+                <p>就本教學而言，您目前不需要新增任何外掛程式。</p>
+            </step>
+            <step>
+                <p>
+                    點擊
+                    <control>Create</control>
+                    並等待 IntelliJ IDEA 產生專案並安裝相依性。
+                </p>
+            </step>
+        </procedure>
+        <p>
+            既然您已建立了新專案，請繼續學習如何 <a href="#open-explore-run">開啟、探索並執行</a> 該應用程式。
+        </p>
+    </chapter>
+    <chapter title="使用 Ktor CLI 工具" id="create_project_with_ktor_cli_tool"
+             collapsible="true">
+        <p>
+            本節說明如何使用 <a href="https://github.com/ktorio/ktor-cli">Ktor CLI 工具</a>進行專案設定。
+        </p>
+        <p>
+            若要建立新的 Ktor 專案，請開啟您偏好的終端機並按照以下步驟操作：
+        </p>
+        <procedure>
+            <step>
+                使用以下指令之一安裝 Ktor CLI 工具：
+                <Tabs>
+                    <TabItem title="macOS/Linux" id="macos-linux">
+                        <code-block lang="console" code="                                brew install ktor"/>
+                    </TabItem>
+                    <TabItem title="Windows" id="windows">
+                        <code-block lang="console" code="                                winget install JetBrains.KtorCLI"/>
+                    </TabItem>
+                </Tabs>
+            </step>
+            <step>
+                若要在互動模式下產生新專案，請使用以下指令：
+                <code-block lang="console" code="                      ktor new"/>
+            </step>
+            <step>
+                輸入
+                <Path>ktor-sample</Path>
+                作為您的專案名稱：
+                <img src="server_create_cli_tool_name_dark.png"
+                     alt="在互動模式下使用 Ktor CLI 工具"
+                     border-effect="rounded"
+                     style="block"
+                     width="706"/>
+                <p>
+                    （選填）您也可以透過編輯專案名稱下方的
+                    <ui-path>Location</ui-path>
+                    路徑來更改專案儲存的位置。
+                </p>
+            </step>
+            <step>
+                按下
+                <shortcut>Enter</shortcut>
+                以繼續。
+            </step>
+            <step>
+                在下一個步驟中，您可以搜尋並將 <Links href="//server-plugins" summary="外掛程式提供常見功能，例如序列化、內容編碼、壓縮等。">外掛程式</Links> 新增到您的專案中。外掛程式是提供 Ktor 應用程式常見功能的建構區塊，例如身份驗證、序列化和內容編碼、壓縮、Cookie 支援等等。
+                <img src="server_create_cli_tool_add_plugins_dark.png"
+                     alt="使用 Ktor CLI 工具將外掛程式新增到專案中"
+                     border-effect="rounded"
+                     style="block"
+                     width="706"/>
+                <p>就本教學而言，您目前不需要新增任何外掛程式。</p>
+            </step>
+            <step>
+                按下
+                <shortcut>CTRL+G</shortcut>
+                以產生專案。
+                <p>
+                    或者，您可以透過選擇
+                    <control>CREATE PROJECT (CTRL+G)</control>
+                    並按下
+                    <shortcut>Enter</shortcut>
+                    來產生專案。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+</chapter>
+<chapter title="解包並執行您的 Ktor 專案" id="unpacking">
+    <p>
+        在本節中，您將學習如何從命令列解包、組建並執行專案。以下步驟假設：
+    </p>
+    <list type="bullet">
+        <li>您已建立並下載了一個名為
+            <Path>ktor-sample</Path>
+            的 Gradle 專案。
+        </li>
+        <li>此專案位於您家目錄中名為
+            <Path>myprojects</Path>
+            的資料夾內。
+        </li>
+    </list>
+    <p>如有必要，請修改名稱和路徑以符合您自己的設定。</p>
+    <p>開啟您偏好的命令列工具並按照以下步驟操作：</p>
+    <procedure>
+        <step>
+            <p>在終端機視窗中，導覽至您下載專案的資料夾：</p>
+            <code-block lang="console" code="                    cd ~/myprojects"/>
+        </step>
+        <step>
+            <p>將 ZIP 封存檔解包到同名的資料夾中：</p>
+            <Tabs>
+                <TabItem title="macOS" group-key="macOS">
+                    <code-block lang="console" code="                            unzip ktor-sample.zip -d ktor-sample"/>
+                </TabItem>
+                <TabItem title="Windows" group-key="windows">
+                    <code-block lang="console" code="                            tar -xf ktor-sample.zip"/>
+                </TabItem>
+            </Tabs>
+            <p>您的目錄現在將包含 ZIP 封存檔和解包後的資料夾。</p>
+        </step>
+        <step>
+            <p>從該目錄導覽進入新建立的資料夾：</p>
+            <code-block lang="console" code="                    cd ktor-sample"/>
+        </step>
+        <step>
+            <p>在 macOS 和 UNIX 系統上，您必須使 Gradle 輔助指令碼成為可執行檔，以便系統將其識別為可執行指令。為此，請使用 <code>chmod</code> 指令：</p>
+            <Tabs>
+                <TabItem title="macOS" group-key="macOS">
+                    <code-block lang="console" code="                            chmod +x ./gradlew"/>
+                </TabItem>
+            </Tabs>
+        </step>
+        <step>
+            <p>若要組建專案，請使用以下指令：</p>
+            <Tabs>
+                <TabItem title="macOS" group-key="macOS">
+                    <code-block lang="console" code="                            ./gradlew build"/>
+                </TabItem>
+                <TabItem title="Windows" group-key="windows">
+                    <code-block lang="console" code="                            gradlew build"/>
+                </TabItem>
+            </Tabs>
+            <p>當組建成功後，繼續下一個步驟以執行專案。</p>
+        </step>
+        <step>
+            <p>若要執行專案，請使用以下指令：</p>
+            <Tabs>
+                <TabItem title="macOS" group-key="macOS">
+                    <code-block lang="console" code="                            ./gradlew run"/>
+                </TabItem>
+                <TabItem title="Windows" group-key="windows">
+                    <code-block lang="console" code="                            gradlew run"/>
+                </TabItem>
+            </Tabs>
+        </step>
+        <step>
+            <p>若要驗證專案是否正在執行，請在瀏覽器中開啟終端機輸出中顯示的 URL (<a
+                    href="http://0.0.0.0:8080">http://0.0.0.0:8080</a>)。
+                您應該會在瀏覽器中看到顯示 "Hello World!" 訊息：</p>
+            <img src="server_get_started_ktor_sample_app_output.png" alt="產生的 Ktor 專案輸出"
+                 border-effect="line" width="706"/>
+        </step>
+    </procedure>
+    <p>恭喜！您已成功啟動您的 Ktor 專案。</p>
+    <note>
+        請注意，命令列沒有回應是因為底層處理程序正在忙於執行 Ktor 應用程式。您可以按下
+        <shortcut>CTRL+C</shortcut>
+        來終止應用程式。
+    </note>
+</chapter>
+<chapter title="在 IntelliJ IDEA 中開啟、探索並執行您的 Ktor 專案" id="open-explore-run">
+    <chapter title="開啟專案" id="open">
+        <p>如果您安裝了 <a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a>，您可以輕鬆地從命令列開啟專案。
+        </p>
+        <p>
+            確保您位於專案資料夾中，然後輸入 <code>idea</code> 指令，後跟一個句點來代表當前資料夾：
+        </p>
+        <code-block lang="Bash" code="                idea ."/>
+        <p>
+            或者，若要手動開啟專案，請啟動 IntelliJ IDEA。
+        </p>
+        <p>
+            如果開啟了歡迎畫面，點擊
+            <control>Open</control>。否則，前往主功能表中的
+            <ui-path>File | Open</ui-path>
+            並選擇
+            <Path>ktor-sample</Path>
+            資料夾以將其開啟。
+        </p>
+        <tip>
+            有關管理專案的更多詳細資訊，請參閱 <a href="https://www.jetbrains.com/help/idea/creating-and-managing-projects.html">IntelliJ IDEA 文件</a>。
+        </tip>
+    </chapter>
+    <chapter title="探索專案" id="explore">
+        <p>開啟專案後，您可以看到以下結構：</p>
+        <img src="tutorial_server_get_started_idea_project_view.png" alt="IDE 中產生的 Ktor 專案檢視" width="706"/>
+        <p>
+            若要檢視完整的版面配置，請點擊每個資料夾旁邊的展開箭頭，在 <control>Project</control> 檢視中展開資料夾。
+        </p>
+        <p>
+            應用程式原始碼位於
+            <Path>src/main/kotlin</Path>
+            下。預設會建立兩個檔案，分別名為
+            <Path>Application.kt</Path>
+            和
+            <Path>Routing.kt</Path>
+        </p>
+        <img src="tutorial_server_get_started_idea_main_folder.png" alt="Ktor 專案 src 資料夾結構" width="400"/>
+        <p>專案名稱是在
+            <Path>settings.gradle.kts</Path>
+            檔案中配置的：
+        </p>
+        <code-block lang="kotlin" code="rootProject.name = &quot;ktor-sample&quot;"/>
+        <p>
+            配置檔案和其他類型的內容位於
+            <Path>src/main/resources</Path>
+            資料夾內。
+        </p>
+        <img src="tutorial_server_get_started_idea_resources_folder.png" alt="Ktor 專案 resources 資料夾結構"
+             width="400"/>
+    </chapter>
+    <chapter title="執行專案" id="run">
+        <procedure>
+            <p>若要在 IntelliJ IDEA 內執行專案：</p>
+            <step>
+                <p>點擊右側提欄上的 Gradle 圖示 (<img alt="IntelliJ IDEA Gradle 圖示"
+                                                      src="intellij_idea_gradle_icon.svg" width="16" height="26"/>)
+                    以開啟 <a href="https://www.jetbrains.com/help/idea/jetgradle-tool-window.html">Gradle 工具視窗</a>。</p>
+            </step>
+            <step>
+                <p>在此工具視窗中，導覽至
+                    <ui-path>Tasks | application</ui-path>
+                    並按兩下
+                    <control>run</control>
+                    任務。
+                </p>
+                <img src="tutorial_server_get_started_idea_gradle_run.png" alt="IntelliJ IDEA 中的 Gradle 索引標籤"
+                     border-effect="line" width="450"/>
+            </step>
+            <step>
+                <p>您的 Ktor 應用程式會在 IDE 底部的 <a
+                        href="https://www.jetbrains.com/help/idea/run-tool-window.html">執行工具視窗</a>中啟動：</p>
+                <img src="tutorial_server_get_started_idea_run_terminal.png" alt="在終端機中執行的專案" width="706"/>
+                <p>先前在命令列上顯示的相同訊息現在將在
+                    <ui-path>Run</ui-path>
+                    工具視窗中可見。
+                </p>
+            </step>
+            <step>
+                <p>若要確認專案正在執行，請在指定的 URL
+                    (<a href="http://0.0.0.0:8080">http://0.0.0.0:8080</a>) 開啟瀏覽器。</p>
+                <p>您應該會再次在螢幕上看到顯示 "Hello World!" 訊息：</p>
+                <img src="server_get_started_ktor_sample_app_output.png" alt="瀏覽器畫面中的 Hello World"
+                     width="706"/>
+            </step>
+        </procedure>
+        <p>
+            您可以透過
+            <ui-path>Run</ui-path>
+            工具視窗管理應用程式。
+        </p>
+        <list type="bullet">
+            <li>
+                要終止應用程式，請點擊停止按鈕 <img src="intellij_idea_terminate_icon.svg"
+                                                                         style="inline" height="16" width="16"
+                                                                         alt="IntelliJ IDEA 終止圖示"/>。
+            </li>
+            <li>
+                要重新啟動程序，請點擊重新執行按鈕 <img src="intellij_idea_rerun_icon.svg"
+                                                                    style="inline" height="16" width="16"
+                                                                    alt="IntelliJ IDEA 重新執行圖示"/>。
+            </li>
+        </list>
+        <p>
+            這些選項在 <a href="https://www.jetbrains.com/help/idea/run-tool-window.html#run-toolbar">IntelliJ IDEA 執行工具視窗文件</a>中有進一步說明。
+        </p>
+    </chapter>
+</chapter>
+<chapter title="嘗試額外的任務" id="additional-tasks">
+    <p>以下是一些您可能希望嘗試的額外任務：</p>
+    <list type="decimal">
+        <li><a href="#change-the-default-port">更改預設連接埠</a></li>
+        <li><a href="#add-a-new-http-endpoint">新增 HTTP 端點</a></li>
+        <li><a href="#configure-static-content">配置靜態內容</a></li>
+        <li><a href="#write-an-integration-test">撰寫整合測試</a></li>
+        <li><a href="#register-error-handlers">註冊錯誤處理常式</a></li>
+    </list>
+    <p>
+        這些任務彼此獨立，但複雜度逐漸增加。按宣告的順序嘗試它們是循序漸進學習的最簡單方式。為了簡單起見並避免重複，下面的描述假設您正按順序嘗試任務。
+    </p>
+    <p>
+        在需要編寫程式碼的地方，我們同時指定了程式碼和對應的匯入。IDE 可能會自動為您新增這些匯入。
+    </p>
+    <chapter title="更改預設連接埠" id="change-the-default-port">
+        <chapter title="在配置檔案中更改連接埠" id="change-the-port-in-config">
+            <p>
+                如果您選擇將配置儲存在外部的 YAML 或 HOCON 檔案中，在
+                <ui-path>Project</ui-path>
+                檢視中導覽至
+                <Path>src/main/resources</Path>
+                資料夾並按照以下步驟操作：
+            </p>
+            <procedure id="change-default-port-yaml-procedure">
+                <step>
+                    開啟您的配置檔案 (
+                    <Path>application.yaml</Path>
+                    或
+                    <Path>application.conf</Path>
+                    )。它應該如下所示：
+                    <Tabs>
+                        <TabItem title="application.yaml (YAML)" group-key="yaml">
+                            <code-block lang="yaml" code="ktor:&#10;  deployment:&#10;    port: 8080&#10;  application:&#10;    modules:&#10;      - com.example.RoutingKt.configureRouting"/>
+                        </TabItem>
+                        <TabItem title="application.conf (HOCON)" group-key="hocon">
+                            <code-block lang="generic" code="ktor {&#10;  deployment {&#10;    port = 8080&#10;    port = ${?PORT}&#10;  }&#10;  application {&#10;    modules = [&#10;      com.example.RoutingKt.configureRouting&#10;    ]&#10;  }&#10;}"/>
+                        </TabItem>
+                    </Tabs>
+                </step>
+                <step>
+                    將檔案中的 <code>port</code> 值更改為您選擇的另一個數字，例如
+                    <code>9292</code>。
+                </step>
+                <step>
+                    <p>點擊重新執行按鈕 (<img alt="IntelliJ IDEA 重新執行按鈕圖示"
+                                                       src="intellij_idea_rerun_icon.svg" height="16" width="16"/>)
+                        以重新啟動應用程式。</p>
+                </step>
+                <step>
+                    <p>要驗證您的應用程式是否在新的連接埠號碼下執行，您可以在瀏覽器中開啟新的 URL (<a href="http://0.0.0.0:9292">http://0.0.0.0:9292</a>) 或
+                        <a href="https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html#creating-http-request-files">在 IntelliJ IDEA 中建立新的 HTTP 請求檔案</a>：</p>
+                    <img src="tutorial_server_get_started_port_change.png"
+                         alt="在 IntelliJ IDEA 中使用 HTTP 請求檔案測試連接埠更改" width="706"/>
+                </step>
+            </procedure>
+        </chapter>
+        <chapter title="在程式碼中更改連接埠" id="change-the-port-in-code">
+            <p>
+                <a href="#configure-project-step">建立新的 Ktor 專案時</a>，您可以選擇將配置儲存在程式碼中或外部的 YAML 或 HOCON 檔案中。
+            </p>
+            <p>
+                如果您選擇了將配置儲存在程式碼中的選項，在
+                <ui-path>Project</ui-path>
+                檢視中導覽至
+                <Path>src/main/kotlin</Path>
+                資料夾並按照以下步驟操作：
+            </p>
+            <procedure id="change-the-default-port-code-procedure">
+                <step>
+                    <p>開啟
+                        <Path>main.kt</Path>
+                        檔案。您應該會發現類似於以下的程式碼：
+                    </p>
+                    <code-block lang="kotlin" code="                            fun main(args: Array&lt;String&gt;) {&#10;                                embeddedServer(&#10;                                    factory = io.ktor.server.netty.Netty,&#10;                                    port = 8080,&#10;                                    host = &quot;0.0.0.0&quot;,&#10;                                    module = Application::rootModule&#10;                                ).start(wait = true)&#10;                            }"/>
+                </step>
+                <step>
+                    <p>在 <code>embeddedServer()</code> 函式中，將 <code>port</code> 參數更改為您選擇的另一個數字，例如 <code>9292</code>。</p>
+                    <code-block lang="kotlin" code="                            fun main(args: Array&lt;String&gt;) {&#10;                                embeddedServer(&#10;                                    factory = io.ktor.server.netty.Netty,&#10;                                    port = 9292,&#10;                                    host = &quot;0.0.0.0&quot;,&#10;                                    module = Application::rootModule&#10;                                ).start(wait = true)&#10;                            }"/>
+                </step>
+                <step>
+                    <p>點擊重新執行按鈕 (<img alt="IntelliJ IDEA 重新執行按鈕圖示"
+                                                       src="intellij_idea_rerun_icon.svg" height="16" width="16"/>)
+                        以重新啟動應用程式。</p>
+                </step>
+                <step>
+                    <p>要驗證您的應用程式是否在新的連接埠號碼下執行，您可以在瀏覽器中開啟新的 URL (<a href="http://0.0.0.0:9292">http://0.0.0.0:9292</a>)，或
+                        <a href="https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html#creating-http-request-files">在 IntelliJ IDEA 中建立新的 HTTP 請求檔案</a>：</p>
+                    <img src="tutorial_server_get_started_port_change.png"
+                         alt="在 IntelliJ IDEA 中使用 HTTP 請求檔案測試連接埠更改" width="706"/>
+                </step>
+            </procedure>
+        </chapter>
+    </chapter>
+    <chapter title="新增 HTTP 端點" id="add-a-new-http-endpoint">
+        <p>
+            在
+            <ui-path>Project</ui-path>
+            工具視窗中，導覽至
+            <Path>src/main/kotlin</Path>
+            資料夾並按照以下步驟操作：
+        </p>
+        <procedure>
+            <step>
+                <p>開啟
+                    <Path>Routing.kt</Path>
+                    檔案。這是您應該看到的程式碼：
+                </p>
+                <code-block lang="Kotlin" validate="true" code="                        fun Application.configureRouting() {&#10;                            routing {&#10;                                get(&quot;/&quot;) {&#10;                                    call.respondText(&quot;Hello World!&quot;)&#10;                                }&#10;                            }&#10;                        }"/>
+            </step>
+            <step>
+                <p>若要建立新端點，請插入如下所示的額外路由：</p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        // ...&#10;&#10;        get(&quot;/test1&quot;) {&#10;            val text = &quot;&lt;h1&gt;Hello From Ktor&lt;/h1&gt;&quot;&#10;            val type = ContentType.parse(&quot;text/html&quot;)&#10;            call.respondText(text, type)&#10;        }&#10;    }&#10;}"/>
+                <note>請注意，您可以將 <code>/test1</code> URL 更改為您喜歡的任何內容。</note>
+            </step>
+            <step>
+                <p>IDE 會自動為 <code>ContentType</code> 新增匯入：</p>
+                <code-block lang="kotlin" code="                        import io.ktor.http.ContentType"/>
+            </step>
+            <step>
+                <p>點擊重新執行按鈕 (<img alt="IntelliJ IDEA 重新執行按鈕圖示"
+                                                   src="intellij_idea_rerun_icon.svg" height="16" width="16"/>)
+                    以重新啟動應用程式。</p>
+            </step>
+            <step>
+                <p>在瀏覽器中請求新的 URL (<a href="http://0.0.0.0:9292/test1">http://0.0.0.0:9292/test1</a>)。連接埠號碼取決於您是否完成了<a href="#change-the-default-port">更改預設連接埠</a>任務。您應該看到如下所示的輸出：</p>
+                <img src="server_get_started_add_new_http_endpoint_output.png"
+                     alt="顯示 Hello from Ktor 的瀏覽器畫面" width="706"/>
+                <p>如果您建立了 HTTP 請求檔案，也可以在那裡驗證新端點：</p>
+                <code-block lang="http" code="                    GET http://0.0.0.0:9292&#10;&#10;                    ###&#10;&#10;                    GET http://0.0.0.0:9292/test1"/>
+                <note>請注意，需要包含三個井字號 (<code>###</code>) 的行來分隔不同的請求。</note>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="配置靜態內容" id="configure-static-content">
+        <p>在
+            <ui-path>Project</ui-path>
+            工具視窗中，導覽至
+            <Path>src/main/kotlin</Path>
+            資料夾並按照以下步驟操作：
+        </p>
+        <procedure>
+            <step>
+                <p>開啟 <Path>Routing.kt</Path> 檔案並將以下路由新增到路由區段：</p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        staticResources(&quot;/content&quot;, &quot;mycontent&quot;)&#10;        // ...&#10;    }&#10;}"/>
+                <p>這一行的含義如下：</p>
+                <list type="bullet">
+                    <li>調用 <code>staticResources()</code> 使您的應用程式能夠提供標準的網站內容，例如 HTML 和 JavaScript 檔案。儘管這些內容可以在瀏覽器中執行，但從伺服器的角度來看，它們被視為靜態的。
+                    </li>
+                    <li>URL <code>/content</code> 指定用於獲取此內容的路徑。
+                    </li>
+                    <li>路徑 <code>mycontent</code> 是靜態內容所在的資料夾名稱。Ktor 將在 <code>resources</code> 目錄中尋找此資料夾。
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>如果 IDE 沒有自動新增，請新增以下匯入。</p>
+                <code-block lang="kotlin" code="                        import io.ktor.server.http.content.staticResources"/>
+            </step>
+            <step>
+                <p>在
+                    <control>Project</control>
+                    工具視窗中，右鍵點擊 <Path>src/main/resources</Path> 資料夾並選擇
+                    <control>New | Directory</control>。
+                </p>
+                <p>或者，選擇 <Path>src/main/resources</Path> 資料夾，按下
+                    <shortcut>⌘Cmd+N</shortcut> (macOS) 或 <shortcut>Ctrl+N</shortcut> (Windows/Linux)
+                    並點擊
+                    <control>Directory</control>。
+                </p>
+            </step>
+            <step>
+                <p>將新目錄命名為 <code>mycontent</code> 並按下
+                    <shortcut>↩Enter</shortcut>。
+                </p>
+            </step>
+            <step>
+                <p>右鍵點擊新建立的資料夾並點擊
+                    <control>New | File</control>。
+                </p>
+            </step>
+            <step>
+                <p>將新檔案命名為 <Path>sample.html</Path> 並按下
+                    <shortcut>↩Enter</shortcut>。
+                </p>
+            </step>
+            <step>
+                <p>在新建的檔案頁面填入有效的 HTML，例如：</p>
+                <code-block lang="html" code="&lt;html lang=&quot;en&quot;&gt;&#10;    &lt;head&gt;&#10;        &lt;meta charset=&quot;UTF-8&quot; /&gt;&#10;        &lt;title&gt;My sample&lt;/title&gt;&#10;    &lt;/head&gt;&#10;    &lt;body&gt;&#10;        &lt;h1&gt;This page is built with:&lt;/h1&gt;&#10;        &lt;ol&gt;&#10;            &lt;li&gt;Ktor&lt;/li&gt;&#10;            &lt;li&gt;Kotlin&lt;/li&gt;&#10;            &lt;li&gt;HTML&lt;/li&gt;&#10;        &lt;/ol&gt;&#10;    &lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>點擊重新執行按鈕 (<img alt="IntelliJ IDEA 重新執行按鈕圖示"
+                                                   src="intellij_idea_rerun_icon.svg" height="16" width="16"/>)
+                    以重新啟動應用程式。</p>
+            </step>
+            <step>
+                <p>當您在瀏覽器開啟 <a href="http://0.0.0.0:9292/content/sample.html">http://0.0.0.0:9292/content/sample.html</a> 時，應該會顯示您範例頁面的內容：</p>
+                <img src="server_get_started_configure_static_content_output.png"
+                     alt="瀏覽器中靜態頁面的輸出" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="撰寫整合測試" id="write-an-integration-test">
+        <p>
+            Ktor 提供對<Links href="//server-testing" summary="了解如何使用特殊的測試引擎測試您的伺服器應用程式。">建立整合測試</Links>的支援，且您產生的專案已隨附此功能。
+        </p>
+        <p>若要使用此功能，請按照以下步驟操作：</p>
+        <procedure>
+            <step>
+                <p>
+                    導覽至
+                    <Path>src/test/kotlin</Path>
+                    資料夾。
+                </p>
+            </step>
+            <step>
+                <p>開啟 <Path>ServerTest.kt</Path> 檔案。您應該會看到如下程式碼：</p>
+                <code-block lang="kotlin" code="class ServerTest {&#10;&#10;    @Test&#10;    fun `test root endpoint`() = testApplication {&#10;        // loads default configuration&#10;        configure()&#10;        // verify server root returns 200&#10;        assertEquals(HttpStatusCode.OK, client.get(&quot;/&quot;).status)&#10;    }&#10;&#10;}"/>
+                <p><code>testApplication()</code> 函式會建立一個新的 Ktor 執行個體。此執行個體是在測試環境中執行的，而不是在 Netty 等伺服器上執行。</p>
+                <p>接著您可以使用 <code>configure()</code> 函式來調用與 <code>embeddedServer()</code> 中相同的設定。</p>
+                <p>最後，您可以使用內建的 <code>client</code> 物件和 JUnit 判斷提示來發送範例請求並檢查回應。</p>
+            </step>
+        </procedure>
+        <p>
+            您可以使用 IntelliJ IDEA 中執行測試的任何標準方式來執行該測試。請注意，由於您正在執行一個新的 Ktor 執行個體，測試的成功與否並不取決於您的應用程式是否正在 <code>0.0.0.0</code> 執行。
+        </p>
+        <p>
+            如果您已成功完成<a href="#add-a-new-http-endpoint">新增 HTTP 端點</a>，請新增此額外測試：
+        </p>
+        <code-block lang="kotlin" code="    @Test&#10;    fun `test new endpoint`() = testApplication {&#10;        configure()&#10;&#10;        val response = client.get(&quot;/test1&quot;)&#10;&#10;        assertEquals(HttpStatusCode.OK, response.status)&#10;        assertEquals(&quot;html&quot;, response.contentType()?.contentSubtype)&#10;        assertContains(response.bodyAsText(), &quot;Hello From Ktor&quot;)&#10;    }"/>
+        <p>新增以下額外匯入：</p>
+        <code-block lang="Kotlin" code="                import io.ktor.http.contentType&#10;                import io.ktor.client.statement.bodyAsText"/>
+    </chapter>
+    <chapter title="註冊錯誤處理常式" id="register-error-handlers">
+        <p>
+            您可以使用 <Links href="//server-status-pages" summary="StatusPages 讓 Ktor 應用程式能根據拋出的例外或狀態碼對任何失敗狀態做出適當回應。">StatusPages 外掛程式</Links>來處理 Ktor 應用程式中的錯誤。
+        </p>
+        <tip>
+            預設情況下，您的專案中不包含此外掛程式。在使用 Ktor 專案產生器建立專案時，您可以透過 <ui-path>Plugins</ui-path> 部分新增它，或者在 IntelliJ IDEA 中透過專案精靈新增。
+        </tip>
+        <p>
+            在接下來的步驟中，您將學習如何手動新增和配置此外掛程式。實現這一目標有四個步驟：
+        </p>
+        <list type="decimal">
+            <li><a href="#add-dependency">在 Gradle 建置檔案中新增相依性。</a></li>
+            <li><a href="#install-plugin-and-specify-handler">安裝外掛程式並指定例外處理常式。</a></li>
+            <li><a href="#write-sample-code">編寫範例程式碼以觸發處理常式。</a></li>
+            <li><a href="#restart-and-invoke">重新啟動並調用範例程式碼。</a></li>
+        </list>
+        <procedure title="新增相依性" id="add-dependency">
+            <p>在
+                <control>Project</control>
+                工具視窗中，導覽至專案根資料夾並按照以下步驟操作：
+            </p>
+            <step>
+                <p>開啟 <Path>build.gradle.kts</Path> 檔案並按如下所示新增相依性：</p>
+                <code-block lang="kotlin" code="dependencies {&#10;    implementation(ktorLibs.server.config.yaml)&#10;    implementation(ktorLibs.server.core)&#10;    implementation(ktorLibs.server.netty)&#10;    // Add new dependency&#10;    implementation(ktorLibs.server.statusPages)&#10;    implementation(libs.logback.classic)&#10;&#10;    testImplementation(kotlin(&quot;test&quot;))&#10;    testImplementation(ktorLibs.server.testHost)&#10;}"/>
+            </step>
+            <step>
+                <p>按下
+                    <shortcut>Shift+⌘Cmd+I</shortcut> (macOS) 或
+                    <shortcut>Ctrl+Shift+O</shortcut> (Windows/Linux) 來重新載入專案。
+                </p>
+            </step>
+        </procedure>
+        <procedure title="安裝外掛程式並指定例外處理常式"
+                   id="install-plugin-and-specify-handler">
+            <step>
+                <p>導覽至 <Path>Routing.kt</Path> 中的 <code>.configureRouting()</code> 方法，並新增以下程式碼行：</p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    install(StatusPages) {&#10;        exception&lt;IllegalStateException&gt; { call, cause -&gt;&#10;            call.respondText(&quot;App in illegal state as ${cause.message}&quot;)&#10;        }&#10;    }&#10;    routing {&#10;        // ...&#10;    }&#10;}"/>
+                <p>這些行安裝了 <code>StatusPages</code> 外掛程式，並指定了當拋出 <code>IllegalStateException</code> 類型的例外時要採取的動作。</p>
+            </step>
+            <step>
+                <p>新增以下匯入：</p>
+                <code-block lang="kotlin" code="                        import io.ktor.server.plugins.statuspages.StatusPages"/>
+            </step>
+        </procedure>
+        <p>
+            請注意，通常會在回應中設定 HTTP 錯誤碼，但出於此任務的目的，輸出會直接顯示在瀏覽器中。
+        </p>
+        <procedure title="編寫範例程式碼以觸發處理常式" id="write-sample-code">
+            <step>
+                <p>保留在 <code>.configureRouting()</code> 方法中，新增如下所示的額外路由：</p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    install(StatusPages) {&#10;        exception&lt;IllegalStateException&gt; { call, cause -&gt;&#10;            call.respondText(&quot;App in illegal state as ${cause.message}&quot;)&#10;        }&#10;    }&#10;    routing {&#10;        // ...&#10;&#10;        get(&quot;/error-test&quot;) {&#10;            throw IllegalStateException(&quot;Too Busy&quot;)&#10;        }&#10;    }&#10;}"/>
+                <p>您現在已經新增了一個 URL 為 <code>/error-test</code> 的端點。當觸發此端點時，將拋出一個在處理常式中使用的類型的例外。</p>
+            </step>
+        </procedure>
+        <procedure title="重新啟動並調用範例程式碼" id="restart-and-invoke">
+            <step>
+                <p>點擊重新執行按鈕 (<img alt="IntelliJ IDEA 重新執行按鈕圖示"
+                                                   src="intellij_idea_rerun_icon.svg" height="16" width="16"/>)
+                    以重新啟動應用程式。</p></step>
+            <step>
+                <p>在您的瀏覽器中，導覽至 URL <a href="http://0.0.0.0:9292/error-test">http://0.0.0.0:9292/error-test</a>。
+                    您應該會看到如下所示的錯誤訊息：</p>
+                <img src="server_get_started_register_error_handler_output.png"
+                     alt="顯示訊息 `App in illegal state as Too Busy` 的瀏覽器畫面" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+</chapter>
+<chapter title="後續步驟" id="next_steps">
+    <p>
+        如果您已經完成了這些額外任務，那麼您現在已經初步掌握了配置 Ktor 伺服器、整合 Ktor 外掛程式以及實作新路由的方法。然而，這僅僅是個開始。若要更深入地了解 Ktor 的核心概念，請繼續閱讀本指南中的下一個教學。
+    </p>
+    <p>
+        接下來，您將學習如何藉由建立一個 <Links href="//server-requests-and-responses" summary="藉由建置任務管理器應用程式，學習使用 Ktor 在 Kotlin 中進行路由、處理請求和參數的基礎知識。">任務管理器應用程式來處理請求並產生回應</Links>。
+    </p>
+</chapter>
+</topic>

--- a/docs/zh-Hant/ktor/server-create-and-configure.md
+++ b/docs/zh-Hant/ktor/server-create-and-configure.md
@@ -1,0 +1,136 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="建立伺服器"
+       id="server-create-and-configure" help-id="start_server;create_server">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <p>
+        <b>程式碼範例</b>：
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">embedded-server</a>、
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">engine-main</a>、
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-yaml">engine-main-yaml</a>
+    </p>
+</tldr>
+<link-summary>
+    了解如何根據您的應用程式部署需求建立伺服器。
+</link-summary>
+<p>
+    在建立 Ktor 應用程式之前，您需要考慮應用程式將如何
+    <Links href="//server-deployment" summary="">
+        部署
+    </Links>
+    ：
+</p>
+<list>
+    <li>
+        <p>
+            作為一個
+            <control><a href="#embedded">獨立的軟件包</a></control>
+        </p>
+        <p>
+            在這種情況下，用於處理網路請求的應用程式<Links href="//server-engines" summary="Learn about engines that process network requests.">引擎</Links>應作為應用程式的一部分。
+            您的應用程式可以控制引擎設定、連線和 SSL 選項。
+        </p>
+    </li>
+    <li>
+        <p>
+            作為一個
+            <control>
+                <a href="#servlet">servlet</a>
+            </control>
+        </p>
+        <p>
+            在這種情況下，Ktor 應用程式可以部署在 servlet 容器（例如 Tomcat 或 Jetty）中，
+            由容器控制應用程式的生命週期和連線設定。
+        </p>
+    </li>
+</list>
+<chapter title="獨立的軟件包" id="embedded">
+    <p>
+        若要將 Ktor 伺服器應用程式作為獨立的軟件包交付，您需要先建立一個伺服器。
+        伺服器配置可以包含不同的設定：
+        伺服器<Links href="//server-engines" summary="Learn about engines that process network requests.">引擎</Links>（例如 Netty、Jetty 等）、
+        各種引擎特定的選項、主機與連接埠值等等。
+        在 Ktor 中有兩種建立和執行伺服器的主要方法：
+    </p>
+    <list>
+        <li>
+            <p>
+                <code>embeddedServer</code> 函式是在
+                <a href="#embedded-server">
+                    程式碼中配置伺服器參數
+                </a>
+                並快速執行應用程式的簡單方法。
+            </p>
+        </li>
+        <li>
+            <p>
+                <code>EngineMain</code> 提供更靈活的伺服器配置方式。您可以
+                <a href="#engine-main">
+                    在檔案中指定伺服器參數
+                </a>
+                並在不重新編譯應用程式的情況下更改配置。此外，您可以從命令列執行應用程式，並透過傳遞對應的命令列引數來覆寫必要的伺服器參數。
+            </p>
+        </li>
+    </list>
+    <chapter title="程式碼中的配置" id="embedded-server">
+        <p>
+            <code>embeddedServer</code> 函式是在
+            <Links href="//server-configuration-code" summary="Learn how to configure various server parameters in code.">程式碼</Links>
+            中配置伺服器參數並快速執行應用程式的簡單方法。在下方的程式碼片段中，它接受一個
+            <Links href="//server-engines" summary="Learn about engines that process network requests.">引擎</Links>
+            和連接埠作為參數來啟動伺服器。在下面的範例中，我們使用
+            <code>Netty</code> 引擎執行伺服器，並監聽 <code>8080</code> 連接埠：
+        </p>
+        <code-block lang="kotlin" code="package com.example&#10;&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;import io.ktor.server.engine.*&#10;import io.ktor.server.netty.*&#10;&#10;fun main(args: Array&lt;String&gt;) {&#10;    if (args.isEmpty()) {&#10;        println(&quot;Running basic server...&quot;)&#10;        println(&quot;Provide the 'configured' argument to run a configured server.&quot;)&#10;        runBasicServer()&#10;    }&#10;&#10;    when (args[0]) {&#10;        &quot;basic&quot; -&gt; runBasicServer()&#10;        &quot;configured&quot; -&gt; runConfiguredServer()&#10;        else -&gt; runServerWithCommandLineConfig(args)&#10;    }&#10;}&#10;&#10;fun runBasicServer() {&#10;    embeddedServer(Netty, port = 8080) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}&#10;&#10;fun runConfiguredServer() {&#10;    embeddedServer(Netty, configure = {&#10;        connectors.add(EngineConnectorBuilder().apply {&#10;            host = &quot;127.0.0.1&quot;&#10;            port = 8080&#10;        })&#10;        connectionGroupSize = 2&#10;        workerGroupSize = 5&#10;        callGroupSize = 10&#10;        shutdownGracePeriod = 2000&#10;        shutdownTimeout = 3000&#10;    }) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}&#10;&#10;fun runServerWithCommandLineConfig(args: Array&lt;String&gt;) {&#10;    embeddedServer(&#10;        factory = Netty,&#10;        configure = {&#10;            val cliConfig = CommandLineConfig(args)&#10;            takeFrom(cliConfig.engineConfig)&#10;            loadCommonConfiguration(cliConfig.rootConfig.environment.config)&#10;        }&#10;    ) {&#10;        routing {&#10;            get(&quot;/&quot;) {&#10;                call.respondText(&quot;Hello, world!&quot;)&#10;            }&#10;        }&#10;    }.start(wait = true)&#10;}"/>
+        <p>
+            有關完整範例，請參閱
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/embedded-server">
+                embedded-server
+            </a>
+            。
+        </p>
+    </chapter>
+    <chapter title="檔案中的配置" id="engine-main">
+        <p>
+            <code>EngineMain</code> 使用選定的引擎啟動伺服器，並從外部<Links href="//server-configuration-file" summary="Learn how to configure various server parameters in a configuration file.">配置文件</Links>（<Path>application.conf</Path> 或 <Path>application.yaml</Path>，通常位於 <Path>resource</Path> 目錄中）載入<Links href="//server-modules" summary="Modules allow you to structure your application by grouping routes.">應用程式模組</Links>。
+        </p>
+        <p>
+            除了指定要載入的模組外，配置文件還可以包含各種伺服器參數，例如連接埠、主機和 SSL 設定。例如，下方的配置將伺服器連接埠設定為 <code>8080</code>。
+        </p>
+        <Tabs>
+            <TabItem title="Application.kt" id="application-kt">
+                <code-block lang="kotlin" code="package com.example&#10;&#10;import io.ktor.server.application.*&#10;import io.ktor.server.response.*&#10;import io.ktor.server.routing.*&#10;&#10;fun main(args: Array&lt;String&gt;): Unit = io.ktor.server.netty.EngineMain.main(args)&#10;&#10;fun Application.module() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, world!&quot;)&#10;        }&#10;    }&#10;}"/>
+            </TabItem>
+            <TabItem title="application.conf" id="application-conf">
+                <code-block code="ktor {&#10;    deployment {&#10;        port = 8080&#10;    }&#10;    application {&#10;        modules = [ com.example.ApplicationKt.module ]&#10;    }&#10;}"/>
+            </TabItem>
+            <TabItem title="application.yaml" id="application-yaml">
+                <code-block lang="yaml" code="ktor:&#10;    deployment:&#10;        port: 8080&#10;    application:&#10;        modules:&#10;            - com.example.ApplicationKt.module"/>
+            </TabItem>
+        </Tabs>
+        <note>
+            除了使用 <code>EngineMain.main()</code> 立即啟動伺服器，您還可以使用 <code>EngineMain.createServer()</code> 手動建立伺服器執行個體。如需更多資訊，請參閱 <a href="#createServer"></a>。
+        </note>
+        <p>
+            有關完整範例，請參閱
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main">
+                engine-main
+            </a>
+            和
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/engine-main-yaml">
+                engine-main-yaml
+            </a>
+            。
+        </p>
+    </chapter>
+</chapter>
+<chapter title="Servlet" id="servlet">
+    <p>
+        Ktor 應用程式可以在包含 Tomcat 和 Jetty 的 servlet 容器中執行和部署。
+        若要部署在 servlet 容器中，您需要產生一個
+        <Links href="//server-war" summary="Learn how to run and deploy a Ktor application inside a servlet container using a WAR archive.">WAR</Links>
+        封存檔，然後將其部署到支援 WAR 的伺服器或雲端服務。
+    </p>
+</chapter>
+</topic>

--- a/docs/zh-Hant/ktor/server-create-restful-apis.md
+++ b/docs/zh-Hant/ktor/server-create-restful-apis.md
@@ -1,0 +1,607 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="如何在 Kotlin 中使用 Ktor 建立 RESTful API" id="server-create-restful-apis"
+       help-id="create-restful-apis">
+<show-structure for="chapter" depth="2"/>
+<tldr>
+    <var name="example_name" value="tutorial-server-restful-api"/>
+    <p>
+        <b>程式碼範例</b>:
+        <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+            %example_name%
+        </a>
+    </p>
+    <p>
+        <b>使用的外掛程式</b>: <Links href="//server-routing" summary="Routing 是伺服器應用程式中處理傳入請求的核心外掛程式。">Routing</Links>,<Links href="//server-static-content" summary="了解如何提供靜態內容，例如樣式表、指令碼、圖片等。">Static Content</Links>,
+        <Links href="//server-serialization" summary="ContentNegotiation 外掛程式有兩個主要目的：協商用戶端與伺服器之間的媒體類型，以及將內容序列化/反序列化為特定格式。">Content Negotiation</Links>, <a
+            href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>
+    </p>
+</tldr>
+<card-summary>
+    了解如何使用 Ktor 建置 RESTful API。本教學透過一個實際範例涵蓋了設定、路由和測試。
+</card-summary>
+<web-summary>
+    學習如何使用 Ktor 建置 Kotlin RESTful API。本教學透過實際範例涵蓋了設定、路由和測試。這是 Kotlin 後端開發人員理想的入門級教學。
+</web-summary>
+<link-summary>
+    了解如何使用 Kotlin 和 Ktor 建置後端服務，並以一個會產生 JSON 檔案的 RESTful API 為例。
+</link-summary>
+<p>
+    在本教學中，我們將解釋如何使用 Kotlin 和 Ktor 建置後端服務，其中包含一個會產生 JSON 檔案的 RESTful API 範例。
+</p>
+<p>
+    在 <Links href="//server-requests-and-responses" summary="透過建置工作管理員應用程式，學習使用 Ktor 處理 Kotlin 路由、請求處理和參數的基礎知識。">前一個教學</Links> 中，我們向您介紹了驗證、錯誤處理和單元測試的基礎。本教學將透過建立一個用於管理任務的 RESTful 服務來擴充這些主題。
+</p>
+<p>
+    您將學習如何執行以下操作：
+</p>
+<list>
+    <li>建立使用 JSON 序列化的 RESTful 服務。</li>
+    <li>了解 <Links href="//server-serialization" summary="ContentNegotiation 外掛程式有兩個主要目的：協商用戶端與伺服器之間的媒體類型，以及將內容序列化/反序列化為特定格式。">Content Negotiation</Links> 的過程。</li>
+    <li>在 Ktor 中定義 REST API 的路由。</li>
+</list>
+<chapter title="先決條件" id="prerequisites">
+    <p>您可以獨立進行本教學，
+        但我們強烈建議您先完成之前的教學，以學習如何 <Links href="//server-requests-and-responses" summary="透過建置工作管理員應用程式，學習使用 Ktor 處理 Kotlin 路由、請求處理和參數的基礎知識。">處理請求並產生回應</Links>。
+    </p>
+    <p>我們建議您安裝 <a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA</a>，但您也可以使用其他您偏好的 IDE。
+    </p>
+</chapter>
+<chapter title="哈囉，RESTful 工作管理員" id="hello-restful-task-manager">
+    <p>在本教學中，您將把現有的工作管理員重寫為 RESTful 服務。為此，您將使用多個 Ktor <Links href="//server-plugins" summary="外掛程式提供常用功能，例如序列化、內容編碼、壓縮等。">外掛程式</Links>。</p>
+    <p>
+        雖然您可以手動將其新增到現有專案中，但產生一個新專案，然後逐步加入前一個教學的程式碼會更簡單。您將在過程中重新審視所有程式碼，因此不需要手邊備有前一個專案。
+    </p>
+    <procedure title="使用外掛程式建立新專案">
+        <step>
+            <p>
+                前往
+                <a href="https://start.ktor.io/">Ktor Project Generator</a>。
+            </p>
+        </step>
+        <step>
+            <p>在
+                <control>Project artifact</control>
+                欄位中，輸入
+                <Path>com.example.ktor-rest-task-app</Path>
+                作為您的專案構件名稱。
+                <img src="tutorial_creating_restful_apis_project_artifact.png"
+                     alt="在 Ktor Project Generator 中命名專案構件"
+                     style="block"
+                     border-effect="line"
+                     width="706"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                在外掛程式區段中，搜尋並點擊
+                <control>Add</control>
+                按鈕來新增以下外掛程式：
+            </p>
+            <list type="bullet">
+                <li>Content Negotiation</li>
+                <li>kotlinx.serialization</li>
+                <li>Static Content</li>
+            </list>
+            <p>
+                <img src="ktor_project_generator_add_plugins.gif" alt="在 Ktor Project Generator 中新增外掛程式"
+                     border-effect="line"
+                     style="block"
+                     width="706"/>
+                新增外掛程式後，您將看到專案設定下方列出的所有外掛程式。
+                <img src="tutorial_creating_restful_apis_plugins_list.png"
+                     alt="Ktor Project Generator 中的外掛程式清單"
+                     border-effect="line"
+                     style="block"
+                     width="706"/>
+            </p>
+        </step>
+        <step>
+            <p>
+                點擊
+                <control>Download</control>
+                按鈕來產生並下載您的 Ktor 專案。
+            </p>
+        </step>
+    </procedure>
+    <procedure title="新增初始程式碼" id="add-starter-code">
+        <step>
+            <p>在 IntelliJ IDEA 中開啟您的專案，如之前的 <a href="server-create-a-new-project.topic#open-explore-run">在 IntelliJ IDEA 中開啟、探索並執行您的 Ktor 專案</a> 教學所述。</p>
+        </step>
+        <step>
+            <p>
+                導覽至
+                <Path>src/main/kotlin</Path>
+                並建立一個名為
+                <Path>model</Path>
+                的子套件。
+            </p>
+        </step>
+        <step>
+            <p>
+                在
+                <Path>model</Path>
+                套件中，建立一個新的
+                <Path>Task.kt</Path>
+                檔案。
+            </p>
+        </step>
+        <step>
+            <p>
+                開啟
+                <Path>Task.kt</Path>
+                檔案並新增一個 <code>enum</code> 來表示優先級，以及一個 <code>class</code> 來表示任務：
+            </p>
+            <code-block lang="kotlin" code="package com.example.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+            <p>
+                在前一個教學中，您使用擴充函式將 <code>Task</code> 轉換為 HTML。而在這裡，
+                <code>Task</code> 類別標註了來自 
+                <code>kotlinx.serialization</code> 程式庫的 <a
+                    href="https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization/-serializable/"><code>Serializable</code></a> 型別。
+            </p>
+        </step>
+        <step>
+            <p>
+                開啟
+                <Path>Routing.kt</Path>
+                檔案，並將現有程式碼替換為下方的實作：
+            </p>
+            <code-block lang="kotlin" code="                    package com.example&#10;&#10;                    import com.example.model.*&#10;                    import io.ktor.server.application.*&#10;                    import io.ktor.server.http.content.*&#10;                    import io.ktor.server.response.*&#10;                    import io.ktor.server.routing.*&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            staticResources(&quot;static&quot;, &quot;static&quot;)&#10;&#10;                            get(&quot;/tasks&quot;) {&#10;                                call.respond(&#10;                                    listOf(&#10;                                        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                                        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                                        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                                        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;                                    )&#10;                                )&#10;                            }&#10;                        }&#10;                    }"/>
+            <p>
+                與之前的教學類似，您為指向 URL <code>/tasks</code> 的 GET 請求建立了一個路由。
+                這一次，您不再需要手動轉換任務清單，而是直接回傳該清單。
+            </p>
+        </step>
+        <step>
+            <p>在 IntelliJ IDEA 中，點擊執行按鈕
+                (<img src="intellij_idea_gutter_icon.svg"
+                      style="inline" height="16" width="16"
+                      alt="intelliJ IDEA 執行圖示"/>)
+                來啟動應用程式。</p>
+        </step>
+        <step>
+            <p>
+                在瀏覽器中導覽至 <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a>。您應該會看到任務清單的 JSON 版本，如下所示：
+            </p>
+        </step>
+        <img src="tutorial_creating_restful_apis_starter_code_preview.png"
+             alt="在瀏覽器畫面中顯示的 JSON 資料"
+             border-effect="rounded"
+             width="706"/>
+        <p>顯然，背後已經為我們完成了很多工作。究竟發生了什麼事？</p>
+    </procedure>
+</chapter>
+<chapter title="了解內容協商" id="content-negotiation">
+    <chapter title="透過瀏覽器進行內容協商" id="via-browser">
+        <p>
+            當您建立專案時，您包含了 <Links href="//server-serialization" summary="ContentNegotiation 外掛程式有兩個主要目的：協商用戶端與伺服器之間的媒體類型，以及將內容序列化/反序列化為特定格式。">Content Negotiation</Links>
+            外掛程式。此外掛程式會查看用戶端可以呈現的內容類型，並將其與當前服務可以提供的內容類型進行比對。因此，這個術語被稱為
+            <format style="italic">內容協商 (Content Negotiation)</format>。
+        </p>
+        <p>
+            在 HTTP 中，用戶端透過 <code>Accept</code> 標頭發出它可以呈現哪些內容類型的訊號。此標頭的值是一個或多個內容類型。在上述情況下，您可以透過使用瀏覽器內建的開發人員工具來檢查此標頭的值。
+        </p>
+        <p>
+            考慮以下範例：
+        </p>
+        <code-block code="                text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"/>
+        <p>請注意 <code>&#42;/&#42;</code> 的包含。此標頭發出它接受 HTML、XML 或圖片的訊號，但也接受任何其他內容類型。</p>
+        <p>Content Negotiation 外掛程式需要找到一種格式來將資料傳回瀏覽器。如果您查看專案中產生的程式碼，您會在
+            <Path>src/main/kotlin</Path>
+            內找到一個名為
+            <Path>Serialization.kt</Path>
+            的檔案，其中包含以下內容：
+        </p>
+        <code-block lang="kotlin" code="fun Application.configureSerialization() {&#10;    install(ContentNegotiation) {&#10;        json()&#10;    }&#10;}"/>
+        <p>
+            這段程式碼安裝了 <code>ContentNegotiation</code> 外掛程式，同時也配置了 <code>kotlinx.serialization</code> 外掛程式。有了這個，當用戶端發送請求時，伺服器可以回傳序列化為 JSON 的物件。
+        </p>
+        <p>
+            在瀏覽器請求的情況下，<code>ContentNegotiation</code> 外掛程式知道它只能回傳 JSON，而瀏覽器會嘗試顯示發送給它的任何內容。所以請求成功了。
+        </p>
+    </chapter>
+    <procedure title="透過 JavaScript 進行內容協商" id="via-javascript">
+        <p>
+            在生產環境中，您通常不會直接在瀏覽器中顯示 JSON。相反地，在瀏覽器中執行的 JavaScript 程式碼會發出請求，然後將回傳的資料作為單頁應用程式 (SPA) 的一部分進行顯示。通常，這種應用程式是使用像 <a href="https://react.dev/">React</a>、
+            <a href="https://angular.io/">Angular</a> 或 <a href="https://vuejs.org/">Vue.js</a> 這樣的架構編寫的。
+        </p>
+        <step>
+            <p>
+                為了模擬這種情況，請開啟
+                <Path>src/main/resources/static</Path>
+                內的
+                <Path>index.html</Path>
+                頁面，並將預設內容替換為以下內容：
+            </p>
+            <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;A Simple SPA For Tasks&lt;/title&gt;&#10;    &lt;script type=&quot;application/javascript&quot;&gt;&#10;        function fetchAndDisplayTasks() {&#10;            fetchTasks()&#10;                .then(tasks =&gt; displayTasks(tasks))&#10;        }&#10;&#10;        function fetchTasks() {&#10;            return fetch(&#10;                &quot;/tasks&quot;,&#10;                {&#10;                    headers: { 'Accept': 'application/json' }&#10;                }&#10;            ).then(resp =&gt; resp.json());&#10;        }&#10;&#10;        function displayTasks(tasks) {&#10;            const tasksTableBody = document.getElementById(&quot;tasksTableBody&quot;)&#10;            tasks.forEach(task =&gt; {&#10;                const newRow = taskRow(task);&#10;                tasksTableBody.appendChild(newRow);&#10;            });&#10;        }&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Viewing Tasks Via JS&lt;/h1&gt;&#10;&lt;form action=&quot;javascript:fetchAndDisplayTasks()&quot;&gt;&#10;    &lt;input type=&quot;submit&quot; value=&quot;View The Tasks&quot;&gt;&#10;&lt;/form&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            <p>
+                此頁面包含一個 HTML 表單和一個空表格。在提交表單時，JavaScript 事件處理常式會向 <code>/tasks</code> 端點發送請求，並將 <code>Accept</code> 標頭設置為 <code>application/json</code>。回傳的資料隨後被反序列化並新增到 HTML 表格中。
+            </p>
+        </step>
+        <step>
+            <p>
+                在 IntelliJ IDEA 中，點擊重新執行按鈕 (<img src="intellij_idea_rerun_icon.svg"
+                                                               style="inline" height="16" width="16"
+                                                               alt="intelliJ IDEA 重新執行圖示"/>) 以重啟應用程式。
+            </p>
+        </step>
+        <step>
+            <p>
+                導覽至 URL <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a>。您應該能夠透過點擊
+                <control>View The Tasks</control>
+                按鈕來獲取資料：
+            </p>
+            <img src="tutorial_creating_restful_apis_tasks_via_js.png"
+                 alt="瀏覽器視窗顯示按鈕和以 HTML 表格顯示的任務"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="新增 GET 路由" id="porting-get-routes">
+    <p>
+        既然您已經熟悉了內容協商的過程，請繼續將
+        <Links href="//server-requests-and-responses" summary="透過建置工作管理員應用程式，學習使用 Ktor 處理 Kotlin 路由、請求處理和參數的基礎知識。">前一個教學</Links> 中的功能轉移到本教學中。
+    </p>
+    <chapter title="重複使用任務存儲庫" id="task-repository">
+        <p>
+            您可以無需任何修改地重複使用任務存儲庫，所以讓我們首先執行此操作。
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    在
+                    <Path>model</Path>
+                    套件中建立一個新的
+                    <Path>TaskRepository.kt</Path>
+                    檔案。
+                </p>
+            </step>
+            <step>
+                <p>
+                    開啟
+                    <Path>TaskRepository.kt</Path>
+                    並新增以下程式碼：
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&#10;        tasks.add(task)&#10;    }&#10;}"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="重複使用 GET 請求的路由" id="get-requests">
+        <p>
+            既然您已經建立了存儲庫，就可以實作 GET 請求的路由。之前的程式碼可以簡化，因為您不再需要擔心將任務轉換為 HTML：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    導覽至
+                    <Path>src/main/kotlin</Path>
+                    中的
+                    <Path>Routing.kt</Path>
+                    檔案。
+                </p>
+            </step>
+            <step>
+                <p>
+                    使用以下實作更新 <code>Application.configureRouting()</code> 函式內的 <code>/tasks</code> 路由程式碼：
+                </p>
+                <code-block lang="kotlin" code="                    package com.example&#10;&#10;                    import com.example.model.Priority&#10;                    import com.example.model.TaskRepository&#10;                    import io.ktor.http.*&#10;                    import io.ktor.server.application.*&#10;                    import io.ktor.server.http.content.*&#10;                    import io.ktor.server.response.*&#10;                    import io.ktor.server.routing.*&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            staticResources(&quot;static&quot;, &quot;static&quot;)&#10;&#10;                            //更新後的實作&#10;                            route(&quot;/tasks&quot;) {&#10;                                get {&#10;                                    val tasks = TaskRepository.allTasks()&#10;                                    call.respond(tasks)&#10;                                }&#10;&#10;                                get(&quot;/byName/{taskName}&quot;) {&#10;                                    val name = call.parameters[&quot;taskName&quot;]&#10;                                    if (name == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@get&#10;                                    }&#10;&#10;                                    val task = TaskRepository.taskByName(name)&#10;                                    if (task == null) {&#10;                                        call.respond(HttpStatusCode.NotFound)&#10;                                        return@get&#10;                                    }&#10;                                    call.respond(task)&#10;                                }&#10;                                get(&quot;/byPriority/{priority}&quot;) {&#10;                                    val priorityAsText = call.parameters[&quot;priority&quot;]&#10;                                    if (priorityAsText == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@get&#10;                                    }&#10;                                    try {&#10;                                        val priority = Priority.valueOf(priorityAsText)&#10;                                        val tasks = TaskRepository.tasksByPriority(priority)&#10;&#10;                                        if (tasks.isEmpty()) {&#10;                                            call.respond(HttpStatusCode.NotFound)&#10;                                            return@get&#10;                                        }&#10;                                        call.respond(tasks)&#10;                                    } catch (ex: IllegalArgumentException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+                <p>
+                    有了這個，您的伺服器可以回應以下 GET 請求：</p>
+                <list>
+                    <li><code>/tasks</code> 回傳存儲庫中的所有任務。</li>
+                    <li><code>/tasks/byName/{taskName}</code> 回傳按指定的 <code>taskName</code> 過濾的任務。
+                    </li>
+                    <li><code>/tasks/byPriority/{priority}</code> 回傳按指定的 <code>priority</code> 過濾的任務。
+                    </li>
+                </list>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，點擊重新執行按鈕 (<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="intelliJ IDEA 重新執行圖示"/>) 以重啟應用程式。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="測試功能" id="test-tasks-routes">
+        <procedure title="使用瀏覽器">
+            <p>您可以在瀏覽器中測試這些路由。例如，導覽至 <a
+                    href="http://0.0.0.0:8080/tasks/byPriority/Medium">http://0.0.0.0:8080/tasks/byPriority/Medium</a>
+                以 JSON 格式查看所有優先級為 <code>Medium</code> 的任務：</p>
+            <img src="tutorial_creating_restful_apis_tasks_medium_priority.png"
+                 alt="瀏覽器視窗顯示以 JSON 格式呈現的中等優先級任務"
+                 border-effect="rounded"
+                 width="706"/>
+            <p>
+                鑑於這些類型的請求通常來自 JavaScript，更精細的測試更為理想。對此，您可以使用專門的工具，例如 <a
+                    href="https://learning.postman.com/docs/sending-requests/requests/">Postman</a>。
+            </p>
+        </procedure>
+        <procedure title="使用 Postman">
+            <step>
+                <p>在 Postman 中，使用 URL 建立一個新的 GET 請求
+                    <code>http://0.0.0.0:8080/tasks/byPriority/Medium</code>。</p>
+            </step>
+            <step>
+                <p>
+                    在
+                    <ui-path>Headers</ui-path>
+                    面板中，將
+                    <ui-path>Accept</ui-path>
+                    標頭的值設置為 <code>application/json</code>。
+                </p>
+            </step>
+            <step>
+                <p>點擊
+                    <control>Send</control>
+                    發送請求，並在回應檢視器中查看回應。
+                </p>
+                <img src="tutorial_creating_restful_apis_tasks_medium_priority_postman.png"
+                     alt="Postman 中的 GET 請求，顯示以 JSON 格式呈現的中等優先級任務"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+        <procedure title="使用 HTTP 請求檔案">
+            <p>在 IntelliJ IDEA Ultimate 中，您可以在 HTTP 請求檔案中執行相同的步驟。</p>
+            <step>
+                <p>
+                    在專案根目錄中，建立一個新的
+                    <Path>REST Task Manager.http</Path>
+                    檔案。
+                </p>
+            </step>
+            <step>
+                <p>
+                    開啟
+                    <Path>REST Task Manager.http</Path>
+                    檔案並新增以下 GET 請求：
+                </p>
+                <code-block lang="http" code="GET http://0.0.0.0:8080/tasks/byPriority/Medium&#10;Accept: application/json"/>
+            </step>
+            <step>
+                <p>
+                    要在 IntelliJ IDEA 中發送請求，請點擊其旁邊的裝訂邊圖示 (<img
+                        alt="intelliJ IDEA 裝訂邊圖示"
+                        src="intellij_idea_gutter_icon.svg"
+                        width="16" height="26"/>)。
+                </p>
+            </step>
+            <step>
+                <p>這將在
+                    <Path>Services</Path>
+                    工具視窗中開啟並執行：
+                </p>
+                <img src="tutorial_creating_restful_apis_tasks_medium_priority_http_file.png"
+                     alt="HTTP 檔案中的 GET 請求，顯示以 JSON 格式呈現的中等優先級任務"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+        <note>
+            另一種測試路由的方法是在 Kotlin Notebook 中使用 <a
+                href="https://khttp.readthedocs.io/en/latest/">khttp</a> 程式庫。
+        </note>
+    </chapter>
+</chapter>
+<chapter title="新增 POST 請求的路由" id="add-a-route-for-post-requests">
+    <p>
+        在前一個教學中，任務是透過 HTML 表單建立的。然而，由於您現在正在建置 RESTful 服務，您不再需要那樣做。相反地，您將利用 <code>kotlinx.serialization</code> 架構，它將承擔大部分繁重的工作。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                開啟
+                <Path>src/main/kotlin</Path>
+                內的
+                <Path>Routing.kt</Path>
+                檔案。
+            </p>
+        </step>
+        <step>
+            <p>
+                向 <code>Application.configureRouting()</code> 函式新增一個新的 POST 路由，如下所示：
+            </p>
+            <code-block lang="kotlin" code="                    //...&#10;&#10;                    fun Application.configureRouting() {&#10;                        routing {&#10;                            //...&#10;&#10;                            route(&quot;/tasks&quot;) {&#10;                                //...&#10;&#10;                                //新增以下新路由&#10;                                post {&#10;                                    try {&#10;                                        val task = call.receive&lt;Task&gt;()&#10;                                        TaskRepository.addTask(task)&#10;                                        call.respond(HttpStatusCode.Created)&#10;                                    } catch (ex: IllegalStateException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    } catch (ex: SerializationException) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+            <p>
+                新增以下新匯入：
+            </p>
+            <code-block lang="kotlin" code="                    //...&#10;                    import com.example.model.Task&#10;                    import io.ktor.server.request.receive&#10;                    import kotlinx.serialization.SerializationException"/>
+            <p>
+                當向 <code>/tasks</code> 發送 POST 請求時，會使用 <code>kotlinx.serialization</code> 架構將請求的主體轉換為 <code>Task</code> 物件。如果成功，任務將新增到存儲庫中。如果反序列化過程失敗，伺服器會處理 <code>SerializationException</code>，而如果任務名稱重複，則會處理 <code>IllegalStateException</code>。
+            </p>
+        </step>
+        <step>
+            <p>
+                重啟應用程式。
+            </p>
+        </step>
+        <step>
+            <p>
+                要在 Postman 中測試此功能，請向 URL <code>http://0.0.0.0:8080/tasks</code> 建立一個新的 POST 請求。
+            </p>
+        </step>
+        <step>
+            <p>
+                在
+                <ui-path>Body</ui-path>
+                面板中，新增以下 JSON 文件以表示新任務：
+            </p>
+            <code-block lang="json" code="{&#10;    &quot;name&quot;: &quot;cooking&quot;,&#10;    &quot;description&quot;: &quot;Cook the dinner&quot;,&#10;    &quot;priority&quot;: &quot;High&quot;&#10;}"/>
+            <img src="tutorial_creating_restful_apis_add_task.png"
+                 alt="Postman 中用於新增任務的 POST 請求"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+        <step>
+            <p>點擊
+                <control>Send</control>
+                發送請求。
+            </p>
+        </step>
+        <step>
+            <p>
+                您可以透過向 <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a> 發送 GET 請求來驗證任務是否已新增。
+            </p>
+        </step>
+        <step>
+            <p>
+                在 IntelliJ IDEA Ultimate 中，您可以透過將以下內容新增到您的 HTTP 請求檔案來執行相同的步驟：
+            </p>
+            <code-block lang="http" code="###&#10;&#10;POST http://0.0.0.0:8080/tasks&#10;Content-Type: application/json&#10;&#10;{&#10;    &quot;name&quot;: &quot;cooking&quot;,&#10;    &quot;description&quot;: &quot;Cook the dinner&quot;,&#10;    &quot;priority&quot;: &quot;High&quot;&#10;}"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="新增移除支援" id="remove-tasks">
+    <p>
+        您即將完成向服務新增基本操作。這些操作通常被總結為 CRUD（建立 Create、讀取 Read、更新 Update 和刪除 Delete）操作。現在您將實作刪除操作。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                在
+                <Path>TaskRepository.kt</Path>
+                檔案中，在 <code>TaskRepository</code> 物件內新增以下方法以根據名稱移除任務：
+            </p>
+            <code-block lang="kotlin" code="    fun removeTask(name: String): Boolean {&#10;        return tasks.removeIf { it.name == name }&#10;    }"/>
+        </step>
+        <step>
+            <p>
+                開啟
+                <Path>Routing.kt</Path>
+                檔案，並在 <code>routing()</code> 函式中新增一個端點以處理 DELETE 請求：
+            </p>
+            <code-block lang="kotlin" code="                    fun Application.configureRouting() {&#10;                        //...&#10;&#10;                        routing {&#10;                            route(&quot;/tasks&quot;) {&#10;                                //...&#10;                                //新增以下函式&#10;                                delete(&quot;/{taskName}&quot;) {&#10;                                    val name = call.parameters[&quot;taskName&quot;]&#10;                                    if (name == null) {&#10;                                        call.respond(HttpStatusCode.BadRequest)&#10;                                        return@delete&#10;                                    }&#10;&#10;                                    if (TaskRepository.removeTask(name)) {&#10;                                        call.respond(HttpStatusCode.NoContent)&#10;                                    } else {&#10;                                        call.respond(HttpStatusCode.NotFound)&#10;                                    }&#10;                                }&#10;                            }&#10;                        }&#10;                    }"/>
+        </step>
+        <step>
+            <p>
+                重啟應用程式。
+            </p>
+        </step>
+        <step>
+            <p>
+                將以下 DELETE 請求新增到您的 HTTP 請求檔案中：
+            </p>
+            <code-block lang="http" code="###&#10;&#10;DELETE http://0.0.0.0:8080/tasks/gardening"/>
+        </step>
+        <step>
+            <p>
+                要在 IntelliJ IDEA 中發送 DELETE 請求，請點擊其旁邊的裝訂邊圖示 (<img
+                    alt="intelliJ IDEA 裝訂邊圖示"
+                    src="intellij_idea_gutter_icon.svg"
+                    width="16" height="26"/>)。
+            </p>
+        </step>
+        <step>
+            <p>您將在
+                <Path>Services</Path>
+                工具視窗中看到回應：
+            </p>
+            <img src="tutorial_creating_restful_apis_delete_task.png"
+                 alt="HTTP 請求檔案中的 DELETE 請求"
+                 border-effect="line"
+                 width="706"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="使用 Ktor Client 建立單元測試" id="create-unit-tests">
+    <p>
+        到目前為止，您一直手動測試應用程式，但正如您已經注意到的，這種方法耗時且無法擴充。相反地，您可以實作 <Links href="//server-testing" summary="了解如何使用特殊測試引擎來測試您的伺服器應用程式。">JUnit 測試</Links>，使用內建的 <code>client</code> 物件來獲取並反序列化 JSON。
+    </p>
+    <procedure>
+        <step>
+            <p>
+                開啟
+                <Path>src/test/kotlin</Path>
+                內的
+                <Path>ServerTest.kt</Path>
+                檔案。
+            </p>
+        </step>
+        <step>
+            <p>
+                將
+                <Path>ServerTest.kt</Path>
+                檔案的內容替換為以下內容：
+            </p>
+            <code-block lang="kotlin" code="package com.example&#10;&#10;import com.example.model.Priority&#10;import com.example.model.Task&#10;import io.ktor.client.call.*&#10;import io.ktor.client.plugins.contentnegotiation.*&#10;import io.ktor.client.request.*&#10;import io.ktor.http.*&#10;import io.ktor.serialization.kotlinx.json.*&#10;import io.ktor.server.testing.*&#10;import kotlin.test.*&#10;&#10;class ApplicationTest {&#10;    @Test&#10;    fun tasksCanBeFoundByPriority() = testApplication {&#10;        configure()&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;        }&#10;&#10;        val response = client.get(&quot;/tasks/byPriority/Medium&quot;)&#10;        val results = response.body&lt;List&lt;Task&gt;&gt;()&#10;&#10;        assertEquals(HttpStatusCode.OK, response.status)&#10;&#10;        val expectedTaskNames = listOf(&quot;gardening&quot;, &quot;painting&quot;)&#10;        val actualTaskNames = results.map(Task::name)&#10;        assertContentEquals(expectedTaskNames, actualTaskNames)&#10;    }&#10;&#10;    @Test&#10;    fun invalidPriorityProduces400() = testApplication {&#10;        configure()&#10;        val response = client.get(&quot;/tasks/byPriority/Invalid&quot;)&#10;        assertEquals(HttpStatusCode.BadRequest, response.status)&#10;    }&#10;&#10;&#10;    @Test&#10;    fun unusedPriorityProduces404() = testApplication {&#10;        configure()&#10;        val response = client.get(&quot;/tasks/byPriority/Vital&quot;)&#10;        assertEquals(HttpStatusCode.NotFound, response.status)&#10;    }&#10;&#10;    @Test&#10;    fun newTasksCanBeAdded() = testApplication {&#10;        configure()&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;        }&#10;&#10;        val task = Task(&quot;swimming&quot;, &quot;Go to the beach&quot;, Priority.Low)&#10;        val response1 = client.post(&quot;/tasks&quot;) {&#10;            header(&#10;                HttpHeaders.ContentType,&#10;                ContentType.Application.Json&#10;            )&#10;&#10;            setBody(task)&#10;        }&#10;        assertEquals(HttpStatusCode.Created, response1.status)&#10;&#10;        val response2 = client.get(&quot;/tasks&quot;)&#10;        assertEquals(HttpStatusCode.OK, response2.status)&#10;&#10;        val taskNames = response2&#10;            .body&lt;List&lt;Task&gt;&gt;()&#10;            .map { it.name }&#10;&#10;        assertContains(taskNames, &quot;swimming&quot;)&#10;    }&#10;}"/>
+            <p>
+                請注意，您需要將 <code>ContentNegotiation</code> 和 <code>kotlinx.serialization</code> 外掛程式安裝到 <a href="client-create-and-configure.md#plugins">Plugins</a> 中，就像在伺服器端所做的一樣。
+            </p>
+        </step>
+        <step>
+            <p>
+                將以下相依性新增到您的
+                <Path>build.gradle.kts</Path>
+                檔案中：
+            </p>
+            <code-block lang="kotlin" code="                    testImplementation(ktorLibs.client.contentNegotiation)"/>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="使用 JsonPath 建立單元測試" id="unit-tests-via-jsonpath">
+    <p>
+        使用 Ktor client 或類似的程式庫測試服務固然方便，但從品質保證 (QA) 的角度來看，它有一個缺點。伺服器不直接處理 JSON，因此無法確定其對 JSON 結構的假設。
+    </p>
+    <p>
+        例如，諸如以下的假設：
+    </p>
+    <list>
+        <li>當實際上使用 <code>object</code> 時，值正被儲存在 <code>array</code> 中。</li>
+        <li>屬性正以 <code>numbers</code> 儲存，而它們實際上是 <code>strings</code>。</li>
+        <li>成員正按照宣告的順序進行序列化，而實際上並非如此。</li>
+    </list>
+    <p>
+        如果您的服務旨在供多個用戶端使用，那麼對 JSON 結構有信心至關重要。為了實現這一點，請使用 Ktor Client 從伺服器檢索文本，然後使用 <a href="https://mvnrepository.com/artifact/com.jayway.jsonpath/json-path">JSONPath</a> 程式庫分析此內容。</p>
+    <procedure>
+        <step>
+            <p>在您的
+                <Path>build.gradle.kts</Path>
+                檔案中，將 JSONPath 程式庫新增到 <code>dependencies</code> 區塊：
+            </p>
+            <code-block lang="kotlin" code="    testImplementation(&quot;com.jayway.jsonpath:json-path:2.9.0&quot;)"/>
+        </step>
+        <step>
+            <p>
+                導覽至
+                <Path>src/test/kotlin</Path>
+                資料夾並建立一個新的
+                <Path>ApplicationJsonPathTest.kt</Path>
+                檔案。
+            </p>
+        </step>
+        <step>
+            <p>
+                開啟
+                <Path>ApplicationJsonPathTest.kt</Path>
+                檔案並向其中新增以下內容：
+            </p>
+            <code-block lang="kotlin" code="package com.example&#10;&#10;import com.jayway.jsonpath.DocumentContext&#10;import com.jayway.jsonpath.JsonPath&#10;import io.ktor.client.*&#10;import com.example.model.Priority&#10;import io.ktor.client.request.*&#10;import io.ktor.client.statement.*&#10;import io.ktor.http.*&#10;import io.ktor.server.testing.*&#10;import kotlin.test.*&#10;&#10;&#10;class ApplicationJsonPathTest {&#10;    @Test&#10;    fun tasksCanBeFound() = testApplication {&#10;        configure()&#10;        val jsonDoc = client.getAsJsonPath(&quot;/tasks&quot;)&#10;&#10;        val result: List&lt;String&gt; = jsonDoc.read(&quot;$[*].name&quot;)&#10;        assertEquals(&quot;cleaning&quot;, result[0])&#10;        assertEquals(&quot;gardening&quot;, result[1])&#10;        assertEquals(&quot;shopping&quot;, result[2])&#10;    }&#10;&#10;    @Test&#10;    fun tasksCanBeFoundByPriority() = testApplication {&#10;        configure()&#10;        val priority = Priority.Medium&#10;        val jsonDoc = client.getAsJsonPath(&quot;/tasks/byPriority/$priority&quot;)&#10;&#10;        val result: List&lt;String&gt; =&#10;            jsonDoc.read(&quot;$[?(@.priority == '$priority')].name&quot;)&#10;        assertEquals(2, result.size)&#10;&#10;        assertEquals(&quot;gardening&quot;, result[0])&#10;        assertEquals(&quot;painting&quot;, result[1])&#10;    }&#10;&#10;    suspend fun HttpClient.getAsJsonPath(url: String): DocumentContext {&#10;        val response = this.get(url) {&#10;            accept(ContentType.Application.Json)&#10;        }&#10;        return JsonPath.parse(response.bodyAsText())&#10;    }&#10;}"/>
+            <p>
+                JsonPath 查詢的工作原理如下：
+            </p>
+            <list>
+                <li>
+                    <code>$[&#42;].name</code> 表示「將文件視為陣列，並回傳每個項目的 name 屬性值」。
+                </li>
+                <li>
+                    <code>$[?(@.priority == '$priority')].name</code> 表示「回傳陣列中優先級等於提供值的所有項目的 name 屬性值」。
+                </li>
+            </list>
+            <p>
+                您可以使用類似這樣的查詢來確認您對回傳 JSON 的理解。當您進行程式碼重構和服務重新部署時，序列化中的任何修改都會被識別出來，即使它們沒有破壞當前架構的反序列化。這使您能夠充滿信心地重新發布公開可用的 API。
+            </p>
+        </step>
+    </procedure>
+</chapter>
+<chapter title="後續步驟" id="next-steps">
+    <p>
+        恭喜！您現在已經完成了為工作管理員應用程式建立 RESTful API 服務，並學習了使用 Ktor Client 和 JsonPath 進行單元測試的細節。</p>
+    <p>
+        繼續閱讀
+        <Links href="//server-create-website" summary="了解如何使用 Ktor 和 Thymeleaf 範本在 Kotlin 中建置網站。">下一個教學</Links>，學習如何重複使用您的 API 服務來建置 Web 應用程式。
+    </p>
+</chapter>
+</topic>

--- a/docs/zh-Hant/ktor/server-create-website.md
+++ b/docs/zh-Hant/ktor/server-create-website.md
@@ -1,0 +1,426 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="使用 Kotlin 與 Ktor 建立網站" id="server-create-website">
+    <show-structure for="chapter,procedure" depth="3"/>
+    <tldr>
+        <var name="example_name" value="tutorial-server-web-application"/>
+        <p>
+            <b>程式碼範例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+        <p>
+            <b>使用的外掛程式</b>：<Links href="//server-static-content" summary="瞭解如何提供靜態內容，例如樣式表、指令嗎、圖片等。">Static Content</Links>、
+            <Links href="//server-thymeleaf" summary="所需的相依性：io.ktor:%artifact_name%">Thymeleaf</Links>
+        </p>
+    </tldr>
+    <web-summary>
+        瞭解如何使用 Ktor 與 Kotlin 建置網站。本教學將向您展示如何結合 Thymeleaf 範本與 Ktor 路由，在伺服器端產生基於 HTML 的使用者介面。
+    </web-summary>
+    <card-summary>
+        瞭解如何使用 Kotlin、Ktor 與 Thymeleaf 範本建置網站。
+    </card-summary>
+    <link-summary>
+        瞭解如何使用 Kotlin、Ktor 與 Thymeleaf 範本建置網站。
+    </link-summary>
+    <p>
+        在本教學中，您將學習如何使用 Kotlin、Ktor 與 <a href="https://www.thymeleaf.org/">Thymeleaf</a> 範本建置一個互動式網站。
+    </p>
+    <p>
+        在<Links href="//server-create-restful-apis" summary="瞭解如何使用 Kotlin 與 Ktor 建置後端服務，其中包含一個產生 JSON 檔案的 RESTful API 範例。">前一個教學</Links>中，您學習了如何建立一個 RESTful 服務，供使用 JavaScript 編寫的單頁應用程式（SPA）使用。雖然這是一種非常流行的架構，但它並不適合所有專案。
+    </p>
+    <p>
+        您可能希望將所有實作保留在伺服器上，僅將標記傳送到用戶端，原因有很多，例如：
+    </p>
+    <list>
+        <li>簡單性 – 維護單一程式碼庫。</li>
+        <li>安全性 – 防止將可能讓攻擊者洞察系統的資料或程式碼放在瀏覽器上。
+        </li>
+        <li>
+            可支援性 – 允許用戶端使用盡可能廣泛的用戶端，包括舊版瀏覽器以及停用 JavaScript 的瀏覽器。
+        </li>
+    </list>
+    <p>
+        Ktor 透過整合<Links href="//server-templating" summary="瞭解如何處理使用 HTML/CSS 或 JVM 範本引擎建置的檢視。">數種伺服器頁面技術</Links>來支援這種方法。
+    </p>
+    <chapter title="先決條件" id="prerequisites">
+        <p>
+            您可以獨立完成本教學，但我們強烈建議您先完成<Links href="//server-create-restful-apis" summary="瞭解如何使用 Kotlin 與 Ktor 建置後端服務，其中包含一個產生 JSON 檔案的 RESTful API 範例。">之前的教學</Links>，以瞭解如何建立 RESTful API。
+        </p>
+        <p>我們建議您安裝 <a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ IDEA</a>，但您也可以使用您選擇的其他編輯器。
+        </p>
+    </chapter>
+    <chapter title="Hello Task Manager Web 應用程式" id="hello-task-manager">
+        <p>
+            在本教學中，您將把在<Links href="//server-create-restful-apis" summary="瞭解如何使用 Kotlin 與 Ktor 建置後端服務，其中包含一個產生 JSON 檔案的 RESTful API 範例。">前一個教學</Links>中建置的任務管理應用程式轉換為 Web 應用程式。為此，您將使用數個 Ktor <Links href="//server-plugins" summary="外掛程式提供通用功能，例如序列化、內容編碼、壓縮等。">外掛程式</Links>。
+        </p>
+        <p>
+            雖然您可以手動將這些外掛程式新增到現有專案中，但產生一個新專案並逐漸納入先前教學中的程式碼會更容易。我們將在過程中提供所有必要的程式碼，因此您不需要手邊有先前的專案。
+        </p>
+        <procedure title="使用外掛程式建立初始專案" id="create-project">
+            <step>
+                <p>
+                    導航至
+                    <a href="https://start.ktor.io/">Ktor Project Generator</a>。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在
+                    <control>Project artifact</control>
+                    欄位中，輸入
+                    <Path>com.example.ktor-task-web-app</Path>
+                    作為您的專案構件名稱。
+                    <img src="server_create_web_app_generator_project_artifact.png"
+                         alt="Ktor Project Generator 專案構件名稱"
+                         style="block"
+                         border-effect="line" width="706"/>
+                </p>
+            </step>
+            <step>
+                <p> 在下一個畫面中，點擊
+                    <control>Add</control>
+                    按鈕來搜尋並新增以下外掛程式：
+                </p>
+                <list>
+                    <li>Static Content</li>
+                    <li>Thymeleaf</li>
+                </list>
+                <p>
+                    <img src="ktor_project_generator_add_plugins.gif"
+                         alt="在 Ktor Project Generator 中新增外掛程式"
+                         border-effect="line"
+                         style="block"
+                         width="706"/>
+                    新增外掛程式後，您將看到專案設定下方列出了所有三個外掛程式。
+                    <img src="server_create_web_app_generator_plugins.png"
+                         alt="Ktor Project Generator 外掛程式列表"
+                         style="block"
+                         border-effect="line" width="706"/>
+                </p>
+            </step>
+            <step>
+                <p>
+                    點擊
+                    <control>Download</control>
+                    按鈕以產生並下載您的 Ktor 專案。
+                </p>
+            </step>
+        </procedure>
+        <procedure title="新增入門程式碼" id="add-starter-code">
+            <step>
+                在 IntelliJ IDEA 或您選擇的其他編輯器中開啟專案。
+            </step>
+            <step>
+                導航至
+                <Path>src/main/kotlin</Path>
+                並建立一個名為
+                <Path>model</Path>
+                的子套件。
+            </step>
+            <step>
+                在
+                <Path>model</Path>
+                套件內，建立一個新的
+                <Path>Task.kt</Path>
+                檔案。
+            </step>
+            <step>
+                <p>
+                    在
+                    <Path>Task.kt</Path>
+                    檔案中，新增一個 <code>enum</code> 來表示優先級，以及一個 <code>data class</code> 來表示任務：
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+                <p>
+                    再次地，您想要建立 <code>Task</code> 物件並以可以顯示的形式傳送給用戶端。
+                </p>
+                <p>
+                    您可能還記得：
+                </p>
+                <list>
+                    <li>
+                        在<Links href="//server-requests-and-responses" summary="透過建置任務管理器應用程式，學習使用 Ktor 與 Kotlin 處理請求、參數以及路由的基礎知識。">處理請求並產生回應</Links>教學中，您新增了手寫的擴充函式來將任務轉換為 HTML。
+                    </li>
+                    <li>
+                        在<Links href="//server-create-restful-apis" summary="瞭解如何使用 Kotlin 與 Ktor 建置後端服務，其中包含一個產生 JSON 檔案的 RESTful API 範例。">建立 RESTful API</Links>教學中，您使用 <code>kotlinx.serialization</code> 程式庫中的 <code>Serializable</code> 型別對 <code>Task</code> 類別進行了註解。
+                    </li>
+                </list>
+                <p>
+                    在這種情況下，目標是建立一個伺服器頁面，將任務內容寫入瀏覽器。
+                </p>
+            </step>
+            <step>
+                開啟
+                <Path>src/main/kotlin</Path>
+                中的
+                <Path>Routing.kt</Path>
+                檔案。
+            </step>
+            <step>
+                <p>
+                    在 <code>.configureRouting()</code> 函式中，為 <code>/tasks</code> 新增一條路由，如下所示：
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, World!&quot;)&#10;        }&#10;        get(&quot;/html-thymeleaf&quot;) {&#10;            call.respond(ThymeleafContent(&quot;index&quot;, mapOf(&quot;user&quot; to ThymeleafUser(1, &quot;user1&quot;))))&#10;        }&#10;        // 新增此額外路由&#10;        get(&quot;/tasks&quot;) {&#10;            val tasks = listOf(&#10;                Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;            )&#10;            call.respond(ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks)))&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;    }&#10;}"/>
+                <p>
+                    當伺服器收到對 <code>/tasks</code> 的請求時，它會建立一個任務清單，然後將其傳遞給 Thymeleaf 範本。<code>ThymeleafContent</code> 型別接收要觸發的範本名稱，以及要在頁面上存取的值表。
+                </p>
+            </step>
+            <step>
+                開啟
+                <Path>src/main/kotlin</Path>
+                中的
+                <Path>Thymeleaf.kt</Path>
+                檔案。
+            </step>
+            <step>
+                <p>您應該會看到以下 <code>.configureThymeleaf</code> 函式：</p>
+                <code-block lang="kotlin" code="fun Application.configureThymeleaf() {&#10;    install(Thymeleaf) {&#10;        setTemplateResolver(ClassLoaderTemplateResolver().apply {&#10;            prefix = &quot;templates/thymeleaf/&quot;&#10;            suffix = &quot;.html&quot;&#10;            characterEncoding = &quot;utf-8&quot;&#10;        })&#10;    }&#10;}"/>
+                <p>
+                    在 Thymeleaf 外掛程式的初始化過程中，Ktor 會在
+                    <Path>templates/thymeleaf</Path>
+                    資料夾中尋找伺服器頁面。與靜態內容一樣，它預期此資料夾位於
+                    <Path>resources</Path>
+                    目錄中。它也預期有
+                    <Path>.html</Path>
+                    後綴。
+                </p>
+                <p>
+                    在這種情況下，名稱 <code>all-tasks</code> 對應到路徑
+                    <code>src/main/resources/templates/thymeleaf/all-tasks.html</code>
+                </p>
+            </step>
+            <step>
+                導航至 <Path>src/main/resources</Path>
+                並建立一個新的 <Path>templates/thymeleaf</Path>
+                目錄。
+            </step>
+            <step>
+                在
+                <Path>src/main/resources/templates/thymeleaf</Path>
+                中，建立一個新的
+                <Path>all-tasks.html</Path>
+                檔案。
+            </step>
+            <step>
+                <p>開啟
+                    <Path>all-tasks.html</Path>
+                    檔案並新增以下內容：
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html &gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;All Current Tasks&lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;All Current Tasks&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr th:each=&quot;task: ${tasks}&quot;&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>在 IntelliJ IDEA 中，點擊執行按鈕
+                    (<img src="intellij_idea_gutter_icon.svg"
+                          style="inline" height="16" width="16"
+                          alt="IntelliJ IDEA 執行圖示"/>)
+                    來啟動應用程式。</p>
+            </step>
+            <step>
+                <p>
+                    在瀏覽器中導航至 <a href="http://0.0.0.0:8080/tasks">http://0.0.0.0:8080/tasks</a>。您應該會看到所有目前任務顯示在表格中，如下所示：
+                </p>
+                <img src="server_create_web_app_all_tasks.png"
+                     alt="顯示任務清單的 Web 瀏覽器視窗" border-effect="rounded" width="706"/>
+                <p>
+                    與所有伺服器頁面架構一樣，Thymeleaf 範本混合了靜態內容（要傳送到瀏覽器）與動態內容（要在伺服器上執行）。如果您選擇了其他架構，例如 <a href="https://freemarker.apache.org/">Freemarker</a>，您也可以使用稍微不同的語法提供相同的功能。
+                </p>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="新增 GET 路由" id="add-get-routes">
+        <p>現在您已經熟悉了請求伺服器頁面的過程，請繼續將先前教學中的功能轉移到本教學中。</p>
+        <p>因為您包含了
+            <control>Static Content</control>
+            外掛程式，所以
+            <Path>Routing.kt</Path>
+            檔案中會存在以下程式碼：
+        </p>
+        <code-block lang="kotlin" code="            staticResources(&quot;/static&quot;, &quot;static&quot;)"/>
+        <p>
+            這意味著，例如，對 <code>/static/index.html</code> 的請求會由以下路徑的內容提供：
+        </p>
+        <code>src/main/resources/static/index.html</code>
+        <p>
+            由於此檔案已經是產生的專案的一部分，您可以將其用作您希望新增的功能的首頁。
+        </p>
+        <procedure title="重複使用索引頁面">
+            <step>
+                <p>
+                    開啟
+                    <Path>src/main/resources/static</Path>
+                    中的
+                    <Path>index.html</Path>
+                    檔案，並將其內容替換為以下實作：
+                </p>
+                <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Task Manager Web Application&lt;/h1&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;&lt;a href=&quot;/tasks&quot;&gt;View all the tasks&lt;/a&gt;&lt;/h3&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;View tasks by priority&lt;/h3&gt;&#10;    &lt;form method=&quot;get&quot; action=&quot;/tasks/byPriority&quot;&gt;&#10;        &lt;select name=&quot;priority&quot;&gt;&#10;            &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;            &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;            &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;            &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;        &lt;/select&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;View a task by name&lt;/h3&gt;&#10;    &lt;form method=&quot;get&quot; action=&quot;/tasks/byName&quot;&gt;&#10;        &lt;input type=&quot;text&quot; name=&quot;name&quot; width=&quot;10&quot;&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;Create or edit a task&lt;/h3&gt;&#10;    &lt;form method=&quot;post&quot; action=&quot;/tasks&quot;&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;name&quot;&gt;Name: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;name&quot; name=&quot;name&quot; size=&quot;10&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;description&quot;&gt;Description: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;description&quot;&#10;                   name=&quot;description&quot; size=&quot;20&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;priority&quot;&gt;Priority: &lt;/label&gt;&#10;            &lt;select id=&quot;priority&quot; name=&quot;priority&quot;&gt;&#10;                &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;                &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;                &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;                &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;            &lt;/select&gt;&#10;        &lt;/div&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，點擊重新執行按鈕 (<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 重新執行圖示"/>) 以重新啟動應用程式。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在瀏覽器中導航至 <a href="http://localhost:8080/static/index.html">http://localhost:8080/static/index.html</a>。您應該會看到一個連結按鈕和三個 HTML 表單，允許您查看、篩選與建立任務：
+                </p>
+                <img src="server_create_web_app_tasks_form.png"
+                     alt="顯示 HTML 表單的 Web 瀏覽器" border-effect="rounded" width="706"/>
+                <p>
+                    請注意，當您按 <code>name</code> 或 <code>priority</code> 篩選任務時，您是透過 GET 請求提交 HTML 表單。這意味著參數會新增到 URL 後方的查詢字串中。
+                </p>
+                <p>
+                    例如，如果您搜尋 <code>Medium</code> 優先級的任務，傳送到伺服器的請求如下所示：
+                </p>
+                <code>http://localhost:8080/tasks/byPriority?priority=Medium</code>
+            </step>
+        </procedure>
+        <procedure title="重複使用任務存儲庫" id="task-repository">
+            <p>
+                任務的存儲庫可以保持與先前教學中的內容完全相同。
+            </p>
+            <p>
+                在
+                <Path>model</Path>
+                套件內建立一個新的
+                <Path>TaskRepository.kt</Path>
+                檔案並新增以下程式碼：
+            </p>
+            <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&#10;        tasks.add(task)&#10;    }&#10;}"/>
+        </procedure>
+        <procedure title="重複使用 GET 請求的路由" id="reuse-routes">
+            <p>
+                現在您已經建立了存儲庫，可以實作 GET 請求的路由。
+            </p>
+            <step>
+                導航至
+                <Path>src/main/kotlin</Path>
+                中的
+                <Path>Routing.kt</Path>
+                檔案。
+            </step>
+            <step>
+                <p>
+                    將目前版本的 <code>.configureRouting()</code> 替換為以下實作：
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        get(&quot;/&quot;) {&#10;            call.respondText(&quot;Hello, World!&quot;)&#10;        }&#10;        get(&quot;/html-thymeleaf&quot;) {&#10;            call.respond(ThymeleafContent(&quot;index&quot;, mapOf(&quot;user&quot; to ThymeleafUser(1, &quot;user1&quot;))))&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;&#10;        route(&quot;/tasks&quot;) {&#10;            get {&#10;                val tasks = TaskRepository.allTasks()&#10;                call.respond(&#10;                    ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks))&#10;                )&#10;            }&#10;            get(&quot;/byName&quot;) {&#10;                val name = call.request.queryParameters[&quot;name&quot;]&#10;                if (name == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                val task = TaskRepository.taskByName(name)&#10;                if (task == null) {&#10;                    call.respond(HttpStatusCode.NotFound)&#10;                    return@get&#10;                }&#10;                call.respond(&#10;                    ThymeleafContent(&quot;single-task&quot;, mapOf(&quot;task&quot; to task))&#10;                )&#10;            }&#10;            get(&quot;/byPriority&quot;) {&#10;                val priorityAsText = call.request.queryParameters[&quot;priority&quot;]&#10;                if (priorityAsText == null) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@get&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(priorityAsText)&#10;                    val tasks = TaskRepository.tasksByPriority(priority)&#10;&#10;&#10;                    if (tasks.isEmpty()) {&#10;                        call.respond(HttpStatusCode.NotFound)&#10;                        return@get&#10;                    }&#10;                    val data = mapOf(&#10;                        &quot;priority&quot; to priority,&#10;                        &quot;tasks&quot; to tasks&#10;                    )&#10;                    call.respond(ThymeleafContent(&quot;tasks-by-priority&quot;, data))&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }&#10;        }&#10;    }&#10;}"/>
+                <p>
+                    上述程式碼可以總結如下：
+                </p>
+                <list>
+                    <li>
+                        在對 <code>/tasks</code> 的 GET 請求中，伺服器從存儲庫中檢索所有任務，並使用
+                        <Path>all-tasks</Path>
+                        範本產生傳送至瀏覽器的下一個檢視。
+                    </li>
+                    <li>
+                        在對 <code>/tasks/byName</code> 的 GET 請求中，伺服器從 <code>queryString</code> 中檢索參數 <code>name</code>，找到相符的任務，並使用
+                        <Path>single-task</Path>
+                        範本產生傳送至瀏覽器的下一個檢視。
+                    </li>
+                    <li>
+                        在對 <code>/tasks/byPriority</code> 的 GET 請求中，伺服器從 <code>queryString</code> 中檢索參數 <code>priority</code>，找到相符的任務，並使用
+                        <Path>tasks-by-priority</Path>
+                        範本產生傳送至瀏覽器的下一個檢視。
+                    </li>
+                </list>
+                <p>為了使這一切正常運作，您需要新增額外的範本。</p>
+            </step>
+            <step>
+                導航至
+                <Path>src/main/resources/templates/thymeleaf</Path>
+                並建立一個新的
+                <Path>single-task.html</Path>
+                檔案。
+            </step>
+            <step>
+                <p>
+                    開啟
+                    <Path>single-task.html</Path>
+                    檔案並新增以下內容：
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html &gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;All Current Tasks&lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;The Selected Task&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Description&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Priority&lt;/th&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+            <step>
+                <p>在同一個資料夾中，建立一個名為
+                    <Path>tasks-by-priority.html</Path>
+                    的新檔案。
+                </p>
+            </step>
+            <step>
+                <p>
+                    開啟
+                    <Path>tasks-by-priority.html</Path>
+                    檔案並新增以下內容：
+                </p>
+                <code-block lang="html" code="&lt;!DOCTYPE html&gt;&#10;&lt;html xmlns:th=&quot;http://www.thymeleaf.org&quot;&gt;&#10;&lt;head&gt;&#10;    &lt;meta charset=&quot;UTF-8&quot;&gt;&#10;    &lt;title&gt;Tasks By Priority &lt;/title&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Tasks With Priority &lt;span th:text=&quot;${priority}&quot;&gt;&lt;/span&gt;&lt;/h1&gt;&#10;&lt;table&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&#10;        &lt;th&gt;Description&lt;/th&gt;&#10;        &lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody&gt;&#10;    &lt;tr th:each=&quot;task: ${tasks}&quot;&gt;&#10;        &lt;td th:text=&quot;${task.name}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.description}&quot;&gt;&lt;/td&gt;&#10;        &lt;td th:text=&quot;${task.priority}&quot;&gt;&lt;/td&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="新增對 POST 請求的支援" id="add-post-requests">
+        <p>
+            接下來，您將在 <code>/tasks</code> 中新增一個 POST 請求處理常式，以執行以下操作：
+        </p>
+        <list>
+            <li>從表單參數中提取資訊。</li>
+            <li>使用存儲庫新增新任務。</li>
+            <li>透過重複使用
+                <control>all-tasks</control>
+                範本來顯示任務。
+            </li>
+        </list>
+        <procedure>
+            <step>
+                導航至
+                <Path>src/main/kotlin</Path>
+                中的
+                <Path>Routing.kt</Path>
+                檔案。
+            </step>
+            <step>
+                <p>
+                    在 <code>.configureRouting()</code> 方法中新增以下 <code>post</code> 請求路由：
+                </p>
+                <code-block lang="kotlin" code="            post {&#10;                val formContent = call.receiveParameters()&#10;                val params = Triple(&#10;                    formContent[&quot;name&quot;] ?: &quot;&quot;,&#10;                    formContent[&quot;description&quot;] ?: &quot;&quot;,&#10;                    formContent[&quot;priority&quot;] ?: &quot;&quot;&#10;                )&#10;                if (params.toList().any { it.isEmpty() }) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                    return@post&#10;                }&#10;                try {&#10;                    val priority = Priority.valueOf(params.third)&#10;                    TaskRepository.addTask(&#10;                        Task(&#10;                            params.first,&#10;                            params.second,&#10;                            priority&#10;                        )&#10;                    )&#10;                    val tasks = TaskRepository.allTasks()&#10;                    call.respond(&#10;                        ThymeleafContent(&quot;all-tasks&quot;, mapOf(&quot;tasks&quot; to tasks))&#10;                    )&#10;                } catch (ex: IllegalArgumentException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                } catch (ex: IllegalStateException) {&#10;                    call.respond(HttpStatusCode.BadRequest)&#10;                }&#10;            }"/>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，點擊重新執行按鈕 (<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="IntelliJ IDEA 重新執行圖示"/>) 以重新啟動應用程式。
+                </p>
+            </step>
+            <step>
+                在瀏覽器中導航至 <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a>。
+            </step>
+            <step>
+                <p>
+                    在
+                    <control>Create or edit a task</control>
+                    表單中輸入新任務詳細資訊。
+                </p>
+                <img src="server_create_web_app_new_task.png"
+                     alt="顯示 HTML 表單的 Web 瀏覽器" border-effect="rounded" width="706"/>
+            </step>
+            <step>
+                <p>點擊
+                    <control>Submit</control>
+                    按鈕以提交表單。
+                    接著您將看到新任務顯示在所有任務的清單中：
+                </p>
+                <img src="server_create_web_app_new_task_added.png"
+                     alt="顯示任務清單的 Web 瀏覽器" border-effect="rounded" width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="後續步驟" id="next-steps">
+        <p>
+            恭喜！您現在已完成將 Task Manager 重建為 Web 應用程式，並學習了如何使用 Thymeleaf 範本。</p>
+        <p>
+            繼續閱讀<Links href="//server-create-websocket-application" summary="瞭解如何利用 WebSockets 的強大功能來傳送與接收內容。">下一個教學</Links>，瞭解如何處理 Web Sockets。
+        </p>
+    </chapter>
+</topic>

--- a/docs/zh-Hant/ktor/server-create-websocket-application.md
+++ b/docs/zh-Hant/ktor/server-create-websocket-application.md
@@ -1,0 +1,449 @@
+<topic xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       title="使用 Ktor 在 Kotlin 中建立 WebSocket 應用程式" id="server-create-websocket-application">
+    <show-structure for="chapter" depth="2"/>
+    <tldr>
+        <var name="example_name" value="tutorial-server-websockets"/>
+        <p>
+            <b>程式碼範例</b>：
+            <a href="https://github.com/ktorio/ktor-documentation/tree/main/codeSnippets/snippets/%example_name%">
+                %example_name%
+            </a>
+        </p>
+        <p>
+            <b>使用的外掛程式</b>：<Links href="//server-static-content" summary="了解如何提供靜態內容，例如樣式表、指令碼、圖片等。">靜態內容 (Static Content)</Links>、
+            <Links href="//server-serialization" summary="Content Negotiation 外掛程式有兩個主要目的：交涉用戶端與伺服器之間的媒體類型，以及將內容以特定格式進行序列化/反序列化。">內容交涉 (Content Negotiation)</Links>、<Links href="//server-websockets" summary="Websockets 外掛程式允許你在伺服器與用戶端之間建立多向通訊工作階段。">Ktor Server 中的 WebSockets</Links>、
+            <a href="https://kotlinlang.org/api/kotlinx.serialization/">kotlinx.serialization</a>
+        </p>
+    </tldr>
+    <card-summary>
+        了解如何利用 WebSockets 的強大功能來傳送與接收內容。
+    </card-summary>
+    <link-summary>
+        了解如何利用 WebSockets 的強大功能來傳送與接收內容。
+    </link-summary>
+    <web-summary>
+        了解如何使用 Ktor 在 Kotlin 中建置 WebSocket 應用程式。本教學將引導你完成透過 WebSockets 將後端服務與用戶端連接的過程。
+    </web-summary>
+    <p>
+        本文將引導你完成使用 Ktor 在 Kotlin 中建立 WebSocket 應用程式的過程。它建立在 <Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 建置後端服務，其中包含一個產生 JSON 檔案的 RESTful API 範例。">建立 RESTful API</Links> 教學所涵蓋的內容之上。
+    </p>
+    <p>本文將教你如何執行以下操作：</p>
+    <list>
+        <li>建立使用 JSON 序列化的服務。</li>
+        <li>透過 WebSocket 連線傳送與接收內容。</li>
+        <li>同時向多個用戶端廣播內容。</li>
+    </list>
+    <chapter title="先決條件" id="prerequisites">
+        <p>你可以獨立完成此教學，但我們建議你先完成
+            <Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 建置後端服務，其中包含一個產生 JSON 檔案的 RESTful API 範例。">建立 RESTful API</Links> 教學，以熟悉 <Links href="//server-serialization" summary="Content Negotiation 外掛程式有兩個主要目的：交涉用戶端與伺服器之間的媒體類型，以及將內容以特定格式進行序列化/反序列化。">內容交涉</Links> 與 REST。
+        </p>
+        <p>我們建議你安裝 <a href="https://www.jetbrains.com/help/idea/installation-guide.html">IntelliJ
+            IDEA</a>，但你也可以使用其他偏好的 IDE。
+        </p>
+    </chapter>
+    <chapter title="Hello WebSockets" id="hello-websockets">
+        <p>
+            在本教學中，你將基於 <Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 建置後端服務，其中包含一個產生 JSON 檔案的 RESTful API 範例。">建立 RESTful API</Links> 教學中開發的工作管理器服務，透過 WebSocket 連線增加與用戶端交換 <code>Task</code> 物件的功能。為了實現這一點，你需要加入 <Links href="//server-websockets" summary="Websockets 外掛程式允許你在伺服器與用戶端之間建立多向通訊工作階段。">WebSockets 外掛程式</Links>。雖然你可以手動將其加入現有專案，但為了本教學，你將從頭開始建立一個新專案。
+        </p>
+        <chapter title="使用外掛程式建立初始專案" id="create=project">
+            <procedure>
+                <step>
+                    <p>
+                        導覽至
+                        <a href="https://start.ktor.io/">Ktor 專案產生器</a>。
+                    </p>
+                </step>
+                <step>
+                    <p>在
+                        <control>Project artifact</control>
+                        欄位中，輸入
+                        <Path>com.example.ktor-websockets-task-app</Path>
+                        作為專案構件的名稱。
+                        <img src="tutorial_server_websockets_project_artifact.png"
+                             alt="在 Ktor 專案產生器中命名專案構件"
+                             border-effect="line"
+                             style="block"
+                             width="706"/>
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        在外掛程式區段搜尋並點擊
+                        <control>Add</control>
+                        按鈕來加入以下外掛程式：
+                    </p>
+                    <list type="bullet">
+                        <li>Content Negotiation</li>
+                        <li>kotlinx.serialization</li>
+                        <li>WebSockets</li>
+                        <li>Static Content</li>
+                    </list>
+                    <p>
+                        <img src="ktor_project_generator_add_plugins.gif"
+                             alt="在 Ktor 專案產生器中加入外掛程式"
+                             border-effect="line"
+                             style="block"
+                             width="706"/>
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        加入外掛程式後，它們將顯示在外掛程式區段的右上角。
+                    </p>
+                    <p>你將看到所有即將加入專案的外掛程式清單：
+                        <img src="tutorial_server_websockets_project_plugins.png"
+                             alt="Ktor 專案產生器中的外掛程式清單"
+                             border-effect="line"
+                             style="block"
+                             width="706"/>
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        點擊
+                        <control>Download</control>
+                        按鈕來產生並下載你的 Ktor 專案。
+                    </p>
+                </step>
+            </procedure>
+        </chapter>
+        <chapter title="加入起始程式碼" id="add-starter-code">
+            <p>下載完成後，在 IntelliJ IDEA 中開啟專案並遵循以下步驟：</p>
+            <procedure>
+                <step>
+                    導覽至
+                    <Path>src/main/kotlin</Path>
+                    並建立一個名為
+                    <Path>model</Path>
+                    的新子套件。
+                </step>
+                <step>
+                    <p>
+                        在
+                        <Path>model</Path>
+                        套件內建立一個新的
+                        <Path>Task.kt</Path>
+                        檔案。
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        開啟
+                        <Path>Task.kt</Path>
+                        檔案並加入一個 <code>enum</code> 來表示優先級，以及一個 <code>data class</code> 來表示任務：
+                    </p>
+                    <code-block lang="kotlin" code="package com.example.model&#10;&#10;import kotlinx.serialization.Serializable&#10;&#10;enum class Priority {&#10;    Low, Medium, High, Vital&#10;}&#10;&#10;@Serializable&#10;data class Task(&#10;    val name: String,&#10;    val description: String,&#10;    val priority: Priority&#10;)"/>
+                    <p>
+                        請注意，<code>Task</code> 類別標記了來自 <code>kotlinx.serialization</code> 程式庫的 <code>Serializable</code> 註解。這意味著執行個體可以與 JSON 互相轉換，從而允許其內容在網路上傳輸。
+                    </p>
+                    <p>
+                        因為你包含了 WebSockets 外掛程式，產生器已在
+                        <Path>src/main/kotlin</Path>
+                        內的
+                        <Path>Webwebsockets.kt</Path>
+                        檔案中加入了一個 <code>webSocket</code> 路由，並在
+                        <Path>Routing.kt</Path> 檔案中加入了相關設定。
+                    </p>
+                </step>
+                <step>
+                    開啟
+                    <Path>Webwebsockets.kt</Path>
+                    檔案，並將現有的 <code>.configureWebsockets()</code> 函式替換為以下內容：
+                    <code-block lang="kotlin" code="                        fun Application.configureWebsockets() {&#10;                            install(WebSockets) {&#10;                                contentConverter = KotlinxWebsocketSerializationConverter(Json)&#10;                                pingPeriod = 15.seconds&#10;                                timeout = 15.seconds&#10;                                maxFrameSize = Long.MAX_VALUE&#10;                                masking = false&#10;                            }&#10;                        }"/>
+                    <list>
+                        <li>安裝 WebSockets 外掛程式並使用標準設定進行配置。</li>
+                        <li>設定 <code>contentConverter</code> 屬性，使外掛程式能夠透過 <a
+                                    href="https://github.com/Kotlin/kotlinx.serialization"><code>kotlinx.serialization</code></a> 程式庫序列化傳送與接收的物件。
+                        </li>
+                    </list>
+                </step>
+                <step>
+                    <p>
+                        開啟
+                        <Path>Routing.kt</Path>
+                        檔案，並將現有的 <code>Application.configureRouting()</code> 函式替換為下方的實作：
+                    </p>
+                    <code-block lang="kotlin" code="                    fun Application.configureRouting() {&#10;                        routing {&#10;                            webSocket(&quot;/tasks&quot;) {&#10;                                val tasks = listOf(&#10;                                    Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;                                    Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;                                    Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;                                    Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;                                )&#10;&#10;                                for (task in tasks) {&#10;                                    sendSerialized(task)&#10;                                    delay(1000.milliseconds)&#10;                                }&#10;&#10;                                close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;                            }&#10;                            staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;                        }&#10;                    }"/>
+                    <list>
+                        <li>路由配置了單一端點，相對 URL 為 <code>/tasks</code>。
+                        </li>
+                        <li>收到請求後，任務清單會透過 WebSocket 連線序列化傳送。</li>
+                        <li>所有項目傳送完畢後，伺服器會關閉連線。</li>
+                    </list>
+                    <p>
+                        為了示範目的，在傳送任務之間引入了一秒鐘的延遲。這讓你可以觀察到任務在用戶端中逐一出現。若沒有這個延遲，此範例看起來會與先前文章中開發的 <Links href="//server-create-restful-apis" summary="了解如何使用 Kotlin 和 Ktor 建置後端服務，其中包含一個產生 JSON 檔案的 RESTful API 範例。">RESTful 服務</Links> 以及 <Links href="//server-create-website" summary="了解如何使用 Kotlin、Ktor 和 Thymeleaf 範本建置網站。">Web 應用程式</Links> 完全相同。
+                    </p>
+                    <p>
+                        此階段的最後一步是為此端點建立一個用戶端。因為你包含了
+                        <Links href="//server-static-content" summary="了解如何提供靜態內容，例如樣式表、指令碼、圖片等。">靜態內容</Links> 外掛程式，Ktor 專案產生器已在
+                        <Path>src/main/resources/static</Path>
+                        內加入了一個
+                        <Path>index.html</Path>
+                        檔案。
+                    </p>
+                </step>
+                <step>
+                    <p>
+                        開啟
+                        <Path>index.html</Path>
+                        檔案，並將現有內容替換為以下內容：
+                    </p>
+                    <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;Using Ktor WebSockets&lt;/title&gt;&#10;    &lt;script&gt;&#10;        function readAndDisplayAllTasks() {&#10;            clearTable();&#10;&#10;            const serverURL = 'ws://0.0.0.0:8080/tasks';&#10;            const socket = new WebSocket(serverURL);&#10;&#10;            socket.onopen = logOpenToConsole;&#10;            socket.onclose = logCloseToConsole;&#10;            socket.onmessage = readAndDisplayTask;&#10;        }&#10;&#10;        function readAndDisplayTask(event) {&#10;            let task = JSON.parse(event.data);&#10;            logTaskToConsole(task);&#10;            addTaskToTable(task);&#10;        }&#10;&#10;        function logTaskToConsole(task) {&#10;            console.log(`Received ${task.name}`);&#10;        }&#10;&#10;        function logCloseToConsole() {&#10;            console.log(&quot;Web socket connection closed&quot;);&#10;        }&#10;&#10;        function logOpenToConsole() {&#10;            console.log(&quot;Web socket connection opened&quot;);&#10;        }&#10;&#10;        function tableBody() {&#10;            return document.getElementById(&quot;tasksTableBody&quot;);&#10;        }&#10;&#10;        function clearTable() {&#10;            tableBody().innerHTML = &quot;&quot;;&#10;        }&#10;&#10;        function addTaskToTable(task) {&#10;            tableBody().appendChild(taskRow(task));&#10;        }&#10;&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body&gt;&#10;&lt;h1&gt;Viewing Tasks Via WebSockets&lt;/h1&gt;&#10;&lt;form action=&quot;javascript:readAndDisplayAllTasks()&quot;&gt;&#10;    &lt;input type=&quot;submit&quot; value=&quot;View The Tasks&quot;&gt;&#10;&lt;/form&gt;&#10;&lt;table rules=&quot;all&quot;&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+                    <p>
+                        此頁面使用了所有現代瀏覽器都提供的 <a href="https://websockets.spec.whatwg.org//#websocket"><code>WebSocket</code> 類型</a>。你在 JavaScript 中建立此物件，並將端點的 URL 傳遞給建構函式。隨後，你為 <code>onopen</code>、<code>onclose</code> 和 <code>onmessage</code> 事件附加事件處理常式。觸發 <code>onmessage</code> 事件時，你會使用文件物件的方法向表格附加一行。
+                    </p>
+                </step>
+                <step>
+                    <p>在 IntelliJ IDEA 中，點擊執行按鈕
+                        (<img src="intellij_idea_gutter_icon.svg"
+                              style="inline" height="16" width="16"
+                              alt="intelliJ IDEA 執行圖示"/>)
+                        來啟動應用程式。</p>
+                </step>
+                <step>
+                    <p>
+                        導覽至 <a href="http://0.0.0.0:8080/static/index.html">http://0.0.0.0:8080/static/index.html</a>。你應該會看到一個包含按鈕的表單和一個空表格：
+                    </p>
+                    <img src="tutorial_server_websockets_iteration_1.png"
+                         alt="顯示一個包含單一按鈕的 HTML 表單的網頁瀏覽器頁面"
+                         border-effect="rounded"
+                         width="706"/>
+                    <p>
+                        點擊表單後，任務會從伺服器載入，並以每秒一個的速度出現。因此，表格會逐次填入內容。你也可以透過開啟瀏覽器 <control>開發者工具</control> 中的 <control>JavaScript 控制台</control> 來查看記錄訊息。
+                    </p>
+                    <img src="tutorial_server_websockets_iteration_1_click.gif"
+                         alt="網頁瀏覽器頁面在點擊按鈕時顯示清單項目"
+                         border-effect="rounded"
+                         width="706"/>
+                    <p>
+                        至此，該服務運作符合預期。WebSocket 連線已開啟，項目被傳送至用戶端，隨後連線關閉。底層網路存在許多複雜性，但 Ktor 預設處理了所有這些細節。
+                    </p>
+                </step>
+            </procedure>
+        </chapter>
+    </chapter>
+    <chapter title="理解 WebSockets" id="understanding-websockets">
+        <p>
+            在進入下一個階段之前，回顧 WebSockets 的一些基本概念可能會有所幫助。如果你已經熟悉 WebSockets，可以直接繼續 <a href="#improve-design">改進你的服務設計</a>。
+        </p>
+        <p>
+            在先前的教學中，你的用戶端傳送 HTTP 請求並接收 HTTP 回應。這種模式運作良好，並使網際網路具備擴展性與韌性。
+        </p>
+        <p>然而，它不適用於以下情境：</p>
+        <list>
+            <li>內容是隨著時間推移增量產生的。</li>
+            <li>內容隨事件頻繁變更。</li>
+            <li>用戶端需要在產生內容時與伺服器互動。</li>
+            <li>一個用戶端傳送的資料需要迅速傳播給其他用戶端。</li>
+        </list>
+        <p>
+            這些情境的範例包括股票交易、購買電影和音樂會門票、線上拍賣競標，以及社群媒體中的聊天功能。WebSockets 的開發就是為了處理這些情況。
+        </p>
+        <p>
+            WebSocket 連線建立在 TCP 之上，且可以持續較長時間。該連線提供 <emphasis>全雙工通訊</emphasis>，這意味著用戶端可以同時向伺服器傳送訊息並從中接收訊息。
+        </p>
+        <p>
+            WebSocket API 定義了四種事件（open、message、close 和 error）以及兩種操作（send 和 close）。如何存取這些功能可能因不同的語言和程式庫而異。例如，在 Kotlin 中，你可以將傳入訊息序列視為 <a
+                href="https://kotlinlang.org/docs/flow.html"><code>Flow</code></a> 來處理。
+        </p>
+    </chapter>
+    <chapter title="改進設計" id="improve-design">
+        <p>接下來，你將重構現有程式碼，為更進階的範例騰出空間。</p>
+        <procedure>
+            <step>
+                <p>
+                    在
+                    <Path>model</Path>
+                    套件中，建立一個新的
+                    <Path>TaskRepository.kt</Path>
+                    檔案。
+                </p>
+            </step>
+            <step>
+                <p>
+                    開啟
+                    <Path>TaskRepository.kt</Path>
+                    並加入 <code>TaskRepository</code> 類型：
+                </p>
+                <code-block lang="kotlin" code="package com.example.model&#10;&#10;object TaskRepository {&#10;    private val tasks = mutableListOf(&#10;        Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;        Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;        Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;        Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;    )&#10;&#10;    fun allTasks(): List&lt;Task&gt; = tasks&#10;&#10;    fun tasksByPriority(priority: Priority) = tasks.filter {&#10;        it.priority == priority&#10;    }&&#10;&#10;    fun taskByName(name: String) = tasks.find {&#10;        it.name.equals(name, ignoreCase = true)&#10;    }&#10;&#10;    fun addTask(task: Task) {&#10;        if (taskByName(task.name) != null) {&#10;            throw IllegalStateException(&quot;Cannot duplicate task names!&quot;)&#10;        }&#10;        tasks.add(task)&#10;    }&#10;&#10;    fun removeTask(name: String): Boolean {&#10;        return tasks.removeIf { it.name == name }&#10;    }&#10;}"/>
+                <p>你可能還記得先前教學中的這段程式碼。</p>
+            </step>
+            <step>
+                導覽至
+                <Path>src/main/kotlin</Path>
+                並開啟
+                <Path>Routing.kt</Path>
+                檔案。
+            </step>
+            <step>
+                <p>
+                    你現在可以透過利用 <code>TaskRepository</code> 來簡化 <code>Application.configureRouting()</code> 中的路由：
+                </p>
+                <code-block lang="kotlin" code="                    routing {&#10;                        webSocket(&quot;/tasks&quot;) {&#10;                            for (task in TaskRepository.allTasks()) {&#10;                                sendSerialized(task)&#10;                                delay(1000.milliseconds)&#10;                            }&#10;                            close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;                        }&#10;                        // ...&#10;                    }"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="透過 WebSockets 傳送訊息" id="send-messages">
+        <p>
+            為了說明 WebSockets 的強大功能，你將建立一個新的端點，其中：
+        </p>
+        <list>
+            <li>
+                當用戶端啟動時，它會接收所有現有任務。
+            </li>
+            <li>
+                用戶端可以建立並傳送任務。
+            </li>
+            <li>
+                當一個用戶端傳送任務時，其他用戶端會收到通知。
+            </li>
+        </list>
+        <procedure>
+            <step>
+                <p>
+                    在
+                    <Path>Routing.kt</Path>
+                    檔案中，將目前的 <code>.configureRouting()</code> 方法替換為下方的實作：
+                </p>
+                <code-block lang="kotlin" code="fun Application.configureRouting() {&#10;    routing {&#10;        val sessions =&#10;            Collections.synchronizedList&lt;WebSocketServerSession&gt;(ArrayList())&#10;&#10;        webSocket(&quot;/tasks&quot;) {&#10;            sendAllTasks()&#10;            close(CloseReason(CloseReason.Codes.NORMAL, &quot;All done&quot;))&#10;        }&#10;&#10;        webSocket(&quot;/tasks2&quot;) {&#10;            sessions.add(this)&#10;            sendAllTasks()&#10;&#10;            while(true) {&#10;                ensureActive()&#10;                val newTask = receiveDeserialized&lt;Task&gt;()&#10;                TaskRepository.addTask(newTask)&#10;                for(session in sessions) {&#10;                    session.sendSerialized(newTask)&#10;                }&#10;            }&#10;        }&#10;        staticResources(&quot;/static&quot;, &quot;static&quot;)&#10;    }&#10;}&#10;&#10;private suspend fun DefaultWebSocketServerSession.sendAllTasks() {&#10;    for (task in TaskRepository.allTasks()) {&#10;        sendSerialized(task)&#10;        delay(1000.milliseconds)&#10;    }&#10;}"/>
+                <p>透過這段程式碼，你完成了以下操作：</p>
+                <list>
+                    <li>
+                        將傳送所有現有任務的功能重構為一個輔助方法。
+                    </li>
+                    <li>
+                        在 <code>routing {}</code> 區塊中，建立了一個執行緒安全的 <code>session</code> 物件清單，用以追蹤所有用戶端。
+                    </li>
+                    <li>
+                        加入了一個相對 URL 為 <code>/tasks2</code> 的新端點。當用戶端連接到此端點時，對應的 <code>session</code> 物件會被加入清單。伺服器隨後進入無限迴圈，等待接收新任務。收到新任務後，伺服器將其存儲在存儲庫中，並向所有用戶端（包括當前用戶端）發送複本。
+                    </li>
+                </list>
+                <p>
+                    為了測試此功能，你將建立一個新頁面，擴充
+                    <Path>index.html</Path>
+                    中的功能。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在
+                    <Path>src/main/resources/static</Path>
+                    中建立一個名為
+                    <Path>wsClient.html</Path>
+                    的新 HTML 檔案。
+                </p>
+            </step>
+            <step>
+                <p>
+                    開啟
+                    <Path>wsClient.html</Path>
+                    並加入以下內容：
+                </p>
+                <code-block lang="html" code="&lt;html&gt;&#10;&lt;head&gt;&#10;    &lt;title&gt;WebSocket Client&lt;/title&gt;&#10;    &lt;script&gt;&#10;        let serverURL;&#10;        let socket;&#10;&#10;        function setupSocket() {&#10;            serverURL = 'ws://0.0.0.0:8080/tasks2';&#10;            socket = new WebSocket(serverURL);&#10;&#10;            socket.onopen = logOpenToConsole;&#10;            socket.onclose = logCloseToConsole;&#10;            socket.onmessage = readAndDisplayTask;&#10;        }&#10;&#10;        function readAndDisplayTask(event) {&#10;            let task = JSON.parse(event.data);&#10;            logTaskToConsole(task);&#10;            addTaskToTable(task);&#10;        }&#10;&#10;        function logTaskToConsole(task) {&#10;            console.log(`Received ${task.name}`);&#10;        }&#10;&#10;        function logCloseToConsole() {&#10;            console.log(&quot;Web socket connection closed&quot;);&#10;        }&#10;&#10;        function logOpenToConsole() {&#10;            console.log(&quot;Web socket connection opened&quot;);&#10;        }&#10;&#10;        function tableBody() {&#10;            return document.getElementById(&quot;tasksTableBody&quot;);&#10;        }&#10;&#10;        function addTaskToTable(task) {&#10;            tableBody().appendChild(taskRow(task));&#10;        }&#10;&#10;        function taskRow(task) {&#10;            return tr([&#10;                td(task.name),&#10;                td(task.description),&#10;                td(task.priority)&#10;            ]);&#10;        }&#10;&#10;        function tr(children) {&#10;            const node = document.createElement(&quot;tr&quot;);&#10;            children.forEach(child =&gt; node.appendChild(child));&#10;            return node;&#10;        }&#10;&#10;        function td(text) {&#10;            const node = document.createElement(&quot;td&quot;);&#10;            node.appendChild(document.createTextNode(text));&#10;            return node;&#10;        }&#10;&#10;        function getFormValue(name) {&#10;            return document.forms[0][name].value&#10;        }&#10;&#10;        function buildTaskFromForm() {&#10;            return {&#10;                name: getFormValue(&quot;newTaskName&quot;),&#10;                description: getFormValue(&quot;newTaskDescription&quot;),&#10;                priority: getFormValue(&quot;newTaskPriority&quot;)&#10;            }&#10;        }&#10;&#10;        function logSendingToConsole(data) {&#10;            console.log(&quot;About to send&quot;,data);&#10;        }&#10;&#10;        function sendTaskViaSocket(data) {&#10;            socket.send(JSON.stringify(data));&#10;        }&#10;&#10;        function sendTaskToServer() {&#10;            let data = buildTaskFromForm();&#10;            logSendingToConsole(data);&#10;            sendTaskViaSocket(data);&#10;            //prevent form submission&#10;            return false;&#10;        }&#10;    &lt;/script&gt;&#10;&lt;/head&gt;&#10;&lt;body onload=&quot;setupSocket()&quot;&gt;&#10;&lt;h1&gt;Viewing Tasks Via WebSockets&lt;/h1&gt;&#10;&lt;table rules=&quot;all&quot;&gt;&#10;    &lt;thead&gt;&#10;    &lt;tr&gt;&#10;        &lt;th&gt;Name&lt;/th&gt;&lt;th&gt;Description&lt;/th&gt;&lt;th&gt;Priority&lt;/th&gt;&#10;    &lt;/tr&gt;&#10;    &lt;/thead&gt;&#10;    &lt;tbody id=&quot;tasksTableBody&quot;&gt;&#10;    &lt;/tbody&gt;&#10;&lt;/table&gt;&#10;&lt;div&gt;&#10;    &lt;h3&gt;Create a new task&lt;/h3&gt;&#10;    &lt;form onsubmit=&quot;return sendTaskToServer()&quot;&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskName&quot;&gt;Name: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;newTaskName&quot;&#10;                   name=&quot;newTaskName&quot; size=&quot;10&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskDescription&quot;&gt;Description: &lt;/label&gt;&#10;            &lt;input type=&quot;text&quot; id=&quot;newTaskDescription&quot;&#10;                   name=&quot;newTaskDescription&quot; size=&quot;20&quot;&gt;&#10;        &lt;/div&gt;&#10;        &lt;div&gt;&#10;            &lt;label for=&quot;newTaskPriority&quot;&gt;Priority: &lt;/label&gt;&#10;            &lt;select id=&quot;newTaskPriority&quot; name=&quot;newTaskPriority&quot;&gt;&#10;                &lt;option name=&quot;Low&quot;&gt;Low&lt;/option&gt;&#10;                &lt;option name=&quot;Medium&quot;&gt;Medium&lt;/option&gt;&#10;                &lt;option name=&quot;High&quot;&gt;High&lt;/option&gt;&#10;                &lt;option name=&quot;Vital&quot;&gt;Vital&lt;/option&gt;&#10;            &lt;/select&gt;&#10;        &lt;/div&gt;&#10;        &lt;input type=&quot;submit&quot;&gt;&#10;    &lt;/form&gt;&#10;&lt;/div&gt;&#10;&lt;/body&gt;&#10;&lt;/html&gt;"/>
+                <p>
+                    這個新頁面引入了一個 HTML 表單，使用者可以在其中輸入新任務的資訊。提交表單後，會呼叫 <code>sendTaskToServer()</code> 事件處理常式。這會使用表單資料建立一個 JavaScript 物件，並使用 WebSocket 物件的 <code>.send()</code> 方法將其傳送至伺服器。
+                </p>
+            </step>
+            <step>
+                <p>
+                    在 IntelliJ IDEA 中，點擊重新執行按鈕 (<img src="intellij_idea_rerun_icon.svg"
+                                                                   style="inline" height="16" width="16"
+                                                                   alt="intelliJ IDEA 重新執行圖示"/>) 來重新啟動應用程式。
+                </p>
+            </step>
+            <step>
+                <p>要測試此功能，請並排開啟兩個瀏覽器並遵循以下步驟。</p>
+                <list type="decimal">
+                    <li>
+                        在瀏覽器 A 中，導覽至
+                        <a href="http://0.0.0.0:8080/static/wsClient.html">http://0.0.0.0:8080/static/wsClient.html</a>。你應該會看到顯示預設任務。
+                    </li>
+                    <li>
+                        在瀏覽器 A 中加入一個新任務。新任務應該會出現在該頁面的表格中。
+                    </li>
+                    <li>
+                        在瀏覽器 B 中，導覽至
+                        <a href="http://0.0.0.0:8080/static/wsClient.html">http://0.0.0.0:8080/static/wsClient.html</a>。你應該會看到預設任務，以及你在瀏覽器 A 中加入的任何新任務。
+                    </li>
+                    <li>
+                        在任一瀏覽器中加入任務。你應該會看到新項目同時出現在兩個頁面上。
+                    </li>
+                </list>
+                <img src="tutorial_server_websockets_iteration_2_test.gif"
+                     alt="兩個並排顯示的網頁瀏覽器頁面，示範透過 HTML 表單建立新任務"
+                     border-effect="rounded"
+                     width="706"/>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="加入自動化測試" id="add-automated-tests">
+        <p>
+            為了簡化你的品質保證 (QA) 流程並使其快速、可重現且自動化，你可以使用 Ktor 內建的 <Links href="//server-testing" summary="了解如何使用特殊的測試引擎測試你的伺服器應用程式。">自動化測試支援</Links>。請遵循以下步驟：
+        </p>
+        <procedure>
+            <step>
+                <p>
+                    將以下相依性加入
+                    <Path>build.gradle.kts</Path>，以便你在 Ktor Client 中配置對 <Links href="//server-serialization" summary="Content Negotiation 外掛程式有兩個主要目的：交涉用戶端與伺服器之間的媒體類型，以及將內容以特定格式進行序列化/反序列化。">內容交涉</Links> 的支援：
+                </p>
+                <code-block lang="kotlin" code="    testImplementation(ktorLibs.client.contentNegotiation)"/>
+            </step>
+            <step>
+                <p>
+                    <p>在 IntelliJ IDEA 中，點擊編輯器右側的 Gradle 通知圖示
+                        (<img alt="intelliJ IDEA gradle 圖示"
+                              src="intellij_idea_gradle_icon.svg" width="16" height="26"/>)
+                        來載入 Gradle 變更。</p>
+                </p>
+            </step>
+            <step>
+                <p>
+                    導覽至
+                    <Path>src/test/kotlin</Path>
+                    並開啟
+                    <Path>ServerTest.kt</Path>
+                    檔案。
+                </p>
+            </step>
+            <step>
+                <p>
+                    將產生的測試類別替換為下方的實作：
+                </p>
+                <code-block lang="kotlin" code="import com.example.model.Priority&#10;import com.example.model.Task&#10;import io.ktor.client.plugins.contentnegotiation.ContentNegotiation&#10;import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession&#10;import io.ktor.client.plugins.websocket.WebSockets&#10;import io.ktor.client.plugins.websocket.converter&#10;import io.ktor.client.plugins.websocket.webSocket&#10;import io.ktor.serialization.deserialize&#10;import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter&#10;import io.ktor.serialization.kotlinx.json.json&#10;import io.ktor.server.testing.testApplication&#10;import kotlinx.coroutines.flow.consumeAsFlow&#10;import kotlinx.coroutines.flow.map&#10;import kotlinx.coroutines.flow.scan&#10;import kotlinx.serialization.json.Json&#10;import kotlin.test.Test&#10;import kotlin.test.assertEquals&#10;&#10;class ServerTest {&#10;    @Test&#10;    fun testRoot() = testApplication {&#10;        configure()&#10;&#10;        val client = createClient {&#10;            install(ContentNegotiation) {&#10;                json()&#10;            }&#10;            install(WebSockets) {&#10;                contentConverter =&#10;                    KotlinxWebsocketSerializationConverter(Json)&#10;            }&#10;        }&#10;&#10;        val expectedTasks = listOf(&#10;            Task(&quot;cleaning&quot;, &quot;Clean the house&quot;, Priority.Low),&#10;            Task(&quot;gardening&quot;, &quot;Mow the lawn&quot;, Priority.Medium),&#10;            Task(&quot;shopping&quot;, &quot;Buy the groceries&quot;, Priority.High),&#10;            Task(&quot;painting&quot;, &quot;Paint the fence&quot;, Priority.Medium)&#10;        )&#10;        var actualTasks = emptyList&lt;Task&gt;()&#10;&#10;        client.webSocket(&quot;/tasks&quot;) {&#10;            consumeTasksAsFlow().collect { allTasks -&gt;&#10;                actualTasks = allTasks&#10;            }&#10;        }&#10;&#10;        assertEquals(expectedTasks.size, actualTasks.size)&#10;        expectedTasks.forEachIndexed { index, task -&gt;&#10;            assertEquals(task, actualTasks[index])&#10;        }&#10;    }&#10;&#10;    private fun DefaultClientWebSocketSession.consumeTasksAsFlow() = incoming&#10;        .consumeAsFlow()&#10;        .map {&#10;            converter!!.deserialize&lt;Task&gt;(it)&#10;        }&#10;        .scan(emptyList&lt;Task&gt;()) { list, task -&gt;&#10;            list + task&#10;        }&#10;}"/>
+                <p>
+                    透過此設定，你：
+                </p>
+                <list>
+                    <li>
+                        配置你的服務在測試環境中執行，並啟用與生產環境相同的功能，包括 JSON 序列化與 WebSockets。
+                    </li>
+                    <li>
+                        在 <Links href="//client-create-and-configure" summary="了解如何建立與配置 Ktor 用戶端。">Ktor Client</Links> 中配置內容交涉與 WebSocket 支援。若沒有這些，用戶端在使用 WebSocket 連線時將不知道如何進行物件的 JSON (反)序列化。
+                    </li>
+                    <li>
+                        宣告你期望服務回傳的 <code>Tasks</code> 清單。
+                    </li>
+                    <li>
+                        使用 <code>client</code> 物件的 <code>.webSocket</code> 函式向 <code>/tasks</code> 傳送請求。
+                    </li>
+                    <li>
+                        將傳入的任務作為 <code>Flow</code> 處理，並將其逐一加入清單。
+                    </li>
+                    <li>
+                        在接收到所有任務後，以通常的方式比較 <code>expectedTasks</code> 與 <code>actualTasks</code>。
+                    </li>
+                </list>
+            </step>
+        </procedure>
+    </chapter>
+    <chapter title="後續步驟" id="next-steps">
+        <p>
+            做得好！透過結合 WebSocket 通訊與 Ktor Client 的自動化測試，你已顯著增強了工作管理器服務。
+        </p>
+        <p>
+            繼續閱讀
+            <Links href="//server-integrate-database" summary="了解如何使用 Exposed SQL 程式庫將 Ktor 服務連接到資料庫存儲庫。">下一篇教學</Links>，探索你的服務如何使用 Exposed 程式庫無縫地與關聯式資料庫互動。
+        </p>
+    </chapter>
+</topic>

--- a/docs/zh-Hant/ktor/server-dependencies.md
+++ b/docs/zh-Hant/ktor/server-dependencies.md
@@ -1,0 +1,228 @@
+<topic xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       title="新增伺服器相依性"
+       id="server-dependencies" help-id="Gradle">
+    <show-structure for="chapter" depth="2"/>
+    <link-summary>了解如何將 Ktor Server 相依性新增至現有的 Gradle/Maven 專案。</link-summary>
+    <p>
+        在本主題中，我們將向您展示如何將 Ktor Server 所需的相依性新增至現有的
+        Gradle/Maven 專案。
+    </p>
+    <chapter title="設定存儲庫" id="repositories">
+        <p>
+            在新增 Ktor 相依性之前，您需要為此專案設定存儲庫：
+        </p>
+        <list>
+            <li>
+                <p>
+                    <control>生產版本</control>
+                </p>
+                <p>
+                    Ktor 的生產版本可在 Maven 中央存儲庫中取得。
+                    您可以在建置指令碼中宣告此存儲庫，如下所示：
+                </p>
+                <Tabs group="languages">
+                    <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                        <code-block lang="Kotlin" code="                            repositories {&#10;                                mavenCentral()&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Gradle (Groovy)" group-key="groovy">
+                        <code-block lang="Groovy" code="                            repositories {&#10;                                mavenCentral()&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Maven" group-key="maven">
+                        <note>
+                            <p>
+                                您不需要在 <Path>pom.xml</Path> 檔案中新增 Maven 中央存儲庫，因為您的專案會從
+                                <a href="https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#super-pom">Super POM</a> 繼承中央存儲庫。
+                            </p>
+                        </note>
+                    </TabItem>
+                </Tabs>
+            </li>
+            <li>
+                <p>
+                    <control>早期體驗體計劃 (EAP)</control>
+                </p>
+                <p>
+                    要存取 Ktor 的 <a href="https://ktor.io/eap/">EAP</a> 版本，您需要參照 <a href="https://redirector.kotlinlang.org/maven/ktor-eap/io/ktor/">Space 存儲庫</a>：
+                </p>
+                <Tabs group="languages">
+                    <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                        <code-block lang="Kotlin" code="                            repositories {&#10;                                maven {&#10;                                    url = uri(&quot;https://redirector.kotlinlang.org/maven/ktor-eap&quot;)&#10;                                }&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Gradle (Groovy)" group-key="groovy">
+                        <code-block lang="Groovy" code="                            repositories {&#10;                                maven {&#10;                                    url &quot;https://redirector.kotlinlang.org/maven/ktor-eap&quot;&#10;                                }&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Maven" group-key="maven">
+                        <code-block lang="XML" code="                            &lt;repositories&gt;&#10;                                &lt;repository&gt;&#10;                                    &lt;id&gt;ktor-eap&lt;/id&gt;&#10;                                    &lt;url&gt;https://redirector.kotlinlang.org/maven/ktor-eap&lt;/url&gt;&#10;                                &lt;/repository&gt;&#10;                            &lt;/repositories&gt;"/>
+                    </TabItem>
+                </Tabs>
+                <p>
+                    請注意，Ktor EAP 可能需要 <a href="https://redirector.kotlinlang.org/maven/dev">Kotlin 開發存儲庫</a>：
+                </p>
+                <Tabs group="languages">
+                    <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                        <code-block lang="Kotlin" code="                            repositories {&#10;                                maven {&#10;                                    url = uri(&quot;https://redirector.kotlinlang.org/maven/dev&quot;)&#10;                                }&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Gradle (Groovy)" group-key="groovy">
+                        <code-block lang="Groovy" code="                            repositories {&#10;                                maven {&#10;                                    url &quot;https://redirector.kotlinlang.org/maven/dev&quot;&#10;                                }&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Maven" group-key="maven">
+                        <code-block lang="XML" code="                            &lt;repositories&gt;&#10;                                &lt;repository&gt;&#10;                                    &lt;id&gt;ktor-eap&lt;/id&gt;&#10;                                    &lt;url&gt;https://redirector.kotlinlang.org/maven/dev&lt;/url&gt;&#10;                                &lt;/repository&gt;&#10;                            &lt;/repositories&gt;"/>
+                    </TabItem>
+                </Tabs>
+            </li>
+        </list>
+    </chapter>
+    <chapter title="新增相依性" id="add-ktor-dependencies">
+        <chapter title="核心相依性" id="core-dependencies">
+            <p>
+                每個 Ktor 應用程式至少需要以下相依性：
+            </p>
+            <list>
+                <li>
+                    <p>
+                        <code>ktor-server-core</code>：包含核心 Ktor 功能。
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        一個<Links href="//server-engines" summary="了解處理網路請求的引擎。">引擎</Links>的相依性（例如 <code>ktor-server-netty</code>）。
+                    </p>
+                </li>
+            </list>
+            <p>
+                對於不同的平台，Ktor 提供特定平台的成品 (artifacts)，並帶有 <code>-jvm</code> 等後綴，例如 <code>ktor-server-core-jvm</code> 或 <code>ktor-server-netty-jvm</code>。
+                請注意，Gradle 會解析適合特定平台的成品，而 Maven 不支援此功能。
+                這意味著對於 Maven，您需要手動新增特定平台的後綴。
+                一個基礎 Ktor 應用程式的 <code>dependencies</code> 區塊可能如下所示：
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                        dependencies {&#10;                            implementation(&quot;io.ktor:ktor-server-core:%ktor_version%&quot;)&#10;                            implementation(&quot;io.ktor:ktor-server-netty:%ktor_version%&quot;)&#10;                        }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                        dependencies {&#10;                            implementation &quot;io.ktor:ktor-server-core:%ktor_version%&quot;&#10;                            implementation &quot;io.ktor:ktor-server-netty:%ktor_version%&quot;&#10;                        }"/>
+                </TabItem>
+                <TabItem title="Maven" group-key="maven">
+                    <code-block lang="XML" code="                        &lt;dependencies&gt;&#10;                            &lt;dependency&gt;&#10;                                &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                                &lt;artifactId&gt;ktor-server-core-jvm&lt;/artifactId&gt;&#10;                                &lt;version&gt;%ktor_version%&lt;/version&gt;&#10;                            &lt;/dependency&gt;&#10;                            &lt;dependency&gt;&#10;                                &lt;groupId&gt;io.ktor&lt;/groupId&gt;&#10;                                &lt;artifactId&gt;ktor-server-netty-jvm&lt;/artifactId&gt;&#10;                                &lt;version&gt;%ktor_version%&lt;/version&gt;&#10;                            &lt;/dependency&gt;&#10;                        &lt;/dependencies&gt;"/>
+                </TabItem>
+            </Tabs>
+        </chapter>
+        <chapter title="記錄相依性" id="logging-dependency">
+            <p>
+                Ktor 使用 SLF4J API 作為各種記錄架構（例如 Logback 或 Log4j）的介面，並允許您記錄應用程式事件。
+                要了解如何新增所需的成品，請參閱<a href="server-logging.md#add_dependencies">新增記錄器相依性</a>。
+            </p>
+        </chapter>
+        <chapter title="外掛程式相依性" id="plugin-dependencies">
+            <p>
+                擴充 Ktor 功能的<Links href="//server-plugins" summary="外掛程式提供常見功能，例如序列化、內容編碼、壓縮等。">外掛程式</Links>可能需要額外的相依性。
+                您可以從相應的主題中了解更多資訊。
+            </p>
+        </chapter>
+    </chapter>
+    <var name="target_module" value="server"/>
+    <chapter title="確保 Ktor 版本一致性" id="ensure-version-consistency">
+        <chapter id="using-gradle-plugin" title="使用 Ktor Gradle 外掛程式">
+            <p>
+                套用 <a href="https://github.com/ktorio/ktor-build-plugins">Ktor Gradle 外掛程式</a>
+                會隱含地新增 Ktor BOM 相依性，並允許您確保所有 Ktor 相依性都處於
+                相同版本。在這種情況下，當相依於 Ktor
+                成品時，您不再需要指定版本：
+            </p>
+            <Tabs group="languages">
+                <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                    <code-block lang="Kotlin" code="                        plugins {&#10;                            // ...&#10;                            id(&quot;io.ktor.plugin&quot;) version &quot;%ktor_version%&quot;&#10;                        }&#10;                        dependencies {&#10;                            implementation(&quot;io.ktor:ktor-%target_module%-core&quot;)&#10;                            // ...&#10;                        }"/>
+                </TabItem>
+                <TabItem title="Gradle (Groovy)" group-key="groovy">
+                    <code-block lang="Groovy" code="                        plugins {&#10;                            // ...&#10;                            id &quot;io.ktor.plugin&quot; version &quot;%ktor_version%&quot;&#10;                        }&#10;                        dependencies {&#10;                            implementation &quot;io.ktor:ktor-%target_module%-core&quot;&#10;                            // ...&#10;                        }"/>
+                </TabItem>
+            </Tabs>
+        </chapter>
+        <chapter id="using-version-catalog" title="使用發佈的版本目錄">
+            <p>
+                您也可以透過使用發佈的版本目錄 (version catalog) 來集中 Ktor 相依性宣告。
+                此方法具有以下優點：
+            </p>
+            <list id="published-version-catalog-benefits">
+                <li>
+                    消除在您自己的目錄中手動宣告 Ktor 版本的需求。
+                </li>
+                <li>
+                    在單一命名空間下公開每個 Ktor 模組。
+                </li>
+            </list>
+            <p>
+                要宣告目錄，請在
+                <Path>settings.gradle.kts</Path>
+                建立一個具有您所選名稱的版本目錄：
+            </p>
+            <code-block lang="kotlin" code="                dependencyResolutionManagement {&#10;                    versionCatalogs {&#10;                        create(&quot;ktorLibs&quot;) {&#10;                            from(&quot;io.ktor:ktor-version-catalog:%ktor_version%&quot;)&#10;                        }&#10;                    }&#10;                }"/>
+            <p>
+                然後，您可以透過參照目錄名稱，在模組的
+                <Path>build.gradle.kts</Path>
+                中新增相依性：
+            </p>
+            <code-block lang="kotlin" code="                dependencies {&#10;                    implementation(ktorLibs.%target_module%.core)&#10;                    // ...&#10;                }"/>
+        </chapter>
+    </chapter>
+    <chapter title="為執行應用程式建立進入點" id="create-entry-point">
+        <p>
+            使用 Gradle/Maven <Links href="//server-run" summary="了解如何執行伺服器 Ktor 應用程式。">執行</Links> Ktor 伺服器取決於<Links href="//server-create-and-configure" summary="了解如何根據您的應用程式部署需求建立伺服器。">建立伺服器</Links>的方式。
+            您可以透過以下方式之一指定應用程式主類別 (main class)：
+        </p>
+        <list>
+            <li>
+                <p>
+                    如果您使用 <a href="#embedded-server">embeddedServer</a>，請按如下方式指定主類別：
+                </p>
+                <Tabs group="languages">
+                    <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                        <code-block lang="Kotlin" code="                            application {&#10;                                mainClass.set(&quot;com.example.ApplicationKt&quot;)&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Gradle (Groovy)" group-key="groovy">
+                        <code-block lang="Groovy" code="                            application {&#10;                                mainClass = &quot;com.example.ApplicationKt&quot;&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Maven" group-key="maven">
+                        <code-block lang="XML" code="                            &lt;properties&gt;&#10;                                &lt;main.class&gt;com.example.ApplicationKt&lt;/main.class&gt;&#10;                            &lt;/properties&gt;"/>
+                    </TabItem>
+                </Tabs>
+            </li>
+            <li>
+                <p>
+                    如果您使用 <a href="#engine-main">EngineMain</a>，您需要將其配置為主類別。
+                    對於 Netty，它將如下所示：
+                </p>
+                <Tabs group="languages">
+                    <TabItem title="Gradle (Kotlin)" group-key="kotlin">
+                        <code-block lang="Kotlin" code="                            application {&#10;                                mainClass.set(&quot;io.ktor.server.netty.EngineMain&quot;)&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Gradle (Groovy)" group-key="groovy">
+                        <code-block lang="Groovy" code="                            application {&#10;                                mainClass = &quot;io.ktor.server.netty.EngineMain&quot;&#10;                            }"/>
+                    </TabItem>
+                    <TabItem title="Maven" group-key="maven">
+                        <code-block lang="XML" code="                            &lt;properties&gt;&#10;                                &lt;main.class&gt;io.ktor.server.netty.EngineMain&lt;/main.class&gt;&#10;                            &lt;/properties&gt;"/>
+                    </TabItem>
+                </Tabs>
+            </li>
+        </list>
+        <note>
+            <p>
+                如果您打算將應用程式封裝為 Fat JAR，則在配置相應的外掛程式時，還需要考慮建立伺服器的方式。
+                請從以下主題中了解更多資訊：
+            </p>
+            <list>
+                <li>
+                    <p>
+                        <Links href="//server-fatjar" summary="了解如何使用 Ktor Gradle 外掛程式建立並執行可執行的 fat JAR。">使用 Ktor Gradle 外掛程式建立 fat JAR</Links>
+                    </p>
+                </li>
+                <li>
+                    <p>
+                        <Links href="//maven-assembly-plugin" summary="範例專案：tutorial-server-get-started-maven">使用 Maven Assembly 外掛程式建立 fat JAR</Links>
+                    </p>
+                </li>
+            </list>
+        </note>
+    </chapter>
+</topic>

--- a/docs/zh-Hant/ktor/server-development-mode.md
+++ b/docs/zh-Hant/ktor/server-development-mode.md
@@ -1,0 +1,75 @@
+<topic xmlns="" xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="server-development-mode" title="開發模式"
+       help-id="development_mode;development-mode">
+    <show-structure for="chapter" depth="2"/>
+    <p>
+        Ktor 提供了一種專門針對開發的特殊模式。此模式啟用了以下功能：
+    </p>
+    <list>
+        <li>用於在不重新啟動伺服器的情況下重新載入應用程式類別的 <Links href="//server-auto-reload" summary="了解如何使用 Auto-reload 在程式碼變更時重新載入應用程式類別。">Auto-reload</Links>。
+        </li>
+        <li>用於偵錯<a href="#pipelines">管線</a>的延伸資訊（包含堆疊追蹤）。
+        </li>
+        <li>發生 <emphasis>5**</emphasis> 伺服器錯誤時，在 <Links href="//server-status-pages" summary="%plugin_name% 允許 Ktor 應用程式根據擲出的例外狀況或狀態碼，對任何失敗狀態做出適當的回應。">回應頁面</Links>上顯示延伸的偵錯資訊。
+        </li>
+    </list>
+    <note>
+        <p>
+            請注意，開發模式會影響效能，不應在生產環境中使用。
+        </p>
+    </note>
+    <chapter title="啟用開發模式" id="enable">
+        <p>
+            您可以透過不同的方式啟用開發模式：在應用程式配置檔案中、使用專用的系統屬性或環境變數。
+        </p>
+        <chapter title="配置檔案" id="application-conf">
+            <p>
+                若要在 <Links href="//server-configuration-file" summary="了解如何在配置檔案中配置各種伺服器參數。">配置檔案</Links>中啟用開發模式，請將 <code>development</code> 選項設為 <code>true</code>：
+            </p>
+            <Tabs group="config">
+                <TabItem title="application.conf" group-key="hocon">
+                    <code-block code="                        ktor {&#10;                            development = true&#10;                        }"/>
+                </TabItem>
+                <TabItem title="application.yaml" group-key="yaml">
+                    <code-block lang="yaml" code="                        ktor:&#10;                            development: true"/>
+                </TabItem>
+            </Tabs>
+        </chapter>
+        <chapter title="'io.ktor.development' 系統屬性" id="system-property">
+            <p>
+                <control>io.ktor.development</control> <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">系統屬性</a>允許您在執行應用程式時啟用開發模式。
+            </p>
+            <p>
+                若要使用 IntelliJ IDEA 在開發模式下執行應用程式，請將 <code>io.ktor.development</code> 搭配 <code>-D</code> 旗標傳遞給 <a href="https://www.jetbrains.com/help/idea/run-debug-configuration-kotlin.html#1">虛擬機選項</a>：
+            </p>
+            <code-block code="                -Dio.ktor.development=true"/>
+            <p>
+                如果您使用 <Links href="//server-dependencies" summary="了解如何將 Ktor Server 相依性新增至現有的 Gradle/Maven 專案。">Gradle</Links> 任務執行應用程式，可以透過以下兩種方式之一啟用開發模式：
+            </p>
+            <list>
+                <li>
+                    <p>
+                        在您的 <Path>build.gradle.kts</Path> 檔案中配置 <code>ktor</code> 區塊：
+                    </p>
+                    <code-block lang="Kotlin" code="                        ktor {&#10;                            development = true&#10;                        }"/>
+                </li>
+                <li>
+                    <p>
+                        透過傳遞 Gradle CLI 旗標來為單次執行啟用開發模式：
+                    </p>
+                    <code-block lang="bash" code="                          ./gradlew run -Pio.ktor.development=true"/>
+                </li>
+            </list>
+            <tip>
+                <p>
+                    您也可以使用 <code>-ea</code> 旗標來啟用開發模式。請注意，使用 <code>-D</code> 旗標傳遞的 <code>io.ktor.development</code> 系統屬性優先級高於 <code>-ea</code>。
+                </p>
+            </tip>
+        </chapter>
+        <chapter title="'io.ktor.development' 環境變數" id="environment-variable">
+            <p>
+                若要為 <a href="#native">原生用戶端</a>啟用開發模式，請使用 <code>io.ktor.development</code> 環境變數。
+            </p>
+        </chapter>
+    </chapter>
+</topic>

--- a/tools/pipeline/processors/MarkdownProcessor.mjs
+++ b/tools/pipeline/processors/MarkdownProcessor.mjs
@@ -4,7 +4,8 @@ import {
     getChapterTitle,
     getTopicTitle,
     processTopicContentAsync,
-    replaceAsync
+    replaceAsync,
+    resolveCodeSnippetsDir,
 } from "./TopicProcessor.mjs";
 import path from "node:path";
 
@@ -37,7 +38,7 @@ export async function processMarkdownContent(filePath, content) {
 
                 const include_lines = /include-lines="([^"]+)"/.exec(attr);
                 const ranges = include_lines ? include_lines[1].split(',') : [];
-                const snippetsPath = path.join(filePath.split('/')[0], "codeSnippets");
+                const snippetsPath = resolveCodeSnippetsDir(path.dirname(filePath));
 
                 let code = await fetchSnippet(snippetsPath, src[1], ranges);
                 let lines = code.split("\n");

--- a/tools/pipeline/processors/TopicProcessor.mjs
+++ b/tools/pipeline/processors/TopicProcessor.mjs
@@ -203,7 +203,7 @@ export async function processTopicContentAsync(currentFilePath, docsPath, topicC
                 ranges = inc[1].split(',');
             }
 
-            const snippetsPath = path.join(docsPath.split('/')[0], 'codeSnippets');
+            const snippetsPath = resolveCodeSnippetsDir(docsPath);
             let codeText = await fetchSnippet(snippetsPath, srcPath, ranges);
 
             codeText = codeText.replace(/^\s*\n/, '').replace(/\n\s*$/, '');
@@ -236,7 +236,7 @@ export async function processTopicContentAsync(currentFilePath, docsPath, topicC
                 const src = /src="([^"]+)"/.exec(rawAttrs);
                 const include_lines = /include-lines="([^"]+)"/.exec(rawAttrs);
                 const ranges = include_lines ? include_lines[1].split(',') : [];
-                const snippetsPath = path.join(docsPath.split('/')[0], "codeSnippets");
+                const snippetsPath = resolveCodeSnippetsDir(docsPath);
                 rawCode = await fetchSnippet(snippetsPath, src[1], ranges);
                 rawAttrs = rawAttrs.replace(/\s+src="[^"]+"/, '')
                     .replace(/\s+include-lines="[^"]+"/, '')
@@ -305,6 +305,14 @@ function removeMinimalIndention(content, indention) {
     lines = lines.map(line => indention + line.slice(minIndent));
 
     return lines.join('\n');
+}
+
+/**
+ * Resolve codeSnippets/ next to the Writerside topics/docs directory.
+ * Works for both absolute and relative paths (unlike path.split('/')[0]).
+ */
+export function resolveCodeSnippetsDir(topicsOrDocsDir) {
+    return path.resolve(topicsOrDocsDir, '..', 'codeSnippets')
 }
 
 export async function fetchSnippet(snippetsPath, srcPath, include_lines) {


### PR DESCRIPTION
## Summary
- Convert and freshly translate 16 missing Ktor `.topic` tutorials (4 locales) that sidebar linked to but content was absent after wipe + md-only incremental sync
- Fix `codeSnippets` path resolution in Topic/Markdown processors so absolute clone paths load snippet sources

## Test plan
- [x] `pnpm test` (41/41, including sidebar-links)
- [ ] `pnpm docs:check` on CI (All tests)