### PR TITLE
ci: push docs sync as openaidoc-admin via PAT

### DIFF
--- a/.github/workflows/docs-update.yaml
+++ b/.github/workflows/docs-update.yaml
@@ -5,18 +5,42 @@ on:
     - cron: "0 0 * * 0" # Run every Sunday at 0:00 UTC
   workflow_dispatch: # Allow manual trigger
 
+# Push uses DOCS_SYNC_TOKEN (admin/maintain PAT) so branch rules can be bypassed.
+# Commit author/committer come from DOCS_SYNC_NAME + DOCS_SYNC_EMAIL (sync bot account).
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   docs-update:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
+      - name: Check sync secrets
+        env:
+          DOCS_SYNC_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
+          DOCS_SYNC_NAME: ${{ secrets.DOCS_SYNC_NAME }}
+          DOCS_SYNC_EMAIL: ${{ secrets.DOCS_SYNC_EMAIL }}
+        run: |
+          missing=0
+          for key in DOCS_SYNC_TOKEN DOCS_SYNC_NAME DOCS_SYNC_EMAIL; do
+            if [ -z "${!key}" ]; then
+              echo "::error::Missing repository secret: $key"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "Add these repository secrets (Settings → Secrets and variables → Actions):"
+            echo "  DOCS_SYNC_TOKEN  — PAT of the sync account (repo contents: read/write; account needs Admin or Maintain to bypass main ruleset)"
+            echo "  DOCS_SYNC_NAME   — git user.name / GitHub display identity (e.g. openaidoc-sync)"
+            echo "  DOCS_SYNC_EMAIL  — verified email or noreply, e.g. 12345678+openaidoc-sync@users.noreply.github.com"
+            exit 1
+          fi
+
       - name: Checkout main repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.DOCS_SYNC_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -36,8 +60,10 @@ jobs:
       # Sync may commit/push even when the tree would fail tests.
       - name: Run Update and Translation Script
         env:
-          GIT_AUTHOR_NAME: "github-actions[bot]"
-          GIT_AUTHOR_EMAIL: "github-actions[bot]@users.noreply.github.com"
+          GIT_AUTHOR_NAME: ${{ secrets.DOCS_SYNC_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.DOCS_SYNC_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ secrets.DOCS_SYNC_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ secrets.DOCS_SYNC_EMAIL }}
           GITHUB_HEAD_REF: ${{ github.head_ref || github.ref_name }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         run: pnpm pipeline:run

--- a/tools/pipeline/docs-pipeline.mjs
+++ b/tools/pipeline/docs-pipeline.mjs
@@ -191,15 +191,29 @@ async function commit(context) {
   const updatedRepos = context.tasks.map((t) => t.repoConfig.id).join(", ");
   const commitMessage = `docs: [${updatedRepos}] Sync and translate upstream documentation`;
 
-  await execa("git", [
-    "-c",
-    `user.name=${process.env.GIT_AUTHOR_NAME}`,
-    "-c",
-    `user.email=${process.env.GIT_AUTHOR_EMAIL}`,
-    "commit",
-    "-m",
-    commitMessage,
-  ]);
+  const authorName = process.env.GIT_AUTHOR_NAME;
+  const authorEmail = process.env.GIT_AUTHOR_EMAIL;
+  if (!authorName || !authorEmail) {
+    throw new Error(
+      "GIT_AUTHOR_NAME and GIT_AUTHOR_EMAIL must be set for sync commits"
+    );
+  }
+  const committerName = process.env.GIT_COMMITTER_NAME || authorName;
+  const committerEmail = process.env.GIT_COMMITTER_EMAIL || authorEmail;
+
+  await execa(
+    "git",
+    ["-c", `user.name=${committerName}`, "-c", `user.email=${committerEmail}`, "commit", "-m", commitMessage],
+    {
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: authorName,
+        GIT_AUTHOR_EMAIL: authorEmail,
+        GIT_COMMITTER_NAME: committerName,
+        GIT_COMMITTER_EMAIL: committerEmail,
+      },
+    }
+  );
 
   const branchName = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME;
   if (!branchName) throw new Error("Could not determine branch to push to.");


### PR DESCRIPTION
## Summary
- Docs update workflow authenticates with `DOCS_SYNC_TOKEN`
- Commit author/committer use `DOCS_SYNC_NAME` / `DOCS_SYNC_EMAIL` (openaidoc-admin)

Separate from the Ktor backfill PR.

## Test plan
- [ ] Secrets `DOCS_SYNC_*` present
- [ ] After merge, run **Docs update** (workflow_dispatch) and confirm push author is openaidoc-admin